### PR TITLE
Communication channel for automatic testing

### DIFF
--- a/Autotests/mock/comm.py
+++ b/Autotests/mock/comm.py
@@ -31,7 +31,7 @@ class CommMockClient:
 
     def on_message(self, args):
         text = args['text']
-        print(f'[CommMockClient] Message recieved: "{text}""')
+        print(f'[CommMockClient] Message received: "{text}"')
         try:
             self._queue.put(text, block=False)
         except Exception as e:
@@ -70,7 +70,7 @@ class CommMockServer:
 
     def on_message(self, args):
         text = args['text']
-        print(f'[CommMockServer] Message recieved: "{text}""')
+        print(f'[CommMockServer] Message received: "{text}"')
         try:
             self._queue.put(text, block=False)
         except Exception as e:

--- a/Autotests/mock/comm.py
+++ b/Autotests/mock/comm.py
@@ -2,17 +2,17 @@
 # the container's loop.metta), and as a plain directory (host-side
 # pytest collecting mock/ without __init__.py).
 try:
-    from .rpc import Rpc, IPCClient, IPCServer, HOST_DEFAULT
+    from .rpc import Rpc, IPCClient, IPCServer
 except ImportError:
-    from rpc import Rpc, IPCClient, IPCServer, HOST_DEFAULT
+    from rpc import Rpc, IPCClient, IPCServer
 from contextlib import contextmanager
 import queue
 
-COMM_MOCK_ADDRESS = (HOST_DEFAULT, 9766)
+COMM_MOCK_PORT = 9766
 
 class CommMockClient:
 
-    def __init__(self, address=COMM_MOCK_ADDRESS):
+    def __init__(self, address):
         self._queue = queue.Queue()
         self._rpc = Rpc(IPCClient(address))
         self._rpc.on_request('message', lambda args: self.on_message(args))
@@ -51,7 +51,7 @@ class CommMockClient:
 
 class CommMockServer:
 
-    def __init__(self, address=COMM_MOCK_ADDRESS):
+    def __init__(self, address):
         self._queue = queue.Queue()
         self._received = []
         self._rpc = Rpc(IPCServer(address))

--- a/Autotests/mock/comm.py
+++ b/Autotests/mock/comm.py
@@ -1,0 +1,105 @@
+# Support both layouts: imported as a package (Autotests.mock.llm in
+# the container's loop.metta), and as a plain directory (host-side
+# pytest collecting mock/ without __init__.py).
+try:
+    from .rpc import Rpc, IPCClient, IPCServer, HOST_DEFAULT
+except ImportError:
+    from rpc import Rpc, IPCClient, IPCServer, HOST_DEFAULT
+from contextlib import contextmanager
+import queue
+
+COMM_MOCK_ADDRESS = (HOST_DEFAULT, 9766)
+
+class CommMockClient:
+
+    def __init__(self, address=COMM_MOCK_ADDRESS):
+        self._queue = queue.Queue()
+        self._rpc = Rpc(IPCClient(address))
+        self._rpc.on_request('message', lambda args: self.on_message(args))
+        self._rpc.on_request('ping', lambda args: self.on_ping(args))
+        self._rpc.start()
+
+    def stop(self, timeout=None):
+        self._rpc.stop(timeout)
+
+    def send_message(self, text, timeout=10):
+        result = self._rpc.request('message', { 'text': text })
+        if result.get(timeout) != True:
+            print(f'[CommMockClient] Cannot set answer to the mock, error: {result.error()}')
+            return False
+        return True
+
+    def on_message(self, args):
+        text = args['text']
+        print(f'[CommMockClient] Message recieved: "{text}""')
+        try:
+            self._queue.put(text, block=False)
+        except Exception as e:
+            print(f'[CommMockClient] Could not add received message into the queue: {e}')
+            return False
+        return True
+
+    def getLastMessage(self):
+        try:
+            return self._queue.get(block=False)
+        except queue.Empty as e:
+            return ""
+
+    def on_ping(self, args):
+        print(f'[CommMockClient] Mock ping request processed')
+        return True
+
+class CommMockServer:
+
+    def __init__(self, address=COMM_MOCK_ADDRESS):
+        self._queue = queue.Queue()
+        self._received = []
+        self._rpc = Rpc(IPCServer(address))
+        self._rpc.on_request('message', lambda args: self.on_message(args))
+        self._rpc.start()
+
+    def stop(self, timeout=None):
+        self._rpc.stop(timeout)
+
+    def send_message(self, text, timeout=10):
+        result = self._rpc.request('message', { 'text': text })
+        if result.get(timeout) != True:
+            print(f'[CommMockServer] Cannot set answer to the mock, error: {result.error()}')
+            return False
+        return True
+
+    def on_message(self, args):
+        text = args['text']
+        print(f'[CommMockServer] Message recieved: "{text}""')
+        try:
+            self._queue.put(text, block=False)
+        except Exception as e:
+            print(f'[CommMockServer] Could not add received message into the queue: {e}')
+            return False
+        return True
+
+    def getLastMessage(self):
+        try:
+            return self._queue.get(block=False)
+        except queue.Empty as e:
+            return ""
+
+    def ping(self, timeout=None):
+        print(f'[CommMockServer] Ping agent')
+        result = self._rpc.request('ping', {})
+        if result.get(timeout) != True:
+            print(f'[CommMockServer] Did not get answer on ping in {timeout} seconds')
+            return False
+        else:
+            return True
+
+@contextmanager
+def comm_mock_server(*args, **kwargs) -> CommMockServer:
+    timeout = kwargs.pop("timeout", 30)
+    server = CommMockServer(*args, **kwargs)
+    if not server.ping(timeout):
+        raise RuntimeError(f"Client didn't answered in {timeout} seconds")
+    try:
+        yield server
+    finally:
+        server.stop(5)

