### PR TITLE
Crash on empty response hackathon

### DIFF
--- a/lib_llm_ext.py
+++ b/lib_llm_ext.py
@@ -16,27 +16,24 @@ ANTHROPIC_CLIENT = _init_openai_client(
     base_url="https://api.anthropic.com/v1/"
 )
 
-def _get_response(resp):
-    try:
-        return _clean(resp.choices[0].message.content)
-    except Exception as e:
-        print(f"[lib_llm_ext] Exception while processing the response {resp}: {e}")
-        return ""
-
 def _clean(text):
     return text.replace("_quote_", '"').replace("_apostrophe_", "'")
 
 def _chat(client, model, content, max_tokens=6000):
-    resp = client.chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": content}],
-        max_tokens=max_tokens,
-        extra_body={
-            "enable_thinking": True,
-            "thinking_budget": 6000 
-        }
-    )
-    return _get_response(resp)
+    try:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": content}],
+            max_tokens=max_tokens,
+            extra_body={
+                "enable_thinking": True,
+                "thinking_budget": 6000 
+            }
+        )
+        return _clean(resp.choices[0].message.content)
+    except Exception as e:
+        print(f"[lib_llm_ext] Exception while processing the response {resp}: {e}")
+        return ""
 
 def useMiniMax(content):
     return _chat(
@@ -70,7 +67,3 @@ def useLocalEmbedding(atom):
         atom,
         normalize_embeddings=True
     ).tolist()
-
-def test_get_response():
-    assert _get_response(type('', (object,), {'choices': [
-        type('', (object,), { 'message': None }) ] })) == ""

--- a/lib_llm_ext.py
+++ b/lib_llm_ext.py
@@ -17,6 +17,8 @@ ANTHROPIC_CLIENT = _init_openai_client(
 )
 
 def _clean(text):
+    if not text:
+        text = ""
     return text.replace("_quote_", '"').replace("_apostrophe_", "'")
 
 def _chat(client, model, content, max_tokens=6000):

--- a/lib_llm_ext.py
+++ b/lib_llm_ext.py
@@ -16,9 +16,14 @@ ANTHROPIC_CLIENT = _init_openai_client(
     base_url="https://api.anthropic.com/v1/"
 )
 
+def _get_response(resp):
+    try:
+        return _clean(resp.choices[0].message.content)
+    except Exception as e:
+        print(f"[lib_llm_ext] Exception while processing the response {resp}: {e}")
+        return ""
+
 def _clean(text):
-    if not text:
-        text = ""
     return text.replace("_quote_", '"').replace("_apostrophe_", "'")
 
 def _chat(client, model, content, max_tokens=6000):
@@ -31,7 +36,7 @@ def _chat(client, model, content, max_tokens=6000):
             "thinking_budget": 6000 
         }
     )
-    return _clean(resp.choices[0].message.content)
+    return _get_response(resp)
 
 def useMiniMax(content):
     return _chat(
@@ -65,3 +70,7 @@ def useLocalEmbedding(atom):
         atom,
         normalize_embeddings=True
     ).tolist()
+
+def test_get_response():
+    assert _get_response(type('', (object,), {'choices': [
+        type('', (object,), { 'message': None }) ] })) == ""


### PR DESCRIPTION
## Description
This is duplicate of the #65 for the hackathon branch.
This is fix for the exception on the empty response returned by LLM API:
```
INFO:httpx:HTTP Request: POST https://api.asi1.ai/v1/chat/completions "HTTP/1.1 200 OK"
ERROR: /PeTTa/src/main.pl:23: user:main Python 'AttributeError':
ERROR:   'NoneType' object has no attribute 'replace'
ERROR: Python stack:
ERROR:   File "/PeTTa/repos/OmegaClaw-Core/lib_llm_ext.py", line 54, in useAsi1
ERROR:     return _chat(
ERROR:            ^^^^^^
ERROR:   File "/PeTTa/repos/OmegaClaw-Core/lib_llm_ext.py", line 37, in _chat
ERROR:     return _clean(resp.choices[0].message.content)
ERROR:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR:   File "/PeTTa/repos/OmegaClaw-Core/lib_llm_ext.py", line 25, in _clean
ERROR:     return text.replace("_quote_", '"').replace("_apostrophe_", "'")
ERROR:            ^^^^^^^^^^^^
ERROR: 
```

## How Has This Been Tested?

I have tested by trying to reproduce the issue using scenario from https://github.com/asi-alliance/OmegaClaw-Core/pull/67#pullrequestreview-4156669266 on MiniMax model/

## Checklist
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
