### PR TITLE
Add GitHub action to build and publish Docker images to Docker Hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,24 +1,10 @@
-name: ci
-
-# Multi-platform Docker build example:
-# https://docs.docker.com/build/ci/github-actions/multi-platform/
+name: build
 
 on:
   workflow_dispatch:
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: user/app:latest
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      publish-docker: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: ci
+
+# Multi-platform Docker build example:
+# https://docs.docker.com/build/ci/github-actions/multi-platform/
+
+on:
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: user/app:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,4 +7,4 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      publish-docker: false
+      publish_docker: false

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -11,6 +11,11 @@ on:
         required: true
         default: false
         type: boolean
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
 
 jobs:
   common:
@@ -20,7 +25,8 @@ jobs:
         if: ${{ inputs.publish-docker }}
         uses: docker/login-action@v4
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
@@ -34,4 +40,4 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: ${{ inputs.publish-docker }}
-          tags: user/app:latest
+          tags: singularitynet/omegaclaw

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -1,0 +1,37 @@
+name: common
+
+# Multi-platform Docker build example:
+# https://docs.docker.com/build/ci/github-actions/multi-platform/
+
+on:
+  workflow_call:
+    inputs:
+      publish-docker:
+        description: 'Publish Docker images to Docker Hub'
+        required: true
+        default: false
+        type: boolean
+
+jobs:
+  common:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        if: ${{ inputs.publish-docker }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: ${{ inputs.publish-docker }}
+          tags: user/app:latest

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -6,11 +6,16 @@ name: common
 on:
   workflow_call:
     inputs:
-      publish-docker:
+      publish_docker:
         description: 'Publish Docker images to Docker Hub'
         required: true
         default: false
         type: boolean
+      tag_name:
+        description: 'Tag to publish'
+        required: false
+        default: 'latest'
+        type: string
     secrets:
       DOCKERHUB_USERNAME:
         required: false
@@ -22,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to Docker Hub
-        if: ${{ inputs.publish-docker }}
+        if: ${{ inputs.publish_docker }}
         uses: docker/login-action@v4
         with:
           registry: docker.io
@@ -39,5 +44,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
-          push: ${{ inputs.publish-docker }}
-          tags: singularitynet/omegaclaw
+          push: ${{ inputs.publish_docker }}
+          tags: |
+            singularitynet/omegaclaw:${{ inputs.tag_name }}
+            singularitynet/omegaclaw:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,3 +9,4 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       publish-docker: true
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,5 +8,6 @@ jobs:
   release:
     uses: ./.github/workflows/common.yml
     with:
-      publish-docker: true
+      publish_docker: true
+      tag_name: ${{ github.event.release.tag_name }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,11 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    uses: ./.github/workflows/common.yml
+    with:
+      publish-docker: true


### PR DESCRIPTION
PR adds GitHub actions to build and publish docker images on Docker hub. Images are built for two platforms: `linux/amd64` and `linux/arm64`.

Build: https://github.com/vsbogd/mettaclaw/actions/runs/24189606170
Test Release: https://github.com/vsbogd/mettaclaw/actions/runs/24188277810