--- a/Autotests/mock/conftest.py
+++ b/Autotests/mock/conftest.py
@@ -12,13 +12,12 @@ same controller.
 """
 import pytest
 
-from llm import LlmMockController
-from rpc import PORT_DEFAULT
+from llm import LlmMockController, LLM_MOCK_PORT
 
 
 @pytest.fixture(scope="session")
 def llm():
-    controller = LlmMockController(("0.0.0.0", PORT_DEFAULT))
+    controller = LlmMockController(("0.0.0.0", LLM_MOCK_PORT))
     try:
         yield controller
     finally:

--- a/Autotests/mock/conftest.py
+++ b/Autotests/mock/conftest.py
@@ -13,6 +13,7 @@ same controller.
 import pytest
 
 from llm import LlmMockController, LLM_MOCK_PORT
+from comm import CommMockServer, COMM_MOCK_PORT
 
 
 @pytest.fixture(scope="session")
@@ -22,3 +23,11 @@ def llm():
         yield controller
     finally:
         controller.stop(5)
+
+@pytest.fixture(scope="session")
+def comm():
+    server = CommMockServer(("0.0.0.0", COMM_MOCK_PORT))
+    try:
+        yield server
+    finally:
+        server.stop(5)

--- a/Autotests/mock/llm.py
+++ b/Autotests/mock/llm.py
@@ -2,17 +2,17 @@
 # the container's loop.metta), and as a plain directory (host-side
 # pytest collecting mock/ without __init__.py).
 try:
-    from .rpc import Rpc, IPCClient, IPCServer, HOST_DEFAULT
+    from .rpc import Rpc, IPCClient, IPCServer
 except ImportError:
-    from rpc import Rpc, IPCClient, IPCServer, HOST_DEFAULT
+    from rpc import Rpc, IPCClient, IPCServer
 from contextlib import contextmanager
 import threading
 
-LLM_MOCK_ADDRESS = (HOST_DEFAULT, 9765)
+LLM_MOCK_PORT = 9765
 
 class LlmMockAgent:
 
-    def __init__(self, address=LLM_MOCK_ADDRESS):
+    def __init__(self, address):
         self._lock = threading.Lock()
         self._answers = {}
         self._rpc = Rpc(IPCClient(address))
@@ -77,7 +77,7 @@ class LlmMockAgent:
 
 class LlmMockController:
 
-    def __init__(self, address=LLM_MOCK_ADDRESS):
+    def __init__(self, address):
         self._rpc = Rpc(IPCServer(address))
         self._rpc.start()
 

--- a/Autotests/mock/llm.py
+++ b/Autotests/mock/llm.py
@@ -2,15 +2,17 @@
 # the container's loop.metta), and as a plain directory (host-side
 # pytest collecting mock/ without __init__.py).
 try:
-    from .rpc import Rpc, IPCClient, IPCServer, HOST_DEFAULT, PORT_DEFAULT
+    from .rpc import Rpc, IPCClient, IPCServer, HOST_DEFAULT
 except ImportError:
-    from rpc import Rpc, IPCClient, IPCServer, HOST_DEFAULT, PORT_DEFAULT
+    from rpc import Rpc, IPCClient, IPCServer, HOST_DEFAULT
 from contextlib import contextmanager
 import threading
 
+LLM_MOCK_ADDRESS = (HOST_DEFAULT, 9765)
+
 class LlmMockAgent:
 
-    def __init__(self, address=(HOST_DEFAULT, PORT_DEFAULT)):
+    def __init__(self, address=LLM_MOCK_ADDRESS):
         self._lock = threading.Lock()
         self._answers = {}
         self._rpc = Rpc(IPCClient(address))
@@ -75,7 +77,7 @@ class LlmMockAgent:
 
 class LlmMockController:
 
-    def __init__(self, address=(HOST_DEFAULT, PORT_DEFAULT)):
+    def __init__(self, address=LLM_MOCK_ADDRESS):
         self._rpc = Rpc(IPCServer(address))
         self._rpc.start()
 

--- a/Autotests/mock/llm.py
+++ b/Autotests/mock/llm.py
@@ -33,12 +33,15 @@ class LlmMockAgent:
         except SyntaxError:
             return ""
 
+        answer = self._answers.get(body)
+        if answer:
+            return answer
+
         # IRC may deliver multiple PRIVMSGs in one agent iteration; the
         # agent concatenates them with " | " between speakers. Split
         # and look up each fragment individually so a registered answer
         # is not missed when several messages arrive together.
         fragments = body.split(" | ")
-        answer = None
         for fragment in fragments:
             if ": " not in fragment:
                 continue

--- a/Autotests/mock/rpc.py
+++ b/Autotests/mock/rpc.py
@@ -4,8 +4,7 @@ import select
 import socket
 import json
 
-HOST_DEFAULT = "localhost"
-PORT_DEFAULT = 9765
+LOCALHOST = "localhost"
 
 class Shared:
 
@@ -318,7 +317,7 @@ class ConnectionTransport:
 
 class IPCServer:
 
-    def __init__(self, address=(HOST_DEFAULT, PORT_DEFAULT)):
+    def __init__(self, address):
         self._server = socket.create_server(address)
         self._server.setblocking(False)
         self._address = address
@@ -349,7 +348,7 @@ class IPCServer:
 
 class IPCClient():
 
-    def __init__(self, address=(HOST_DEFAULT, PORT_DEFAULT)):
+    def __init__(self, address):
         self._address = address
         self._transport = ConnectionTransport(lambda: self._connect())
 

--- a/Autotests/mock/test_comm.py
+++ b/Autotests/mock/test_comm.py
@@ -1,9 +1,9 @@
 import pytest
 
 from comm import *
-from rpc import HOST_DEFAULT
+from rpc import LOCALHOST
 
-TEST_ADDRESS = (HOST_DEFAULT, 9767)
+TEST_ADDRESS = (LOCALHOST, 9767)
 
 class TestCommMock:
 

--- a/Autotests/mock/test_comm.py
+++ b/Autotests/mock/test_comm.py
@@ -1,0 +1,70 @@
+import pytest
+
+from comm import *
+from rpc import HOST_DEFAULT
+
+TEST_ADDRESS = (HOST_DEFAULT, 9767)
+
+class TestCommMock:
+
+    def setup_class(cls):
+        import logging
+        import threading
+
+        def thread_id_filter(record):
+            record.thread_id = threading.get_native_id()
+            return record
+
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter('[%(levelname)s] [%(thread_id)d]: %(message)s'))
+        handler.addFilter(thread_id_filter)
+        logging.getLogger().handlers.clear()
+        logging.getLogger().addHandler(handler)
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    @pytest.fixture
+    def client(self):
+        client = CommMockClient(TEST_ADDRESS)
+        yield client
+        client.stop(5)
+
+    @pytest.fixture
+    def server(self):
+        server = CommMockServer(TEST_ADDRESS)
+        yield server
+        server.stop(5)
+
+    def test_response(self, client, server):
+        assert server.send_message("hello")
+        assert client.getLastMessage() == "hello"
+        assert client.send_message("world")
+        assert server.getLastMessage() == "world"
+
+    def test_test_restart(self, client):
+        server = CommMockServer(TEST_ADDRESS)
+        assert server.send_message("hello world")
+        assert client.getLastMessage() == "hello world"
+        server.stop(5)
+        server = CommMockServer(TEST_ADDRESS)
+        assert server.send_message("hello earth")
+        assert client.getLastMessage() == "hello earth"
+        server.stop(5)
+
+    def test_two_messages(self, client, server):
+        assert server.send_message("hello")
+        assert server.send_message("world")
+        assert client.getLastMessage() == "hello"
+        assert client.getLastMessage() == "world"
+
+    def test_context_manager(self, client):
+        with comm_mock_server(address=TEST_ADDRESS) as server:
+            assert server.send_message("hello world")
+            assert client.getLastMessage() == "hello world"
+
+    def test_context_manager_timeout(self, client):
+        address = (TEST_ADDRESS[0], TEST_ADDRESS[1] + 1)
+        try:
+            with comm_mock_server(address=address, timeout=2) as server:
+                assert False
+        except RuntimeError as e:
+            assert e.args == ("Client didn't answered in 2 seconds",)

--- a/Autotests/mock/test_create_file_mock.py
+++ b/Autotests/mock/test_create_file_mock.py
@@ -24,7 +24,7 @@ def test_hello_file(llm, comm):
 
         start_ts = int(time.time()) - 1
 
-        c.step("connect to IRC and send prompt")
+        c.step("send prompt via comm channel")
         prompt = make_prompt(
             c.run_id,
             f"Please overwrite {TARGET_FILE} so it contains exactly the single "
@@ -33,8 +33,8 @@ def test_hello_file(llm, comm):
         llm.set_answer(prompt, f'(shell "mkdir -p /tmp/testcat") (write-file "/tmp/testcat/hello.txt" "Hello")')
 
         if not comm.send_message(prompt):
-            c.fail("irc", "could not deliver prompt within 60s")
-        c.ok("irc", f"prompt delivered, run-id={c.run_id}")
+            c.fail("comm", "could not deliver prompt within 60s")
+        c.ok("comm", f"prompt delivered, run-id={c.run_id}")
 
         c.step(f"wait for {TARGET_FILE} (timeout {WAIT}s)")
         file_mtime = wait_for_file(TARGET_FILE, start_ts, timeout=WAIT)

--- a/Autotests/mock/test_create_file_mock.py
+++ b/Autotests/mock/test_create_file_mock.py
@@ -16,7 +16,7 @@ TARGET_FILE = "/tmp/testcat/hello.txt"
 WAIT = 30
 
 
-def test_hello_file(llm):
+def test_hello_file(llm, comm):
     with Checker("create hello.txt", cleanup_dirs=[TARGET_DIR]) as c:
         print(f"\n=== OmegaClaw smoke test (run-id {c.run_id}) ===", flush=True)
 
@@ -32,7 +32,7 @@ def test_hello_file(llm):
         )
         llm.set_answer(prompt, f'(shell "mkdir -p /tmp/testcat") (write-file "/tmp/testcat/hello.txt" "Hello")')
 
-        if not send_prompt(prompt):
+        if not comm.send_message(prompt):
             c.fail("irc", "could not deliver prompt within 60s")
         c.ok("irc", f"prompt delivered, run-id={c.run_id}")
 

--- a/Autotests/mock/test_llm.py
+++ b/Autotests/mock/test_llm.py
@@ -1,9 +1,9 @@
 import pytest
 
 from llm import *
-from rpc import HOST_DEFAULT
+from rpc import LOCALHOST
 
-TEST_ADDRESS = (HOST_DEFAULT, 9767)
+TEST_ADDRESS = (LOCALHOST, 9767)
 
 class TestLlmMock:
 

--- a/Autotests/mock/test_rpc.py
+++ b/Autotests/mock/test_rpc.py
@@ -2,7 +2,7 @@ import pytest
 
 from rpc import *
 
-TEST_ADDRESS = (HOST_DEFAULT, 9767)
+TEST_ADDRESS = (LOCALHOST, 9767)
 
 class TestClass:
 

--- a/Autotests/mock_memory/conftest.py
+++ b/Autotests/mock_memory/conftest.py
@@ -16,13 +16,11 @@ _MOCK_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "mock
 if _MOCK_DIR not in sys.path:
     sys.path.insert(0, _MOCK_DIR)
 
-from llm import LlmMockController  # noqa: E402
-from rpc import PORT_DEFAULT  # noqa: E402
-
+from llm import LlmMockController, LLM_MOCK_PORT  # noqa: E402
 
 @pytest.fixture(scope="session")
 def llm():
-    controller = LlmMockController(("0.0.0.0", PORT_DEFAULT))
+    controller = LlmMockController(("0.0.0.0", LLM_MOCK_PORT))
     try:
         yield controller
     finally:

--- a/channels/mock.py
+++ b/channels/mock.py
@@ -1,3 +1,4 @@
+import os
 import Autotests.mock.comm as comm
 
 _client = None
@@ -13,4 +14,4 @@ def start_mock():
 
 def send_message(text):
     global _client
-    _client.send_message(text)
+    return _client.send_message(text)

--- a/channels/mock.py
+++ b/channels/mock.py
@@ -1,0 +1,16 @@
+import Autotests.mock.comm as comm
+
+_client = None
+
+def getLastMessage():
+    global _client
+    return _client.getLastMessage()
+
+def start_mock():
+    global _client
+    server_ip = os.environ.get("TEST_SERVER_IP")
+    _client = comm.CommMockClient((server_ip, comm.COMM_MOCK_PORT))
+
+def send_message(text):
+    global _client
+    _client.send_message(text)

--- a/lib_llm_ext.py
+++ b/lib_llm_ext.py
@@ -120,9 +120,8 @@ class TestProvider(AbstractAIProvider):
 
     def _llm_mock(self):
         if not self._mock:
-            import Autotests.mock.rpc as rpc
-            from Autotests.mock.llm import LlmMockAgent
-            self._mock = LlmMockAgent((self._controller_ip, rpc.PORT_DEFAULT))
+            from Autotests.mock.llm import LlmMockAgent, LLM_MOCK_PORT
+            self._mock = LlmMockAgent((self._controller_ip, LLM_MOCK_PORT))
         return self._mock
 
     @property

--- a/lib_llm_ext.py
+++ b/lib_llm_ext.py
@@ -116,7 +116,7 @@ class TestProvider(AbstractAIProvider):
     def __init__(self):
         super().__init__("Test")
         self._mock = None
-        self._controller_ip = os.environ.get("TEST_API_KEY")
+        self._controller_ip = os.environ.get("TEST_SERVER_IP")
 
     def _llm_mock(self):
         if not self._mock:

--- a/scripts/omegaclaw
+++ b/scripts/omegaclaw
@@ -208,7 +208,7 @@ def _choose_provider():
         elif c in ["1", "2", "3", "4", "5", "6"]:
             provider_id = int(c) - 1
         else:
-            print("Please enter 1-4 or 'q'", file=sys.stderr)
+            print("Please enter 1-6 or 'q'", file=sys.stderr)
             continue
 
         providers = [
@@ -402,7 +402,7 @@ help() {
     echo -e "\t              Pass API token via environment variable."
     echo -e "\t-u <LLM API url> set LLM API URL for the local models (Ollama-local)"
     echo -e "\t-c <IRC channel> set IRC channel"
-    echo -e "\t-t <channel type> set communication channel type: irc|telegram|slack"
+    echo -e "\t-t <channel type> set communication channel type: irc|telegram|slack|mattermost|test"
     echo -e "\t-d <Docker image> set Docker image name (default omegaclaw:latest)"
 }
 
@@ -463,7 +463,7 @@ options() {
             ;;
         Test)
             embeddingprovider="Local"
-            api_token_var="TEST_API_KEY"
+            api_token_var="TEST_SERVER_IP"
             ;;
         *) help
            return 1
@@ -505,6 +505,8 @@ start() {
       docker_cmd+=("SL_BOT_TOKEN=${SL_BOT_TOKEN}")
       docker_cmd+=("SL_CHANNEL_ID=${SL_CHANNEL_ID}")
       docker_cmd+=("SL_POLL_INTERVAL=${SL_POLL_INTERVAL}")
+    elif [ "${commchannel}" = "test" ]; then
+      docker_cmd+=("TEST_SERVER_IP=${TEST_SERVER_IP}")
     else
       echo "Unsupported commchannel: ${commchannel}" >&2
       return 1

--- a/src/channels.metta
+++ b/src/channels.metta
@@ -34,10 +34,12 @@
                              (configure SL_CHANNEL_ID "")
                              (configure SL_POLL_INTERVAL 60)
                              (py-call (slack.start_slack (SL_BOT_TOKEN) (SL_CHANNEL_ID) (SL_POLL_INTERVAL))))
-                      (progn (configure MM_URL "https://chat.singularitynet.io")
-                             (configure MM_CHANNEL_ID "8fjrmabjx7gupy7e5kjznpt5qh")
-                             (configure MM_BOT_TOKEN "")
-                             (py-call (mattermost.start_mattermost (MM_URL) (MM_CHANNEL_ID) (MM_BOT_TOKEN)))))))))
+                      (if (== (commchannel) mattermost)
+                          (progn (configure MM_URL "https://chat.singularitynet.io")
+                                 (configure MM_CHANNEL_ID "8fjrmabjx7gupy7e5kjznpt5qh")
+                                 (configure MM_BOT_TOKEN "")
+                                 (py-call (mattermost.start_mattermost (MM_URL) (MM_CHANNEL_ID) (MM_BOT_TOKEN))))
+                          (py-call (mock.start_mock))))))))
 
 ;Receive the latest user message considering all communication channels:
 (= (receive)
@@ -47,7 +49,9 @@
            (py-call (telegram.getLastMessage))
            (if (== (commchannel) slack)
                (py-call (slack.getLastMessage))
-               (py-call (mattermost.getLastMessage))))))
+               (if (== (commchannel) mattermost)
+                   (py-call (mattermost.getLastMessage))
+                   (py-call (mock.getLastMessage)))))))
 
 ;Send a message to all communication channels:
 !(change-state! &lastsend "")
@@ -61,7 +65,9 @@
                            (let $temp (cut) (py-call (telegram.send_message $safemsg)))
                            (if (== (commchannel) slack)
                                (let $temp (cut) (py-call (slack.send_message $safemsg)))
-                               (let $temp (cut) (py-call (mattermost.send_message $safemsg)))))))) _))
+                               (if (== (commchannel) slack)
+                                   (let $temp (cut) (py-call (mattermost.send_message $safemsg)))
+                                   (let $temp (cut) (py-call (mock.send_message $safemsg))))))))) _))
 
 ;Search the internet for some information:
 (= (search $msg)

--- a/src/channels.metta
+++ b/src/channels.metta
@@ -65,7 +65,7 @@
                            (let $temp (cut) (py-call (telegram.send_message $safemsg)))
                            (if (== (commchannel) slack)
                                (let $temp (cut) (py-call (slack.send_message $safemsg)))
-                               (if (== (commchannel) slack)
+                               (if (== (commchannel) mattermost)
                                    (let $temp (cut) (py-call (mattermost.send_message $safemsg)))
                                    (let $temp (cut) (py-call (mock.send_message $safemsg))))))))) _))
 


### PR DESCRIPTION
## Description
Adding local communication channel for writing automatic tests in controlled environment:
- [`comm.py`](https://github.com/asi-alliance/OmegaClaw-Core/pull/134/changes#diff-4d92c40d3e9c8e596468d15bac387122dc770968d2565396b7ef8001331c87b6) contains test communication channel logic.
- [`mock.py`](https://github.com/asi-alliance/OmegaClaw-Core/pull/134/changes#diff-7d45278b254516db712f1bc03aa84678ff424f0b151cd3a09015a3c7835e19c3) adds new communication channel based on `comm.py`.
- `TEST_API_KEY` variable is renamed to `TEST_SERVER_IP`.
- `HOST_DEFAULT` is renamed to `LOCALHOST`.
- `PORT_DEFAULT` is removed as there is no common default port.
- add condition to check if received chat content can be matched with predefined LLM mock answers, because previous method implementation was IRC specific
- [test_create_file_mock.py](https://github.com/asi-alliance/OmegaClaw-Core/pull/134/changes#diff-a65a5bf37a355d0d1b49b505fbc81fc8095b256346038ef60a23e128ddbe89f4) is an example of the test which uses this communication channel

## How Has This Been Tested?
```
export TEST_SERVER_IP=<local ip>
pytest ./Autotests/mock/test_comm.py

podman build -t omegaclaw:latest .
./scripts/omegaclaw start -p Test -t test -d localhost/omegaclaw:latest
pytest ./Autotests/mock/test_create_file_mock.py
```

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
