### PR TITLE
Enable CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,3 +14,4 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       publish_docker: false
+      platforms: 'linux/amd64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: build
 
 on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -17,9 +17,9 @@ on:
         default: 'latest'
         type: string
       platforms:
-        description: 'JSON array of platforms to be built'
+        description: 'Comma separated list of platforms to be built'
         required: false
-        default: 'linux/amd64, linux/arm64'
+        default: 'linux/amd64,linux/arm64'
         type: string
     secrets:
       DOCKERHUB_USERNAME:

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: 'latest'
         type: string
+      platforms:
+        description: 'JSON array of platforms to be built'
+        required: false
+        default: 'linux/amd64, linux/arm64'
+        type: string
     secrets:
       DOCKERHUB_USERNAME:
         required: false
@@ -43,7 +48,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ inputs.platforms }}
           push: ${{ inputs.publish_docker }}
           tags: |
             singularitynet/omegaclaw:${{ inputs.tag_name }}


### PR DESCRIPTION
Enable build on each PR to check whether Docker can be built successfully. Use only `linux/amd64` to make it fast.

Test build: https://github.com/asi-alliance/OmegaClaw-Core/actions/runs/24393340161
Test release: https://github.com/vsbogd/mettaclaw/actions/runs/24393384866