### PR TITLE
Configure LLM in agent bootstrap script

### DIFF
--- a/scripts/omegaclaw_setup.sh
+++ b/scripts/omegaclaw_setup.sh
@@ -8,14 +8,12 @@ set -euo pipefail
 image="${1:?usage: $0 <container-image>}"
 
 # Create temporary files
-tmp_channel_file="$(mktemp)"
-tmp_token_file="$(mktemp)"
+tmp_config_file="$(mktemp)"
 tmp_py_file="$(mktemp)"
-trap 'rm -f "$tmp_channel_file" "$tmp_token_file" "$tmp_py_file"' EXIT
+trap 'rm -f "$tmp_config_file" "$tmp_py_file"' EXIT
 
 # Lock down permissions immediately after creation
-chmod 0600 "$tmp_channel_file"
-chmod 0600 "$tmp_token_file"
+chmod 0600 "$tmp_config_file"
 chmod 0600 "$tmp_py_file"
 
 cat >"$tmp_py_file" <<'PY'
@@ -23,6 +21,7 @@ import sys
 import shutil
 import textwrap
 import getpass
+import secrets
 
 LICENSE_TEXT = """\
 
@@ -50,7 +49,7 @@ def require_license_acceptance():
             sys.exit(1)
         print("You must type 'accept' or 'q'.", file=sys.stderr)
 
-def config_run_omegaclaw(channel_output_path, token_output_path):
+def config_run_omegaclaw(config_output_path):
     print(" ")
     print("Welcome to OmegaClaw IRC!")
     print(" ")
@@ -81,25 +80,18 @@ def config_run_omegaclaw(channel_output_path, token_output_path):
 
         break
 
-    with open(channel_output_path, "w", encoding="utf-8") as f:
-        f.write(channel)
-
-    with open(token_output_path, "w", encoding="utf-8") as f:
-        f.write(token)
+    with open(config_output_path, "w", encoding="utf-8") as f:
+        f.write(f'IRC_channel={channel}\n')
+        f.write(f'ANTHROPIC_API_KEY={token}\n')
+        f.write(f'OMEGACLAW_AUTH_SECRET={secrets.token_urlsafe(24)}\n')
 
 if __name__ == "__main__":
-    config_run_omegaclaw(sys.argv[1], sys.argv[2])
+    config_run_omegaclaw(sys.argv[1])
 PY
 
-python3 "$tmp_py_file" "$tmp_channel_file" "$tmp_token_file" </dev/tty
+python3 "$tmp_py_file" "$tmp_config_file" </dev/tty
 
-channel="$(cat "$tmp_channel_file")"
-token="$(cat "$tmp_token_file")"
-auth_secret="$(python3 - <<'PY'
-import secrets
-print(secrets.token_urlsafe(24))
-PY
-)"
+. "$tmp_config_file"
 
 cat <<EOF
 ============================================
@@ -110,7 +102,7 @@ and enter your name and channel.
 
 Authentication step (required):
   In your channel, send this one-time secret exactly once:
-  auth ${auth_secret}
+  auth ${OMEGACLAW_AUTH_SECRET}
   The first nickname that sends it becomes the only accepted user.
   Messages from all other users will be silently ignored.
 
@@ -135,7 +127,7 @@ docker run -d -it \
   --tmpfs /tmp:size=64m,mode=1777 \
   --tmpfs /run:size=16m,mode=755 \
   --tmpfs /var/tmp:size=64m,mode=1777 \
-  -e ANTHROPIC_API_KEY="$token" \
-  -e OMEGACLAW_AUTH_SECRET="$auth_secret" \
+  -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  -e OMEGACLAW_AUTH_SECRET="$OMEGACLAW_AUTH_SECRET" \
   "$image" \
-  IRC_channel="$channel"
+  IRC_channel="$IRC_channel"

--- a/scripts/omegaclaw_setup.sh
+++ b/scripts/omegaclaw_setup.sh
@@ -69,6 +69,31 @@ def config_run_omegaclaw(config_output_path):
         break
 
     while True:
+        print("Please select your LLM provider.")
+        print("1) Anthropic/Claude 2) OpenAI/ChatGPT 3) ASI Cloud Minimax")
+        c = input("Enter 1-3 or 'q' to exit (default: 1): ").strip()
+
+        if c.lower() == "q":
+            sys.exit(1)
+
+        if not c:
+            provider_id = 0
+        elif c in ["1", "2", "3"]:
+            provider_id = int(c) - 1
+        else:
+            print("Plese enter 1-3 or 'q'", file=sys.stderr)
+            continue
+
+        providers = [("Anthropic", "Local", "ANTHROPIC_API_KEY"),
+            ("OpenAI", "OpenAI", "OPENAI_API_KEY"),
+            ("ASICloud", "Local", "ASI_API_KEY")]
+        provider = providers[provider_id][0]
+        embeddingprovider = providers[provider_id][1]
+        api_token_var = providers[provider_id][2]
+
+        break
+
+    while True:
         token = getpass.getpass("Please paste your LLM token and press ENTER or 'q' to exit: ").strip()
 
         if token.lower() == "q":
@@ -81,9 +106,12 @@ def config_run_omegaclaw(config_output_path):
         break
 
     with open(config_output_path, "w", encoding="utf-8") as f:
-        f.write(f'IRC_channel={channel}\n')
-        f.write(f'ANTHROPIC_API_KEY={token}\n')
+        f.write(f'api_token_var={api_token_var}\n')
+        f.write(f'api_token={token}\n')
         f.write(f'OMEGACLAW_AUTH_SECRET={secrets.token_urlsafe(24)}\n')
+        f.write(f'IRC_channel={channel}\n')
+        f.write(f'provider={provider}\n')
+        f.write(f'embeddingprovider={embeddingprovider}\n')
 
 if __name__ == "__main__":
     config_run_omegaclaw(sys.argv[1])
@@ -127,7 +155,9 @@ docker run -d -it \
   --tmpfs /tmp:size=64m,mode=1777 \
   --tmpfs /run:size=16m,mode=755 \
   --tmpfs /var/tmp:size=64m,mode=1777 \
-  -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  -e ${api_token_var}="${api_token}" \
   -e OMEGACLAW_AUTH_SECRET="$OMEGACLAW_AUTH_SECRET" \
   "$image" \
-  IRC_channel="$IRC_channel"
+  IRC_channel="$IRC_channel" \
+  provider="$provider" \
+  embeddingprovider="$embeddingprovider"

--- a/scripts/omegaclaw_setup.sh
+++ b/scripts/omegaclaw_setup.sh
@@ -81,7 +81,7 @@ def config_run_omegaclaw(config_output_path):
         elif c in ["1", "2", "3"]:
             provider_id = int(c) - 1
         else:
-            print("Plese enter 1-3 or 'q'", file=sys.stderr)
+            print("Please enter 1-3 or 'q'", file=sys.stderr)
             continue
 
         providers = [("Anthropic", "Local", "ANTHROPIC_API_KEY"),


### PR DESCRIPTION
Add menu to allow user selecting the LLM/embedding provider:
```
Please select your LLM provider.
1) Anthropic/Claude 2) OpenAI/ChatGPT 3) ASI Cloud Minimax
Enter 1-3 or 'q' to exit (default: 1):  
```
Option 2 selects OpenAI embedding, options 1,3 select local embedding provider.
I have smoketested it with both Anthropic and OpenAI key.