### PR TITLE
[WIP] Persist memory on the Docker volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,15 +101,18 @@ COPY --from=builder /PeTTa /PeTTa
 COPY --from=builder /opt/huggingface /opt/huggingface
 COPY --from=builder /opt/sentence_transformers /opt/sentence_transformers
 
-# Bring in only local OmegaClaw source (filtered by .dockerignore).
-COPY . /PeTTa/repos/OmegaClaw-Core
+ENV OMEGACLAW_DIR=/PeTTa/repos/OmegaClaw-Core
+ENV MEMORY_DIR=${OMEGACLAW_DIR}/memory
 
-RUN cp /PeTTa/repos/OmegaClaw-Core/run.metta /PeTTa/run.metta \
- && mkdir ./chroma_db \
- && chown -R 65534:65534 ./chroma_db \
- && chown -R 65534:65534 /PeTTa/repos/OmegaClaw-Core/memory \
- && find /PeTTa/repos/OmegaClaw-Core/memory -type f -exec chmod 0644 {} \; \
- && chmod 0444 /PeTTa/repos/OmegaClaw-Core/memory/prompt.txt \
+# Bring in only local OmegaClaw source (filtered by .dockerignore).
+COPY . ${OMEGACLAW_DIR}
+
+RUN cp ${OMEGACLAW_DIR}/run.metta /PeTTa/run.metta \
+ && mkdir ${MEMORY_DIR}/chroma_db \
+ && ln -s ${MEMORY_DIR}/chroma_db ./chroma_db \
+ && chown -R 65534:65534 ${MEMORY_DIR} \
+ && find ${MEMORY_DIR} -type f -exec chmod 0644 {} \; \
+ && chmod 0444 ${MEMORY_DIR}/prompt.txt \
  && chown -R 65534:65534 /opt/huggingface /opt/sentence_transformers
 
 USER 65534:65534

--- a/scripts/omegaclaw_setup.sh
+++ b/scripts/omegaclaw_setup.sh
@@ -152,6 +152,7 @@ docker run -d -it \
   --user 65534:65534 \
   --security-opt no-new-privileges:true \
   --init \
+  --volume omegaclaw-memory:/PeTTa/repos/OmegaClaw-Core/memory \
   --tmpfs /tmp:size=64m,mode=1777 \
   --tmpfs /run:size=16m,mode=755 \
   --tmpfs /var/tmp:size=64m,mode=1777 \


### PR DESCRIPTION
1. `chroma_db` directory is moved under `memory` directory
2. Empty Docker volume is mounted to `memory` directory on the first container start, at this point empty volume is filled by files from the container filesystem
3. If Docker volume mounted is not empty (when container is restarted or upgraded) then `memory` folder contents is replaced by the contents of the volume.