### PR TITLE
Use --pull newer instead of always

### DIFF
--- a/scripts/omegaclaw
+++ b/scripts/omegaclaw
@@ -155,7 +155,7 @@ EOF
 docker rm -f omegaclaw 2>/dev/null || true
 
 docker run -d -it \
-  --pull always \
+  --pull newer \
   --name omegaclaw \
   --user 65534:65534 \
   --security-opt no-new-privileges:true \


### PR DESCRIPTION
## Description

If I start image using `localhost/omegaclaw:latest` Docker image name to guarantee that local image is used, I see the following error:
```
docker build -t omegaclaw:latest .
cat scripts/omegaclaw | bash -s -- localhost/omegaclaw:latest
...
WARN[0002] Failed, retrying in 1s ... (3/3). Error: initializing source docker://localhost/omegaclaw:latest: pinging container registry localhost: Get "https://localhost/v2/": dial tcp [::1]:443: connect: connection refused 
Error: unable to copy from source docker://localhost/omegaclaw:latest: initializing source docker://localhost/omegaclaw:latest: pinging container registry localhost: Get "https://localhost/v2/": dial tcp [::1]:443: connect: connection refused
```
The reason is that --pull always fails to me if I try to run the local version. I use Podman instead of Docker so may be it is Podman's specific behavior.

## How Has This Been Tested?

Running local build:
```
docker build -t omegaclaw:latest .
cat scripts/omegaclaw | bash -s -- localhost/omegaclaw:latest
```
Running singularitynet build:
```
cat scripts/omegaclaw | bash -s -- singularitynet/omegaclaw:latest
...
Resolving "singularitynet/omegaclaw" using unqualified-search registries (/etc/containers/registries.conf)
Trying to pull docker.io/singularitynet/omegaclaw:latest...
...
```

## Checklist
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
