### PR TITLE
Fixes memory leakage / late gc collecting issue

### DIFF
--- a/src/loop.metta
+++ b/src/loop.metta
@@ -74,4 +74,6 @@
                                 (if (> (get_time) (get-state &nextWakeAt))
                                     (change-state! &loops (+ 1 (maxWakeLoops))) _)))
                       (sleep (sleepInterval))
+                      (cut)
+                      (gc)
                       (omegaclaw (+ 1 $k))))))

--- a/src/memory.metta
+++ b/src/memory.metta
@@ -19,8 +19,7 @@
    (read-file (library OmegaClaw-Core ./memory/prompt.txt)))
 
 (= (getHistory)
-   (let $ret (read-file (library OmegaClaw-Core ./memory/history.metta))
-        (last_chars $ret (maxHistory))))
+   (read_file_tail (library OmegaClaw-Core ./memory/history.metta) (maxHistory)))
 
 (= (addToHistory $lastmessage $response $sexpr $msgnew)
    (if $msgnew

--- a/src/skills.metta
+++ b/src/skills.metta
@@ -54,7 +54,7 @@
 (= (technical-analysis $ticker)
    (py-call (agentverse.technical_analysis $ticker)))
 
-!(import_prolog_functions_from_file (library OmegaClaw-Core ./src/skills.pl) (shell first_char))
+!(import_prolog_functions_from_file (library OmegaClaw-Core ./src/skills.pl) (shell first_char gc))
 
 (= (metta $str)
    (let $code (sread $str)

--- a/src/skills.metta
+++ b/src/skills.metta
@@ -54,7 +54,7 @@
 (= (technical-analysis $ticker)
    (py-call (agentverse.technical_analysis $ticker)))
 
-!(import_prolog_functions_from_file (library OmegaClaw-Core ./src/skills.pl) (shell first_char gc))
+!(import_prolog_functions_from_file (library OmegaClaw-Core ./src/skills.pl) (shell first_char gc read_file_tail))
 
 (= (metta $str)
    (let $code (sread $str)

--- a/src/skills.pl
+++ b/src/skills.pl
@@ -41,5 +41,4 @@ first_char(Str, C) :- sub_string(Str, 0, 1, _, C).
 
 gc(true) :- garbage_collect,
             garbage_collect_atoms,
-            trim_stacks,
-            memlog.
+            trim_stacks.

--- a/src/skills.pl
+++ b/src/skills.pl
@@ -38,3 +38,8 @@ shell(Cmd, Out) :-
 
 
 first_char(Str, C) :- sub_string(Str, 0, 1, _, C).
+
+gc(true) :- garbage_collect,
+            garbage_collect_atoms,
+            trim_stacks,
+            memlog.

--- a/src/skills.pl
+++ b/src/skills.pl
@@ -42,3 +42,15 @@ first_char(Str, C) :- sub_string(Str, 0, 1, _, C).
 gc(true) :- garbage_collect,
             garbage_collect_atoms,
             trim_stacks.
+
+read_file_tail(Path, MaxChars, Text) :-
+    setup_call_cleanup(
+        open(Path, read, In, [type(text), encoding(utf8)]),
+        (
+            seek(In, 0, eof, End),
+            Start is max(0, End - MaxChars),
+            seek(In, Start, bof, _),
+            read_string(In, _, Text)
+        ),
+        close(In)
+    ).


### PR DESCRIPTION
## Description
Fixes memory leak / avoids late gc by Swi-Prolog.

## How Has This Been Tested?
Monitored process RAM via
`watch -n 2 'ps -p $(pgrep -n swipl) -o rss= | awk "{printf \"%.1f MB\n\", \$1/1024}"'`
and also further confirmed by adding into the gc function a call to memlog to confirm atoms count does not increase:
```
memlog :-
    statistics(atoms, Atoms),
    statistics(global_stack, Global),
    statistics(local_stack, Local),
    statistics(trail, Trail),
    statistics(cputime, CPU),
    statistics(process_cputime, PCPU),
    setup_call_cleanup(
        open('/tmp/swipl_memlog.tsv', append, S),
        format(S,
               'atoms=~w\tglobal=~w\tlocal=~w\ttrail=~w\tcpu=~w\tpcpu=~w~n',
               [Atoms, Global, Local, Trail, CPU, PCPU]),
        close(S)
    ).
```

## Checklist
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
