### PR TITLE
Fix exception handling section

### DIFF
--- a/lib_llm_ext.py
+++ b/lib_llm_ext.py
@@ -32,7 +32,7 @@ def _chat(client, model, content, max_tokens=6000):
         )
         return _clean(resp.choices[0].message.content)
     except Exception as e:
-        print(f"[lib_llm_ext] Exception while processing the response {resp}: {e}")
+        print(f"[lib_llm_ext._chat] Exception while communicating with LLM: {e}")
         return ""
 
 def useMiniMax(content):


### PR DESCRIPTION
## Description
Exception:
```
ERROR: /PeTTa/src/main.pl:23: user:main Python 'UnboundLocalError':
ERROR:   cannot access local variable 'resp' where it is not associated with a value
ERROR: Python stack:
ERROR:   File "/PeTTa/repos/OmegaClaw-Core/lib_llm_ext.py", line 59, in useAsi1
ERROR:     return _chat(
ERROR:            ^^^^^^
ERROR:   File "/PeTTa/repos/OmegaClaw-Core/lib_llm_ext.py", line 41, in _chat
ERROR:     print(f"[lib_llm_ext] Exception while processing the response {resp}: {e}")
ERROR:                                                                    ^^^^
ERROR: 
```

## How Has This Been Tested?

Edit `lib_llm_ext.py` to add incorrect parameters to the `client.chat.completions.create` call.
Result is:
```
[lib_llm_ext._chat] Exception while communicating with LLM: Error code: 422 - {'error': {'code': 'unprocessable_entity', 'message': 'Validation of the message failed', 'param': None, 'type': None}}
```

## Checklist
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
