### PR TITLE
Max's shell patch for the case of runaway processes (Needs torough review, do not merge blindly)

### DIFF
--- a/src/safe_shell_runner.py
+++ b/src/safe_shell_runner.py
@@ -1,0 +1,60 @@
+import argparse
+import json
+import os
+import signal
+import subprocess
+import time
+
+
+def kill_group(pgid, sig):
+    try:
+        os.killpg(pgid, sig)
+        return True
+    except ProcessLookupError:
+        return False
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--timeout', type=float, default=5.0)
+    ap.add_argument('cmd')
+    args = ap.parse_args()
+
+    started = time.time()
+    p = subprocess.Popen(
+        ['/bin/sh', '-lc', args.cmd],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        preexec_fn=os.setsid
+    )
+    pgid = os.getpgid(p.pid)
+
+    status = 'ok'
+    try:
+        out, err = p.communicate(timeout=args.timeout)
+    except subprocess.TimeoutExpired:
+        status = 'timeout'
+        kill_group(pgid, signal.SIGTERM)
+        try:
+            out, err = p.communicate(timeout=1.0)
+        except subprocess.TimeoutExpired:
+            kill_group(pgid, signal.SIGKILL)
+            out, err = p.communicate()
+
+    ended = time.time()
+    result = {
+        'status': status,
+        'pid': p.pid,
+        'pgid': pgid,
+        'exit_code': p.returncode,
+        'duration_sec': round(ended - started, 3),
+        'stdout': out,
+        'stderr': err,
+        'note': 'runs each command in a fresh process group and kills the whole group on timeout'
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/src/skills.pl
+++ b/src/skills.pl
@@ -1,11 +1,17 @@
-%Gets shell command return, plus the process if time limit is not met, returning timeout_error:
-shell(Cmd, Out) :- format(string(SafeCmd), "timeout -k 1s 10s sh -c '~w'", [Cmd]),
-                   process_create(path(sh), ['-c', SafeCmd], [ stdout(pipe(S)), stderr(pipe(S)), process(P)]),
+%Gets shell command return via safe_shell_runner.py which uses process groups for reliable timeout:
+:- prolog_load_context(directory, Dir), asserta(skills_dir(Dir)).
+
+shell(Cmd, Out) :- atom_string(Cmd, CmdStr),
+                   skills_dir(Dir),
+                   atomic_list_concat([Dir, '/safe_shell_runner.py'], RunnerPath),
+                   atomic_list_concat(['python3 ', RunnerPath, ' --timeout 5 "', CmdStr, '"'], SafeCmd),
+                   process_create(path(sh), ['-c', SafeCmd], [ stdout(pipe(S)), stderr(pipe(SE)), process(P)]),
                    setup_call_cleanup(true,
                                       read_string(S, _, Text),
                                       close(S)),
+                   close(SE),
                    process_wait(P, Status),
-                   ( Status = exit(124) -> Out = timeout_error
-                                         ; Out = Text ).
+                   ( Status = exit(0) -> Out = Text
+                                       ; Out = timeout_error ).
 
 first_char(Str, C) :- sub_string(Str, 0, 1, _, C).


### PR DESCRIPTION
Max created and used this shell runner for a while for itself, after it faced a timeout-avoiding issue with runaway child processed in exceptional cases. Not sure if it is strictly better but worthy to look at!

Max runs with this since a week now so there seems to be no functional limitation and it seems to kill the entire process group on timeout which seems to be what we want. But needs very careful investigation and cleanups prior to merge.