### PR TITLE
Update sonar.yml

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - development
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -12,5 +11,10 @@ on:
 
 jobs:
   sonar:
-    uses: asi-alliance/security-workflows/.github/workflows/sonar.yml@main
-    secrets: inherit
+    uses: singnet/security-workflows/.github/workflows/sonar.yml@master
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      OPENSEARCH_URL: ${{ secrets.OPENSEARCH_URL }}
+      OPENSEARCH_USER: ${{ secrets.OPENSEARCH_USER }}
+      OPENSEARCH_PASS: ${{ secrets.OPENSEARCH_PASS }}


### PR DESCRIPTION
Because this is a public repository, it was necessary to correctly reference the reusable workflow. Previously, it was a reference to a private workflow, which is why we received the error: 

```
[Invalid workflow file: .github/workflows/sonar.yml#L15](https://github.com/asi-alliance/OmegaClaw-Core/actions/runs/26760254176/workflow)
error parsing called workflow
".github/workflows/sonar.yml"
-> "asi-alliance/security-workflows/.github/workflows/sonar.yml@main"
: workflow was not found. See https://docs.github.com/actions/learn-github-actions/reusing-workflows#access-to-reusable-workflows for more information.
```
To solve this problem, it was necessary to change sonar.yml, namely, change it to uses: singnet/security-workflows/.github/workflows/sonar.yml@master

