### PR TITLE
Add ability to publish dev builds to the DockerHub

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       publish_docker:
         description: 'Publish Docker images to Docker Hub'
-        required: true
+        required: false
         default: false
         type: boolean
       tag_name:
@@ -18,7 +18,7 @@ on:
         type: string
       move_latest:
         description: 'Move latest version to the new one'
-        required: true
+        required: false
         default: false
         type: boolean
       platforms:

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: 'latest'
         type: string
+      move_latest:
+        description: 'Move latest version to the new one'
+        required: true
+        default: false
+        type: boolean
       platforms:
         description: 'Comma separated list of platforms to be built'
         required: false
@@ -45,7 +50,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build and push
+      - name: Build and push and move latest
+        if: ${{ inputs.move_latest }}
         uses: docker/build-push-action@v7
         with:
           platforms: ${{ inputs.platforms }}
@@ -53,3 +59,12 @@ jobs:
           tags: |
             singularitynet/omegaclaw:${{ inputs.tag_name }}
             singularitynet/omegaclaw:latest
+
+      - name: Build and push
+        if: ${{ !inputs.move_latest }}
+        uses: docker/build-push-action@v7
+        with:
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.publish_docker }}
+          tags: |
+            singularitynet/omegaclaw:${{ inputs.tag_name }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -28,3 +28,4 @@ jobs:
       tag_name: ${{ github.sha }}
       move_latest: false
       platforms: ${{ inputs.platforms }}
+    secrets: inherit

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -21,7 +21,7 @@ on:
         type: string
 
 jobs:
-  build:
+  manual:
     uses: ./.github/workflows/common.yml
     with:
       publish_docker: ${{ inputs.publish_docker }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,12 +1,6 @@
 name: manual
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       publish_docker:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,30 @@
+name: manual
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      publish_docker:
+        description: 'Publish Docker images to Docker Hub'
+        required: false
+        default: false
+        type: boolean
+      platforms:
+        description: 'Comma separated list of platforms to be built'
+        required: false
+        default: 'linux/amd64,linux/arm64'
+        type: string
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      publish_docker: ${{ inputs.publish_docker }}
+      tag_name: ${{ github.sha }}
+      move_latest: false
+      platforms: ${{ inputs.platforms }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,4 +10,5 @@ jobs:
     with:
       publish_docker: true
       tag_name: ${{ github.event.release.tag_name }}
+      move_latest: true
     secrets: inherit


### PR DESCRIPTION
Add action to publish Docker image from the branch manually. The head commit has of the branch is used as the Docker tag. `latest` tag is not moved.

To run it select Actions/manual/Run workflow, select platforms and tick publish checkbox.

1. Manual docker publish: https://github.com/vsbogd/mettaclaw/actions/runs/24469457044
2. Build results: https://github.com/vsbogd/mettaclaw/actions/runs/24470665033
3. Release results: https://github.com/vsbogd/mettaclaw/actions/runs/24470595877