### PR TITLE
Shell timeout enforced

### DIFF
--- a/src/skills.pl
+++ b/src/skills.pl
@@ -1,11 +1,40 @@
 %Gets shell command return, plus the process if time limit is not met, returning timeout_error:
-shell(Cmd, Out) :- format(string(SafeCmd), "timeout -k 1s 10s sh -c '~w'", [Cmd]),
-                   process_create(path(sh), ['-c', SafeCmd], [ stdout(pipe(S)), stderr(pipe(S)), process(P)]),
-                   setup_call_cleanup(true,
-                                      read_string(S, _, Text),
-                                      close(S)),
-                   process_wait(P, Status),
-                   ( Status = exit(124) -> Out = timeout_error
-                                         ; Out = Text ).
+shell(Cmd, Out) :-
+    tmp_file_stream(text, TmpFile, TmpInit),
+    close(TmpInit),
+    open(TmpFile, write, TmpOut, [type(text)]),
+    catch(
+        setup_call_cleanup(
+            process_create(
+                path(timeout),
+                ['-k', '1s', '5s', 'sh', '-c', Cmd],
+                [ stdout(stream(TmpOut)),
+                  stderr(stream(TmpOut)),
+                  process(P)
+                ]
+            ),
+            (
+                process_wait(P, Status),
+                close(TmpOut),
+                read_file_to_string(TmpFile, Text, [])
+            ),
+            (
+                catch(close(TmpOut), _, true),
+                catch(delete_file(TmpFile), _, true)
+            )
+        ),
+        E,
+        (
+            catch(close(TmpOut), _, true),
+            catch(delete_file(TmpFile), _, true),
+            throw(E)
+        )
+    ),
+    ( Status = exit(124) -> Out = timeout_error
+    ; Status = exit(137) -> Out = timeout_error
+    ; Status = killed(_) -> Out = timeout_error
+    ; Out = Text
+    ).
+
 
 first_char(Str, C) :- sub_string(Str, 0, 1, _, C).


### PR DESCRIPTION
## Description

Previous shell runner still was hanging in edge cases like when process hierarchy that was spawned was compromise by an OOM kill and sometimes in case of runaway children.

Several fixes for edge cases are in now: Do not read before process wait, do not rely on string concat to avoid quoting hell, do handle OOM kill cases too, handle resource cleanup in all cases, use tmp file instead of pipe to avoid blocking. This is now as far as it gets to be portable (between Max and Linux at least) without going into OS-specific details.

## How Has This Been Tested?
Letting the bot read and write files and write and invoke Python scripts. (basic use)
Explicitly running a script that spawns children and grandchildren then checking if the 5s timeout is still enforced.

## Checklist
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
