### PR TITLE
Fix fail on starting locally build image

### DIFF
--- a/scripts/omegaclaw
+++ b/scripts/omegaclaw
@@ -146,7 +146,7 @@ def _choose_provider():
             ("Anthropic", "Local", "ANTHROPIC_API_KEY"),
             ("OpenAI", "OpenAI", "OPENAI_API_KEY"),
             ("ASICloud", "Local", "ASI_API_KEY"),
-            ("ASIOne", "Local", "ASIONE_API_KEY")]
+            ("ASIOne", "Local", "ASIONE_API_KEY"),
         ]
         provider, embeddingprovider, api_token_var = providers[provider_id]
         return provider, embeddingprovider, api_token_var
@@ -329,10 +329,10 @@ options() {
 
 start() {
     docker rm -f omegaclaw 2>/dev/null || true
+    docker pull "${image}" || true
 
     docker_cmd=(
         docker run -d -it
-            --pull always
             --name omegaclaw
             --user 65534:65534
             --security-opt no-new-privileges:true


### PR DESCRIPTION
Pull image but don't fail if pull fails which happens in case of the local build.

## Description
Replace `--pull always` by separate `docker pull` command.
Fix typo in the Python array.

## How Has This Been Tested?
Start locally built image using `./scripts/omegaclaw <image>` command.

## Checklist
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
