### PR TITLE
dont break messages to IRC mid-word

### DIFF
--- a/channels/irc.py
+++ b/channels/irc.py
@@ -3,6 +3,7 @@ import random
 import socket
 import threading
 import time
+import textwrap
 
 _running = False
 _sock = None
@@ -157,12 +158,13 @@ def stop_irc():
 
 def send_message(text):
     max_len = 400
-    lines = text.replace("\r", "").split("\\n")
-    for text in lines:
+    segments = text.replace("\r", "").split("\\n")
+    lines = []
+    for segment in segments:
+        lines.extend(textwrap.wrap(segment, width=max_len, break_long_words=False))
+    for chunk in lines:
         try:
             if _connected and _channel:
-                for i in range(0, len(text), max_len):
-                    chunk = text[i:i + max_len]
-                    _send(f"PRIVMSG {_channel} :{chunk}")
+                 _send(f"PRIVMSG {_channel} :{chunk}")
         except Exception:
-            pass
+            print(f"[IRC] error in send_message function using {server}:{port} as {nick} for channel {channel}")


### PR DESCRIPTION
## Description
fix string/word splits in output of IRC

## How Has This Been Tested?

Tested well on Anthropic. On minimax I need to use a prompt like:
**send all output to me in IRC compatible format. If necessary use multiple segments** but problem unlikely due to this fix

## Checklist
- [ x] Self-review completed
- [ x
<img width="1280" height="1024" alt="Screenshot from 2026-04-23 21-06-39" src="https://github.com/user-attachments/assets/58d2c458-07b8-45a3-86de-d0b1484e5793" />
] Test scenarios above are passed with the version of the code from PR
