### PR TITLE
Fix API token check on macOS bash

### DIFF
--- a/scripts/omegaclaw
+++ b/scripts/omegaclaw
@@ -469,7 +469,7 @@ options() {
            return 1
            ;;
     esac
-    if [[ -v ${api_token_var} ]]; then
+    if [[ -n "${!api_token_var:-}" ]]; then
         api_token="${!api_token_var}"
     fi
 }


### PR DESCRIPTION
## Description
Per Kevin Machiels suggested fix to let the startup script works for mac:
https://chat.singularitynet.io/chat/pl/7q1had1x13yg8qwjtic3887hia

ChatGPT was used to make the fix and build the PR, so please review carefully

## How Has This Been Tested?
Successfully started Mike A.'s latest docker on my mac M1
curl -fsSL https://raw.githubusercontent.com/asi-alliance/OmegaClaw-Core/refs/heads/main/scripts/omegaclaw | bash -s -- singularitynet/omegaclaw:v0.1.12

## Checklist
- [ ] The code generated by LLM is reviewed by the PR creator
- [ ] Self-review completed
- [ ] Test scenarios above are passed with the version of the code from PR
