### PR TITLE
Narrative helper, syllogistic reasoning for nal implications

### DIFF
--- a/lib_nal.metta
+++ b/lib_nal.metta
@@ -157,6 +157,10 @@
 (= (|-nal ((--> $R (× $A $B)) $T1) ((--> $C $B) $T2)) ((--> $R (× $A $C)) (Truth_Abduction $T1 $T2)))
 
 ;;NAL-5
+;;Syllogisms:
+(= (|-nal ((==> $a $b) $T1) ((==> $b $c) $T2)) ((==> $a $c) (Truth_Deduction $T1 $T2)))
+(= (|-nal ((==> $a $b) $T1) ((==> $a $c) $T2)) ((==> $c $b) (Truth_Induction $T1 $T2)))
+(= (|-nal ((==> $a $c) $T1) ((==> $b $c) $T2)) ((==> $b $a) (Truth_Abduction $T1 $T2)))
 ;;!Negation ∧ and ∨ decomposition:
 (= (|-nal ((¬ $A) $T)) ($A (Truth_Negation $T)))
 (= (|-nal ((∧ $A $B) $T)) ($A (Truth_StructuralDeduction $T)))

--- a/src/helper.py
+++ b/src/helper.py
@@ -43,16 +43,30 @@ def around_time(needle_time_str, k):
     return ret
 
 def balance_parentheses(s):
-    s=s.replace("_quote_", '"')
-    s = s.strip()
+    s = s.replace("_quote_", '"').strip()
+    # Find first "((" which should begin the command block
+    cmd_start = s.find("((")
+    if cmd_start == -1:
+        # No command block at all: treat whole thing as narrative
+        narrative = s.strip()
+        if narrative:
+            return f'((pin "{narrative}"))'
+        return "(())"
+    narrative = s[:cmd_start].strip()
+    cmd_part = s[cmd_start:].strip()
+    # Normalize outer parentheses of command part
     left = 0
-    while left < len(s) and s[left] == '(':
+    while left < len(cmd_part) and cmd_part[left] == '(':
         left += 1
     right = 0
-    while right < len(s) and s[len(s) - 1 - right] == ')':
+    while right < len(cmd_part) and cmd_part[len(cmd_part) - 1 - right] == ')':
         right += 1
-    core = s[left:len(s) - right if right else len(s)].strip()
-    return f"(({core}))"
+    core = cmd_part[left:len(cmd_part) - right if right else len(cmd_part)].strip()
+    if narrative:
+        narrative = narrative.replace('"', '\\"')
+        return f'((pin "{narrative}") {core})'
+    else:
+        return f"(({core}))"
 
 def normalize_string(x):
     try:

--- a/src/helper.py
+++ b/src/helper.py
@@ -44,29 +44,18 @@ def around_time(needle_time_str, k):
 
 def balance_parentheses(s):
     s = s.replace("_quote_", '"').strip()
-    # Find first "((" which should begin the command block
-    cmd_start = s.find("((")
-    if cmd_start == -1:
-        # No command block at all: treat whole thing as narrative
-        narrative = s.strip()
-        if narrative:
-            return f'((pin "{narrative}"))'
-        return "(())"
-    narrative = s[:cmd_start].strip()
-    cmd_part = s[cmd_start:].strip()
-    # Normalize outer parentheses of command part
-    left = 0
-    while left < len(cmd_part) and cmd_part[left] == '(':
-        left += 1
-    right = 0
-    while right < len(cmd_part) and cmd_part[len(cmd_part) - 1 - right] == ')':
-        right += 1
-    core = cmd_part[left:len(cmd_part) - right if right else len(cmd_part)].strip()
-    if narrative:
-        narrative = narrative.replace('"', '\\"')
-        return f'((pin "{narrative}") {core})'
-    else:
-        return f"(({core}))"
+    first_paren = s.find('(')
+    if first_paren > 0:
+        garbage = s[:first_paren].strip()
+        s = s[first_paren:]
+        if garbage:
+            garbage = garbage.replace('"', '\\"')
+            s = s[:1] + f'(pin "{garbage}") ' + s[1:]
+    if s.startswith("((") and s.endswith("))"):
+        return s
+    if s.startswith("(") and s.endswith(")"):
+        return f"({s})"
+    return f"(({s}))"
 
 def normalize_string(x):
     try:


### PR DESCRIPTION
Addresses the issue that some models can't hamper themselves from creating a narrative before the command output despite the prompt being clear that there should only be command output.