### PR TITLE
Changes to allow external memory and repeated auth tokens (Clone of PR 35)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,15 +101,18 @@ COPY --from=builder /PeTTa /PeTTa
 COPY --from=builder /opt/huggingface /opt/huggingface
 COPY --from=builder /opt/sentence_transformers /opt/sentence_transformers
 
-# Bring in only local OmegaClaw source (filtered by .dockerignore).
-COPY . /PeTTa/repos/OmegaClaw-Core
+ENV OMEGACLAW_DIR=/PeTTa/repos/OmegaClaw-Core
+ENV MEMORY_DIR=${OMEGACLAW_DIR}/memory
 
-RUN cp /PeTTa/repos/OmegaClaw-Core/run.metta /PeTTa/run.metta \
- && mkdir ./chroma_db \
- && chown -R 65534:65534 ./chroma_db \
- && chown -R 65534:65534 /PeTTa/repos/OmegaClaw-Core/memory \
- && find /PeTTa/repos/OmegaClaw-Core/memory -type f -exec chmod 0644 {} \; \
- && chmod 0444 /PeTTa/repos/OmegaClaw-Core/memory/prompt.txt \
+# Bring in only local OmegaClaw source (filtered by .dockerignore).
+COPY . ${OMEGACLAW_DIR}
+
+RUN cp ${OMEGACLAW_DIR}/run.metta /PeTTa/run.metta \
+ && mkdir ${MEMORY_DIR}/chroma_db \
+ && ln -s ${MEMORY_DIR}/chroma_db ./chroma_db \
+ && chown -R 65534:65534 ${MEMORY_DIR} \
+ && find ${MEMORY_DIR} -type f -exec chmod 0644 {} \; \
+ && chmod 0444 ${MEMORY_DIR}/prompt.txt \
  && chown -R 65534:65534 /opt/huggingface /opt/sentence_transformers
 
 USER 65534:65534

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Requirement: Docker
 
 OmegaClaw can be installed and started with:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/asi-alliance/OmegaClaw-Core/refs/heads/main/scripts/omegaclaw_setup.sh | bash -s -- singularitynet/omegaclaw:latest
+curl -fsSL https://raw.githubusercontent.com/asi-alliance/OmegaClaw-Core/refs/heads/main/scripts/omegaclaw | bash -s -- singularitynet/omegaclaw:latest
 ```
 When prompted, enter your OpenAI API key and a unique IRC channel name, then interact with your OmegaClaw at [webchat.quakenet.org](https://webchat.quakenet.org) or any IRC portal. 
 
@@ -83,7 +83,9 @@ When done interacting with your OmegaClaw, please use these commands as needed:
 | Action | Command |
 |--------|---------|
 | Stop OmegaClaw | `docker stop omegaclaw` |
-| Restart OmegaClaw | `docker start omegaclaw` |
 | View logs | `docker logs -f omegaclaw` |
 
+To restart Omegaclaw simply rerun the same curl script show above.
 Your OmegaClaw will retain its memory for subsequent restarts.
+
+

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ OmegaClaw can be installed and started with:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/asi-alliance/OmegaClaw-Core/refs/heads/main/scripts/omegaclaw | bash -s -- singularitynet/omegaclaw:latest
 ```
-When prompted, enter your OpenAI API key and a unique IRC channel name, then interact with your OmegaClaw at [webchat.quakenet.org](https://webchat.quakenet.org) or any IRC portal. 
+When prompted, please select from a list of available models, enter an API key and a unique IRC channel name, then interact with your OmegaClaw at [webchat.quakenet.org](https://webchat.quakenet.org) or any IRC portal. 
 
 ### Channel authentication
 
@@ -86,6 +86,7 @@ When done interacting with your OmegaClaw, please use these commands as needed:
 | View logs | `docker logs -f omegaclaw` |
 
 To restart Omegaclaw simply rerun the same curl script show above.
+
 Your OmegaClaw will retain its memory for subsequent restarts.
 
 

--- a/scripts/omegaclaw
+++ b/scripts/omegaclaw
@@ -122,26 +122,33 @@ python3 "$tmp_py_file" "$tmp_config_file" </dev/tty
 . "$tmp_config_file"
 
 cat <<EOF
-============================================
- QuakeNet / OmegaClaw Instructions
-============================================
-Please go to https://webchat.quakenet.org/
-and enter your name and channel.
 
-Authentication step (required):
-  In your channel, send this one-time secret exactly once:
-  auth ${OMEGACLAW_AUTH_SECRET}
-  The first nickname that sends it becomes the only accepted user.
-  Messages from all other users will be silently ignored.
+============================================
+ HOW TO START AND STOP OMEGACLAW IRC
+============================================
 
 Stop OmegaClaw:
   docker stop omegaclaw
 
 Restart OmegaClaw:
-  docker start omegaclaw
+  --> Simply rerun this script
 
 Examine log file in case of problem:
   docker logs -f omegaclaw
+
+============================================
+ HOW TO INTERACT WITH OMEGACLAW IRC
+============================================
+
+Please go to https://webchat.quakenet.org/ or any IRC client. 
+Then, enter a unique username and this channel:
+  $IRC_channel
+
+Authentication step (required):
+  Once in the $IRC_channel channel, send this one-time secret exactly once:
+  auth ${OMEGACLAW_AUTH_SECRET}
+  The first nickname that sends it becomes the only accepted user.
+  Messages from all other users will be silently ignored.
 
 EOF
 
@@ -152,6 +159,7 @@ docker run -d -it \
   --user 65534:65534 \
   --security-opt no-new-privileges:true \
   --init \
+  --volume omegaclaw-memory:/PeTTa/repos/OmegaClaw-Core/memory \
   --tmpfs /tmp:size=64m,mode=1777 \
   --tmpfs /run:size=16m,mode=755 \
   --tmpfs /var/tmp:size=64m,mode=1777 \


### PR DESCRIPTION
This is a clone of PR #35 
There are just some small text changes to the script and a rename of the install script to just "omegaclaw"
Testing looked good for retention of memory even with changes in LLMs and docker upgrades.
Authentication and repeated authentication on subsequent runs using the same script works.