### PR TITLE
Add docker pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ OmegaClaw is a persistent AI agent written in MeTTa — SingularityNET's AGI pro
 **1. Run the launch script:**
 
 ```shell
+docker pull singularitynet/omegaclaw:hackathon2604
 curl -fsSL https://raw.githubusercontent.com/asi-alliance/OmegaClaw-Core/refs/tags/hackathon2604/scripts/omegaclaw | bash -s -- singularitynet/omegaclaw:hackathon2604
 ```
 


### PR DESCRIPTION
## Description
Without docker pull command from the instruction can start old Docker image

## How Has This Been Tested?
Tag some old release as singularitynet/omegaclaw:hackathon2604 locally. Use startup command. Login into docker and check that OmegaClaw-Core repo has stale version.

## Checklist
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
