### PR TITLE
Add Telegram channel support with token-only bootstrap and idempotent chroma_db init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ ENV MEMORY_DIR=${OMEGACLAW_DIR}/memory
 COPY . ${OMEGACLAW_DIR}
 
 RUN cp ${OMEGACLAW_DIR}/run.metta /PeTTa/run.metta \
- && mkdir ${MEMORY_DIR}/chroma_db \
+ && mkdir -p ${MEMORY_DIR}/chroma_db \
  && ln -s ${MEMORY_DIR}/chroma_db ./chroma_db 
 # && chown -R 65534:65534 ${MEMORY_DIR} \
 # && find ${MEMORY_DIR} -type f -exec chmod 0644 {} \; \

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ When the agent outputs a conclusion, you can trace it back through every step: w
 
 ---
 
-## Quick Start - IRC Channel
+## Quick Start - Channel Setup
 
 Requirement: Docker
 
@@ -68,7 +68,10 @@ OmegaClaw can be installed, started, and subsequently restarted with this single
 ```bash
 curl -fsSL https://raw.githubusercontent.com/asi-alliance/OmegaClaw-Core/refs/heads/main/scripts/omegaclaw | bash -s -- singularitynet/omegaclaw:latest
 ```
-OmegaClaw requires an LLM model to run. When prompted, please select from a list of supported models, enter an API key and a unique IRC channel name, then interact with your OmegaClaw at [webchat.quakenet.org](https://webchat.quakenet.org). 
+OmegaClaw requires an LLM model to run. When prompted, select a communication channel (`IRC` or `Telegram`), pick an LLM provider, and enter your API key.
+
+- **IRC:** enter a unique channel name and interact at [webchat.quakenet.org](https://webchat.quakenet.org).
+- **Telegram:** enter only your bot token. You do **not** need to provide a chat ID; OmegaClaw auto-binds after the first valid auth message.
 
 ### Channel authentication
 
@@ -94,8 +97,7 @@ When done interacting with your OmegaClaw, please use these commands as needed:
 | Remove Containers | `docker rm -f omegaclaw` |
 | Clear Memory | `docker volume rm omegaclaw-memory` |
 
-To restart Omegaclaw simply rerun the single curl command show above. If there is an updated version of OmegaClaw, it will automatically be installed. When you restart OmegaClaw, you will receive a new authentication token secret to paste into your IRC channel chat for re-verification.
+To restart Omegaclaw simply rerun the single curl command show above. If there is an updated version of OmegaClaw, it will automatically be installed. When you restart OmegaClaw, you will receive a new authentication token secret to paste into your channel chat for re-verification.
 
 Your OmegaClaw will retain its memory for subsequent restarts unless you clear memory. To clear OmegaClaw memory and return to its initialized state, please run the command to stop OmegaClaw, the command to remove containers, the command to clear memory (all shown above), and then the single curl script command shown above.
-
 

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -1,0 +1,257 @@
+import json
+import os
+import threading
+import time
+import urllib.parse
+import urllib.request
+
+_running = False
+_last_message = ""
+_msg_lock = threading.Lock()
+_state_lock = threading.Lock()
+
+_bot_token = ""
+_api_base = ""
+_chat_id = ""
+_poll_timeout = 20
+_offset = None
+_connected = False
+
+_auth_secret = ""
+_authenticated_user_id = None
+_authenticated_chat_id = None
+
+
+def _set_last(msg):
+    global _last_message
+    with _msg_lock:
+        if _last_message == "":
+            _last_message = msg
+        else:
+            _last_message = _last_message + " | " + msg
+
+
+def getLastMessage():
+    global _last_message
+    with _msg_lock:
+        tmp = _last_message
+        _last_message = ""
+        return tmp
+
+
+def _set_auth_secret(secret=None):
+    global _auth_secret, _authenticated_user_id, _authenticated_chat_id
+    if secret is None:
+        secret = os.environ.get("OMEGACLAW_AUTH_SECRET", "")
+    with _state_lock:
+        _auth_secret = (secret or "").strip()
+        _authenticated_user_id = None
+        _authenticated_chat_id = None
+
+
+def _parse_auth_candidate(msg):
+    text = msg.strip()
+    lower = text.lower()
+    if lower.startswith("auth "):
+        return text[5:].strip()
+    if lower.startswith("/auth "):
+        return text[6:].strip()
+    return text
+
+
+def _display_name(user, chat):
+    username = str(user.get("username", "")).strip()
+    if username:
+        return f"@{username}"
+
+    first = str(user.get("first_name", "")).strip()
+    last = str(user.get("last_name", "")).strip()
+    full = f"{first} {last}".strip()
+    if full:
+        return full
+
+    title = str(chat.get("title", "")).strip()
+    if title:
+        return title
+
+    return "telegram_user"
+
+
+def _api_call(method, params=None, timeout=30, use_post=False):
+    if not _api_base:
+        raise RuntimeError("Telegram adapter not initialized")
+
+    params = params or {}
+    encoded = urllib.parse.urlencode(params).encode("utf-8")
+    url = f"{_api_base}/{method}"
+
+    if use_post:
+        req = urllib.request.Request(url, data=encoded)
+    else:
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+        req = urllib.request.Request(url)
+
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8", errors="ignore"))
+
+    if not payload.get("ok"):
+        raise RuntimeError(payload.get("description", f"{method} failed"))
+
+    return payload.get("result")
+
+
+def _initialize_offset():
+    global _offset
+    try:
+        updates = _api_call("getUpdates", {"timeout": 0}, timeout=10) or []
+    except Exception as exc:
+        print(f"[TELEGRAM] Could not read initial offset: {exc}")
+        return
+
+    max_update = -1
+    for update in updates:
+        update_id = update.get("update_id")
+        if isinstance(update_id, int):
+            max_update = max(max_update, update_id)
+
+    if max_update >= 0:
+        with _state_lock:
+            _offset = max_update + 1
+
+
+def _is_allowed_message(chat_id, user_id, msg):
+    global _chat_id, _authenticated_user_id, _authenticated_chat_id
+    candidate = _parse_auth_candidate(msg)
+
+    with _state_lock:
+        if _chat_id and chat_id != _chat_id:
+            return "ignore"
+
+        if not _auth_secret:
+            if not _chat_id:
+                _chat_id = chat_id
+            return "allow"
+
+        if _authenticated_user_id is None:
+            if candidate == _auth_secret:
+                _authenticated_user_id = user_id
+                _authenticated_chat_id = chat_id
+                _chat_id = chat_id
+                return "auth_bound"
+            return "ignore"
+
+        if chat_id != _authenticated_chat_id:
+            return "ignore"
+        return "allow" if user_id == _authenticated_user_id else "ignore"
+
+
+def _poll_loop():
+    global _connected, _offset
+    print("[TELEGRAM] Polling started")
+
+    while _running:
+        try:
+            params = {"timeout": int(_poll_timeout)}
+            with _state_lock:
+                if _offset is not None:
+                    params["offset"] = _offset
+
+            updates = _api_call("getUpdates", params=params, timeout=int(_poll_timeout) + 10) or []
+            _connected = True
+
+            for update in updates:
+                update_id = update.get("update_id")
+                if isinstance(update_id, int):
+                    with _state_lock:
+                        if _offset is None or (update_id + 1) > _offset:
+                            _offset = update_id + 1
+
+                message = update.get("message") or update.get("edited_message")
+                if not isinstance(message, dict):
+                    continue
+
+                text = message.get("text")
+                if not text:
+                    continue
+
+                chat = message.get("chat") or {}
+                user = message.get("from") or {}
+                chat_id = str(chat.get("id", "")).strip()
+                user_id = str(user.get("id", "")).strip()
+                if not chat_id or not user_id:
+                    continue
+
+                state = _is_allowed_message(chat_id, user_id, text)
+                display_name = _display_name(user, chat)
+                if state == "allow":
+                    _set_last(f"{display_name}: {text}")
+                elif state == "auth_bound":
+                    send_message(f"Authentication successful for {display_name}.")
+        except Exception as exc:
+            _connected = False
+            print(f"[TELEGRAM] Poll error: {exc}")
+            time.sleep(2)
+
+    _connected = False
+    print("[TELEGRAM] Polling stopped")
+
+
+def start_telegram(bot_token, chat_id="", poll_timeout=20, auth_secret=None):
+    global _running, _bot_token, _api_base, _chat_id, _poll_timeout, _offset, _connected
+
+    _bot_token = str(bot_token).strip()
+    if not _bot_token:
+        raise ValueError("TG_BOT_TOKEN is required")
+
+    _api_base = f"https://api.telegram.org/bot{_bot_token}"
+    _chat_id = str(chat_id).strip()
+
+    try:
+        _poll_timeout = max(1, int(poll_timeout))
+    except Exception:
+        _poll_timeout = 20
+
+    _offset = None
+    _running = True
+    _connected = False
+    _set_auth_secret(auth_secret)
+    print(f"[TELEGRAM] Starting adapter with chat target: {_chat_id or 'auto-bind'}")
+    _initialize_offset()
+
+    t = threading.Thread(target=_poll_loop, daemon=True)
+    t.start()
+    return t
+
+
+def stop_telegram():
+    global _running
+    _running = False
+
+
+def send_message(text):
+    text = str(text).replace("\\n", "\n").replace("\r", "")
+    if not text:
+        return
+
+    with _state_lock:
+        target_chat = _chat_id
+
+    if not _connected or not target_chat:
+        return
+
+    max_len = 3900
+    for i in range(0, len(text), max_len):
+        chunk = text[i:i + max_len]
+        if not chunk:
+            continue
+        try:
+            _api_call(
+                "sendMessage",
+                {"chat_id": target_chat, "text": chunk},
+                timeout=15,
+                use_post=True,
+            )
+        except Exception as exc:
+            print(f"[TELEGRAM] Send failed: {exc}")
+            return

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ User-facing MeTTa skills the agent invokes. Each page follows the template **Sig
 ### Configuration & Adapters
 
 - [reference-configuration.md](./reference-configuration.md) — `configure` form and all runtime parameters
-- [reference-channels.md](./reference-channels.md) — IRC, Mattermost, websearch adapters and the channel contract
+- [reference-channels.md](./reference-channels.md) — IRC, Telegram, Mattermost, and websearch adapters plus the channel contract
 - [reference-python-bridges.md](./reference-python-bridges.md) — `lib_llm_ext.py`, `src/agentverse.py`, `src/helper.py`, `src/skills.pl`
 
 ### Internals

--- a/docs/intro-installation.md
+++ b/docs/intro-installation.md
@@ -7,14 +7,15 @@ OmegaClaw supports two setups: the recommended Docker one-liner and a manual MeT
 Requirements: Docker.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/asi-alliance/OmegaClaw-Core/refs/heads/main/scripts/omegaclaw_setup.sh \
+curl -fsSL https://raw.githubusercontent.com/asi-alliance/OmegaClaw-Core/refs/heads/main/scripts/omegaclaw \
   | bash -s -- singularitynet/omegaclaw:latest
 ```
 
 The script prompts for:
 
 - an LLM API key (OpenAI by default)
-- a unique IRC channel name
+- a communication channel selection (`IRC` or `Telegram`)
+- channel details (IRC name, or Telegram bot token)
 
 and prints a one-time secret used to authenticate the first IRC user. See [tutorial-01-first-run.md](./tutorial-01-first-run.md) for the full first-run walkthrough.
 
@@ -76,10 +77,11 @@ Set via `embeddingprovider` in `src/memory.metta`:
 | Channel | Env var | Notes |
 |---|---|---|
 | IRC | *(none required)* | Connects anonymously to QuakeNet. Optional `OMEGACLAW_AUTH_SECRET` gates who the agent treats as its owner. |
+| Telegram | *(none required if passed as args)* | Provide `commchannel=telegram` and `TG_BOT_TOKEN=<token>` at startup. `TG_CHAT_ID` is optional; if omitted, the adapter can auto-bind on first valid inbound auth/message. |
 | Mattermost | `MM_BOT_TOKEN` | Set via `configure` or directly in `src/channels.metta`. |
 
 ### Docker setup script
 
-`scripts/omegaclaw_setup.sh` (invoked by the Docker one-liner above) asks which provider you want, writes the chosen key into the container's runtime config, and auto-pairs the embedding provider: `Anthropic → Local`, `OpenAI → OpenAI`, `ASICloud → Local`. You don't need to set anything manually when using Docker.
+`scripts/omegaclaw` (invoked by the Docker one-liner above) asks which channel/provider you want, writes the chosen keys into the container's runtime config, and auto-pairs the embedding provider: `Anthropic → Local`, `OpenAI → OpenAI`, `ASICloud → Local`. You don't need to set anything manually when using Docker.
 
 All runtime parameters are listed in [reference-configuration.md](./reference-configuration.md).

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -126,6 +126,7 @@ lib_omegaclaw.metta       loads all submodules
 └── lib_llm_ext.py        Claude / GPT / MiniMax / local embeddings
 
 channels/irc.py           IRC adapter
+channels/telegram.py      Telegram adapter
 channels/mattermost.py    Mattermost adapter
 channels/websearch.py     web search
 
@@ -282,7 +283,7 @@ The set of callable operations available to the agent at each turn — plain MeT
 
 ### Channels
 
-Abstract communication endpoints. `(send ...)` and `(receive)` delegate to the active channel adapter (IRC or Mattermost by default). See [reference-channels.md](./reference-channels.md).
+Abstract communication endpoints. `(send ...)` and `(receive)` delegate to the active channel adapter (IRC, Telegram, or Mattermost by default). See [reference-channels.md](./reference-channels.md).
 
 ### Orchestration
 
@@ -343,7 +344,7 @@ A skill whose implementation is a remote agent reached through the Agentverse br
 - a small, auditable agent that can explain **why** it reached a conclusion;
 - reasoning with explicit uncertainty (`stv frequency confidence`) rather than opaque probabilities;
 - a platform for experimenting with NAL and PLN inside an agent loop;
-- a chat-facing agent over IRC, Mattermost, or a channel you add yourself.
+- a chat-facing agent over IRC, Telegram, Mattermost, or a channel you add yourself.
 
 ### Honest limits
 

--- a/docs/reference-channels.md
+++ b/docs/reference-channels.md
@@ -18,7 +18,9 @@ The MeTTa side reads `commchannel` and branches:
 (= (receive)
    (if (== (commchannel) irc)
        (py-call (irc.getLastMessage))
-       (py-call (mattermost.getLastMessage))))
+       (if (== (commchannel) telegram)
+           (py-call (telegram.getLastMessage))
+           (py-call (mattermost.getLastMessage)))))
 ```
 
 ## `channels/irc.py`
@@ -35,6 +37,14 @@ Mattermost adapter using a bot token.
 
 - `start_mattermost(url, channel_id, bot_token)` — connect to a Mattermost instance.
 - Requires `MM_BOT_TOKEN` configured (empty by default — set via `configure` or command line).
+
+## `channels/telegram.py`
+
+Telegram adapter using Bot API long polling.
+
+- `start_telegram(bot_token, chat_id, poll_timeout)` — starts a poll loop.
+- `TG_CHAT_ID` is optional; if empty, the adapter can auto-bind to the first valid inbound chat.
+- Outbound messages are chunked to Telegram-safe lengths.
 
 ## `channels/websearch.py`
 

--- a/docs/reference-configuration.md
+++ b/docs/reference-configuration.md
@@ -37,11 +37,14 @@ This reads a command-line override via `argk` (`name=value` on the MeTTa command
 
 | Parameter | Default | Meaning |
 |---|---|---|
-| `commchannel` | `irc` | Active channel — `irc` or `mattermost`. |
+| `commchannel` | `irc` | Active channel — `irc`, `telegram`, or `mattermost`. |
 | `IRC_channel` | `##omegaclaw` | IRC channel to join. |
 | `IRC_server` | `irc.quakenet.org` | IRC server hostname. |
 | `IRC_port` | 6667 | IRC port. |
 | `IRC_user` | `omegaclaw` | IRC nickname. |
+| `TG_BOT_TOKEN` | *(empty — set at runtime)* | Telegram bot token (from BotFather). |
+| `TG_CHAT_ID` | *(empty — auto-bind supported)* | Optional fixed Telegram chat ID. Leave empty to auto-bind on first valid inbound auth/message. |
+| `TG_POLL_TIMEOUT` | 20 | Telegram long-poll timeout in seconds. |
 | `MM_URL` | `https://chat.singularitynet.io` | Mattermost base URL. |
 | `MM_CHANNEL_ID` | `8fjrmabjx7gupy7e5kjznpt5qh` | Target channel ID. |
 | `MM_BOT_TOKEN` | *(empty — set at runtime)* | Bot auth token. |

--- a/docs/reference-skills-communication.md
+++ b/docs/reference-skills-communication.md
@@ -12,7 +12,7 @@ Defined in `src/channels.metta`. Dispatch depends on the `commchannel` configura
 ```
 
 ### Purpose
-Send a message to the currently active communication channel (IRC or Mattermost by default).
+Send a message to the currently active communication channel (IRC, Telegram, or Mattermost).
 
 ### Parameters
 - `message` — the text to send. Newlines are replaced with `\n` before transmission.
@@ -55,7 +55,7 @@ The agent does not normally call `receive` itself; the loop wraps it:
 ```
 
 ### Notes / Limits
-- Delegates to `irc.getLastMessage` or `mattermost.getLastMessage`.
+- Delegates to `irc.getLastMessage`, `telegram.getLastMessage`, or `mattermost.getLastMessage`.
 - The loop treats an unchanged message as "no new input" via the `&prevmsg` state.
 
 ---

--- a/docs/tutorial-01-first-run.md
+++ b/docs/tutorial-01-first-run.md
@@ -11,7 +11,7 @@
 ## 1. Start the container
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/asi-alliance/OmegaClaw-Core/refs/heads/main/scripts/omegaclaw_setup.sh \
+curl -fsSL https://raw.githubusercontent.com/asi-alliance/OmegaClaw-Core/refs/heads/main/scripts/omegaclaw \
   | bash -s -- singularitynet/omegaclaw:latest
 ```
 

--- a/lib_omegaclaw.metta
+++ b/lib_omegaclaw.metta
@@ -9,6 +9,7 @@
 !(import! &self (library OmegaClaw-Core ./src/agentverse.py))
 !(import! &self (library OmegaClaw-Core ./channels/irc.py))
 !(import! &self (library OmegaClaw-Core ./channels/mattermost.py))
+!(import! &self (library OmegaClaw-Core ./channels/telegram.py))
 !(import! &self (library OmegaClaw-Core ./channels/websearch.py))
 !(import! &self (library OmegaClaw-Core ./src/utils))
 !(import! &self (library OmegaClaw-Core ./src/channels))

--- a/scripts/omegaclaw
+++ b/scripts/omegaclaw
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 ########################################################
-#  Required parameter is Docker image 
-#  Invoke this script:  "./omegaclaw_setup.sh <image>  
+#  Required parameter is Docker image
+#  Invoke this script:  "./omegaclaw <image>
 #######################################################
 image="${1:?usage: $0 <container-image>}"
 
@@ -17,11 +17,16 @@ chmod 0600 "$tmp_config_file"
 chmod 0600 "$tmp_py_file"
 
 cat >"$tmp_py_file" <<'PY'
-import sys
-import shutil
-import textwrap
 import getpass
+import json
 import secrets
+import shlex
+import shutil
+import sys
+import textwrap
+import urllib.error
+import urllib.parse
+import urllib.request
 
 LICENSE_TEXT = """\
 
@@ -32,11 +37,13 @@ OmegaClaw is experimental, open-source software developed by SingularityNET Foun
 
 """
 
+
 def print_wrapped(text: str) -> None:
     width = max(60, min(shutil.get_terminal_size((100, 24)).columns - 2, 100))
     for paragraph in text.strip().split("\n\n"):
         print(textwrap.fill(paragraph, width=width))
         print()
+
 
 def require_license_acceptance():
     print_wrapped(LICENSE_TEXT)
@@ -49,25 +56,81 @@ def require_license_acceptance():
             sys.exit(1)
         print("You must type 'accept' or 'q'.", file=sys.stderr)
 
-def config_run_omegaclaw(config_output_path):
-    print(" ")
-    print("Welcome to OmegaClaw IRC!")
-    print(" ")
-    require_license_acceptance()
 
+def _telegram_api_call(bot_token, method, params=None, timeout=20):
+    params = params or {}
+    url = f"https://api.telegram.org/bot{bot_token}/{method}"
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8", errors="ignore"))
+
+    if not payload.get("ok"):
+        raise RuntimeError(payload.get("description", f"{method} failed"))
+
+    return payload.get("result")
+
+
+def _choose_channel():
     while True:
-        print("Please enter your unique IRC channel. Example: ##MyOmega54323")
-        channel = input("Enter IRC channel or 'q' to exit: ").strip()
+        print("Please select your communication channel.")
+        print("1) IRC (QuakeNet) 2) Telegram Bot")
+        c = input("Enter 1-2 or 'q' to exit (default: 1): ").strip()
 
-        if channel.lower() == "q":
+        if c.lower() == "q":
             sys.exit(1)
 
-        if not channel:
-            print("IRC channel is required.", file=sys.stderr)
-            continue
+        if c in ("", "1"):
+            while True:
+                print("Please enter your unique IRC channel. Example: ##MyOmega54323")
+                channel = input("Enter IRC channel or 'q' to exit: ").strip()
+                if channel.lower() == "q":
+                    sys.exit(1)
+                if not channel:
+                    print("IRC channel is required.", file=sys.stderr)
+                    continue
+                return {
+                    "commchannel": "irc",
+                    "IRC_channel": channel,
+                }
 
-        break
+        if c == "2":
+            while True:
+                token = getpass.getpass("Please paste your Telegram bot token and press ENTER or 'q' to exit: ").strip()
 
+                if token.lower() == "q":
+                    sys.exit(1)
+
+                if not token:
+                    print("Telegram bot token is required.", file=sys.stderr)
+                    continue
+
+                try:
+                    me = _telegram_api_call(token, "getMe", timeout=15)
+                    username = str(me.get("username", "")).strip()
+                except (RuntimeError, urllib.error.URLError, TimeoutError) as exc:
+                    print(f"Telegram token validation failed: {exc}", file=sys.stderr)
+                    continue
+
+                print("Telegram bot token validated.")
+                if username:
+                    print(f"Talk to your bot here: https://t.me/{username}")
+                print("No Telegram chat ID is needed. OmegaClaw will auto-bind after your first auth message.")
+
+                return {
+                    "commchannel": "telegram",
+                    "TG_BOT_TOKEN": token,
+                    "TG_CHAT_ID": "",
+                    "TG_POLL_TIMEOUT": "20",
+                    "TG_BOT_USERNAME": username,
+                }
+
+        print("Please enter 1, 2, or 'q'.", file=sys.stderr)
+
+
+def _choose_provider():
     while True:
         print("Please select your LLM provider.")
         print("1) Anthropic/Claude 2) OpenAI/ChatGPT 3) ASI Cloud Minimax")
@@ -84,15 +147,16 @@ def config_run_omegaclaw(config_output_path):
             print("Please enter 1-3 or 'q'", file=sys.stderr)
             continue
 
-        providers = [("Anthropic", "Local", "ANTHROPIC_API_KEY"),
+        providers = [
+            ("Anthropic", "Local", "ANTHROPIC_API_KEY"),
             ("OpenAI", "OpenAI", "OPENAI_API_KEY"),
-            ("ASICloud", "Local", "ASI_API_KEY")]
-        provider = providers[provider_id][0]
-        embeddingprovider = providers[provider_id][1]
-        api_token_var = providers[provider_id][2]
+            ("ASICloud", "Local", "ASI_API_KEY"),
+        ]
+        provider, embeddingprovider, api_token_var = providers[provider_id]
+        return provider, embeddingprovider, api_token_var
 
-        break
 
+def _prompt_llm_token():
     while True:
         token = getpass.getpass("Please paste your LLM token and press ENTER or 'q' to exit: ").strip()
 
@@ -103,15 +167,32 @@ def config_run_omegaclaw(config_output_path):
             print("Error: Invalid token", file=sys.stderr)
             continue
 
-        break
+        return token
+
+
+def _write_kv(fp, key, value):
+    fp.write(f"{key}={shlex.quote(str(value))}\n")
+
+
+def config_run_omegaclaw(config_output_path):
+    print(" ")
+    print("Welcome to OmegaClaw!")
+    print(" ")
+    require_license_acceptance()
+
+    channel_config = _choose_channel()
+    provider, embeddingprovider, api_token_var = _choose_provider()
+    token = _prompt_llm_token()
 
     with open(config_output_path, "w", encoding="utf-8") as f:
-        f.write(f'api_token_var={api_token_var}\n')
-        f.write(f'api_token={token}\n')
-        f.write(f'OMEGACLAW_AUTH_SECRET={secrets.token_urlsafe(24)}\n')
-        f.write(f'IRC_channel={channel}\n')
-        f.write(f'provider={provider}\n')
-        f.write(f'embeddingprovider={embeddingprovider}\n')
+        _write_kv(f, "api_token_var", api_token_var)
+        _write_kv(f, "api_token", token)
+        _write_kv(f, "OMEGACLAW_AUTH_SECRET", secrets.token_urlsafe(24))
+        _write_kv(f, "provider", provider)
+        _write_kv(f, "embeddingprovider", embeddingprovider)
+        for key, value in channel_config.items():
+            _write_kv(f, key, value)
+
 
 if __name__ == "__main__":
     config_run_omegaclaw(sys.argv[1])
@@ -124,7 +205,7 @@ python3 "$tmp_py_file" "$tmp_config_file" </dev/tty
 cat <<EOF
 
 ============================================
- HOW TO START AND STOP OMEGACLAW IRC
+ HOW TO START AND STOP OMEGACLAW
 ============================================
 
 Stop OmegaClaw:
@@ -136,28 +217,72 @@ Restart OmegaClaw:
 Examine log file in case of problem:
   docker logs -f omegaclaw
 
+Auth secret (required once on first message in supported channels):
+  $OMEGACLAW_AUTH_SECRET
+
+EOF
+
+if [ "${commchannel}" = "irc" ]; then
+cat <<EOF
+
 ============================================
  HOW TO INTERACT WITH OMEGACLAW IRC
 ============================================
 
-Please go to https://webchat.quakenet.org/ or any IRC client. 
+Please go to https://webchat.quakenet.org/ or any IRC client.
 Then, enter a unique username and this channel:
   $IRC_channel
 
 EOF
+else
+cat <<EOF
+
+============================================
+ HOW TO INTERACT WITH OMEGACLAW TELEGRAM
+============================================
+
+Open Telegram and send this auth message to your bot:
+  auth $OMEGACLAW_AUTH_SECRET
+
+EOF
+
+if [ -n "${TG_BOT_USERNAME:-}" ]; then
+cat <<EOF
+Bot link:
+  https://t.me/$TG_BOT_USERNAME
+
+EOF
+fi
+
+cat <<EOF
+No chat ID is required. OmegaClaw binds to your chat automatically after successful auth.
+
+EOF
+fi
 
 docker rm -f omegaclaw 2>/dev/null || true
 
-docker run -d -it \
-  --name omegaclaw \
-  --init \
-  --volume omegaclaw-memory:/PeTTa/repos/OmegaClaw-Core/memory \
-  --tmpfs /tmp:size=64m,mode=1777 \
-  --tmpfs /run:size=16m,mode=755 \
-  --tmpfs /var/tmp:size=64m,mode=1777 \
-  -e ${api_token_var}="${api_token}" \
-  -e OMEGACLAW_AUTH_SECRET=0000 \
-  "$image" \
-  IRC_channel="$IRC_channel" \
-  provider="$provider" \
-  embeddingprovider="$embeddingprovider"
+docker_cmd=(
+  docker run -d -it
+  --name omegaclaw
+  --init
+  --volume omegaclaw-memory:/PeTTa/repos/OmegaClaw-Core/memory
+  --tmpfs /tmp:size=64m,mode=1777
+  --tmpfs /run:size=16m,mode=755
+  --tmpfs /var/tmp:size=64m,mode=1777
+  -e "${api_token_var}=${api_token}"
+  -e "OMEGACLAW_AUTH_SECRET=${OMEGACLAW_AUTH_SECRET}"
+  "$image"
+  "commchannel=${commchannel}"
+  "provider=${provider}"
+  "embeddingprovider=${embeddingprovider}"
+)
+
+if [ "${commchannel}" = "irc" ]; then
+  docker_cmd+=("IRC_channel=${IRC_channel}")
+else
+  docker_cmd+=("TG_BOT_TOKEN=${TG_BOT_TOKEN}")
+  docker_cmd+=("TG_POLL_TIMEOUT=${TG_POLL_TIMEOUT:-20}")
+fi
+
+"${docker_cmd[@]}"

--- a/src/channels.metta
+++ b/src/channels.metta
@@ -7,6 +7,9 @@
 (= (MM_URL) (empty))
 (= (MM_CHANNEL_ID) (empty))
 (= (MM_BOT_TOKEN) (empty))
+(= (TG_BOT_TOKEN) (empty))
+(= (TG_CHAT_ID) (empty))
+(= (TG_POLL_TIMEOUT) (empty))
 
 ;Connect all the channels:
 (= (initChannels)
@@ -18,16 +21,23 @@
                      (configure IRC_port 6667)
                      (configure IRC_user omegaclaw)
                      (py-call (irc.start_irc (IRC_channel) (IRC_server) (IRC_port) (IRC_user))))
-              (progn (configure MM_URL "https://chat.singularitynet.io")
-                     (configure MM_CHANNEL_ID "8fjrmabjx7gupy7e5kjznpt5qh")
-                     (configure MM_BOT_TOKEN "")
-                     (py-call (mattermost.start_mattermost (MM_URL) (MM_CHANNEL_ID) (MM_BOT_TOKEN)))))))
+              (if (== (commchannel) telegram)
+                  (progn (configure TG_BOT_TOKEN "")
+                         (configure TG_CHAT_ID "")
+                         (configure TG_POLL_TIMEOUT 20)
+                         (py-call (telegram.start_telegram (TG_BOT_TOKEN) (TG_CHAT_ID) (TG_POLL_TIMEOUT))))
+                  (progn (configure MM_URL "https://chat.singularitynet.io")
+                         (configure MM_CHANNEL_ID "8fjrmabjx7gupy7e5kjznpt5qh")
+                         (configure MM_BOT_TOKEN "")
+                         (py-call (mattermost.start_mattermost (MM_URL) (MM_CHANNEL_ID) (MM_BOT_TOKEN))))))))
 
 ;Receive the latest user message considering all communication channels:
 (= (receive)
    (if (== (commchannel) irc)
        (py-call (irc.getLastMessage))
-       (py-call (mattermost.getLastMessage))))
+       (if (== (commchannel) telegram)
+           (py-call (telegram.getLastMessage))
+           (py-call (mattermost.getLastMessage)))))
 
 ;Send a message to all communication channels:
 !(change-state! &lastsend "")
@@ -37,7 +47,9 @@
               (let $safemsg (string-replace $msg  "\n" "\\n")
                    (if (== (commchannel) irc)
                        (let $temp (cut) (py-call (irc.send_message $safemsg)))
-                       (let $temp (cut) (py-call (mattermost.send_message $safemsg)))))) _))
+                       (if (== (commchannel) telegram)
+                           (let $temp (cut) (py-call (telegram.send_message $safemsg)))
+                           (let $temp (cut) (py-call (mattermost.send_message $safemsg))))))) _))
 
 ;Search the internet for some information:
 (= (search $msg)


### PR DESCRIPTION
## Summary

This PR adds first-class Telegram channel support and updates bootstrap UX so users do not need to know or provide a Telegram chat ID.
It also fixes local container startup when memory/chroma_db already exists.

## Changes
- Added Telegram channel adapter:
 - channels/telegram.py
 - Long-poll receive loop + send support
 - Supports auth <secret> flow and auto-bind behavior when TG_CHAT_ID is not provided
- Wired Telegram into runtime channel dispatch:
 - lib_omegaclaw.metta imports Telegram adapter
 - src/channels.metta adds commchannel=telegram + TG_BOT_TOKEN, TG_CHAT_ID, TG_POLL_TIMEOUT
 - receive / send now dispatch to Telegram when selected
- Improved bootstrap script UX:
 - scripts/omegaclaw now supports channel selection (IRC or Telegram)
 - Telegram path validates bot token via getMe
 - No chat ID prompt for Telegram
 - Uses generated OMEGACLAW_AUTH_SECRET (instead of hardcoded 0000)
- Documentation updates across README + docs to include Telegram flow/config
- Docker reliability fix:
 - Dockerfile: mkdir -p ${MEMORY_DIR}/chroma_db to avoid failures with existing vector store

## Validation
- bash -n scripts/omegaclaw
- python3 -m py_compile channels/telegram.py
- python3 -m py_compile channels/irc.py channels/mattermost.py

## Notes
- Existing channels (irc, mattermost) remain supported.
- TG_CHAT_ID remains available as an optional explicit override.