### PR TITLE
Break long IRC message on the word edge

### DIFF
--- a/channels/irc.py
+++ b/channels/irc.py
@@ -3,6 +3,7 @@ import random
 import socket
 import threading
 import time
+import textwrap
 
 _running = False
 _sock = None
@@ -157,12 +158,13 @@ def stop_irc():
 
 def send_message(text):
     max_len = 400
-    lines = text.replace("\r", "").split("\\n")
-    for text in lines:
+    segments = text.replace("\r", "").split("\\n")
+    lines = []
+    for segment in segments:
+        lines.extend(textwrap.wrap(segment, width=max_len, break_long_words=True, break_on_hyphens=False))
+    for chunk in lines:
         try:
             if _connected and _channel:
-                for i in range(0, len(text), max_len):
-                    chunk = text[i:i + max_len]
-                    _send(f"PRIVMSG {_channel} :{chunk}")
+                 _send(f"PRIVMSG {_channel} :{chunk}")
         except Exception:
-            pass
+            print(f"[IRC] error in send_message on channel {_channel}")

--- a/channels/irc.py
+++ b/channels/irc.py
@@ -166,5 +166,5 @@ def send_message(text):
         try:
             if _connected and _channel:
                  _send(f"PRIVMSG {_channel} :{chunk}")
-        except Exception:
-            print(f"[IRC] error in send_message on channel {_channel}")
+        except Exception as e:
+            print(f"[IRC] error in send_message on channel {_channel}: {e}")


### PR DESCRIPTION
## Description

Previous code was breaking long messages in the middle of the word. This PR fixes this.
Any exception on sending the message are logged to the stdout.

## How Has This Been Tested?

1. Check word breaking scenario
Request: "Generate a new story in 400 words and send it to the chat."

2. Check exception handling scenario
Insert an incorrect code into the `try/catch` block of the `send_message` function.
Restart the agent. Check logs for the error message.

## Checklist
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
