### PR TITLE
[OMEGA-124] Merge kb load to embeddings facility to core

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,6 @@ User-facing MeTTa skills the agent invokes. Each page follows the template **Sig
 ### Internals
 
 - [reference-internals-loop.md](./reference-internals-loop.md) — `src/loop.metta` lifecycle and turn structure
-- [reference-internals-memory-store.md](./reference-internals-memory-store.md) — The three-tier memory architecture
+- [reference-internals-memory-store.md](./reference-internals-memory-store.md) — The three-tier memory architecture, including `knowledge-priors` markdown seeding into ChromaDB
 - [reference-internals-skill-dispatch.md](./reference-internals-skill-dispatch.md) — How `(skill args)` calls resolve
 - [reference-internals-extension-points.md](./reference-internals-extension-points.md) — Where to hook in new skills, tools, channels, LLMs, engines

--- a/docs/reference-internals-memory-store.md
+++ b/docs/reference-internals-memory-store.md
@@ -76,6 +76,12 @@ Returns the top-`k` items by embedding similarity. **Known issue:** query can mi
 
 Reads lines around `$time` from `memory/history.metta` — the **episodic trace**, not the embedding store. See §4 below.
 
+### Startup knowledge priors
+
+At startup, OmegaClaw also checks for a folder named `knowledge-priors` in the OmegaClaw-Core project root. If that folder exists and contains Markdown files (`*.md`), their contents are chunked, embedded, and loaded into the ChromaDB `memories` collection for semantic lookup.
+
+The loader skips the step when the folder is missing, or when the folder exists but has no `.md` files. Indexed chunks are tagged with `time = knowledge_prior` instead of an actual time.
+
 ### Use it for
 - Facts that must persist across sessions.
 - Verified, grounded premises (attach provenance in the atom body).

--- a/lib_omegaclaw.metta
+++ b/lib_omegaclaw.metta
@@ -18,5 +18,6 @@
 !(import! &self (library OmegaClaw-Core ./src/memory))
 !(import! &self (library OmegaClaw-Core ./src/context))
 !(import! &self (library OmegaClaw-Core ./src/loop))
+!(import! &self (library OmegaClaw-Core ./src/rag.py))
 !(git-import! "https://github.com/patham9/petta_lib_chromadb.git")
 !(import! &self (library petta_lib_chromadb lib_chromadb))

--- a/src/loop.metta
+++ b/src/loop.metta
@@ -22,6 +22,12 @@
           (change-state! &lastresults "")
           (change-state! &loops (maxNewInputLoops))))
 
+(= (initKnowledge)
+   (progn (println! "Initializing knowledge base")
+          (if (== (embeddingprovider) OpenAI)
+              (println! (py-call (rag.init_knowledge "OpenAI")))
+              (println! (py-call (rag.init_knowledge "Local"))))))
+
 (= (getContext)
    (string-safe (py-str ("PROMPT: " (getPrompt) " SKILLS: " (getSkills)
                          " OUTPUT_FORMAT: Up to 5 lines, do not wrap quotes around args, do not use variables:" (newline)
@@ -42,6 +48,7 @@
 (= (omegaclaw $k)
    (progn (if (== $k 1) (progn (initLoop)
                                (initMemory)
+                               (initKnowledge)
                                (initChannels))
                         (change-state! &loops (- (get-state &loops) 1)))
           (let $prompt (getContext)

--- a/src/rag.py
+++ b/src/rag.py
@@ -1,0 +1,332 @@
+import os
+import re
+import glob
+import hashlib
+import logging
+import traceback
+
+import chromadb
+import openai
+from   lib_llm_ext import initLocalEmbedding, useLocalEmbedding
+
+logger = logging.getLogger(__name__)
+
+# --- Constants -----------------------------------------------------------
+
+EMBEDDING_MODEL = "text-embedding-3-large"
+COLLECTION_NAME = "memories"
+TOP_K = 5
+MIN_CHUNK_CHARS = 100
+MAX_CHUNK_CHARS = 6000
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+DB_PATH = os.environ.get(
+    "CHROMA_DB_PATH",
+    "/PeTTa/chroma_db" if os.path.isdir("/PeTTa/chroma_db") else
+    os.path.join(_PROJECT_ROOT, "..", "..","chroma_db")
+)
+
+# --- Lazy ChromaDB client ------------------------------------------------
+
+_client = None
+_collection = None
+
+
+def _get_collection():
+    global _client, _collection
+    if _collection is None:
+        os.makedirs(DB_PATH, exist_ok=True)
+        _client = chromadb.PersistentClient(path=DB_PATH)
+        _collection = _client.get_or_create_collection(
+            name=COLLECTION_NAME,
+            embedding_function=None,
+        )
+    return _collection
+
+
+# --- Helpers -------------------------------------------------------------
+
+HEADING_RE = re.compile(r"^(#{1,4})\s+(.+)$", re.MULTILINE)
+
+
+def _resolve_knowledge_dir():
+    return os.path.join(_PROJECT_ROOT, "knowledge-priors")
+
+
+def _file_hash(filepath):
+    return hashlib.md5(open(filepath, "rb").read()).hexdigest()
+
+
+def _decode_metta(s):
+    return (s.replace("_quote_", '"')
+             .replace("_newline_", "\n")
+             .replace("_apostrophe_", "'"))
+
+
+# --- Chunking ------------------------------------------------------------
+
+def _chunk_markdown(text, filename):
+    """Heading-aware markdown chunking with breadcrumb tracking."""
+    matches = list(HEADING_RE.finditer(text))
+    if not matches:
+        return [{"text": text.strip(), "breadcrumb": filename}]
+
+    sections = []
+    stack = {}  # level -> heading text
+
+    for i, m in enumerate(matches):
+        level = len(m.group(1))
+        heading = m.group(2).strip()
+
+        # Clear deeper headings from stack
+        for lvl in list(stack):
+            if lvl >= level:
+                del stack[lvl]
+        stack[level] = heading
+
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[start:end].strip()
+
+        breadcrumb = filename + " > " + " > ".join(
+            stack[k] for k in sorted(stack)
+        )
+        sections.append({"text": body, "breadcrumb": breadcrumb, "heading": heading})
+
+    # Skip Table of Contents section
+    sections = [s for s in sections if "table of contents" not in s["heading"].lower()]
+
+    # Merge small sections into next sibling
+    merged = []
+    carry = ""
+    carry_bc = ""
+    for s in sections:
+        combined = (carry + "\n\n" + s["text"]).strip() if carry else s["text"]
+        bc = carry_bc or s["breadcrumb"]
+        if len(combined) < MIN_CHUNK_CHARS and s is not sections[-1]:
+            carry = combined
+            carry_bc = bc
+        else:
+            merged.append({"text": combined, "breadcrumb": bc})
+            carry = ""
+            carry_bc = ""
+    if carry:
+        if merged:
+            merged[-1]["text"] += "\n\n" + carry
+        else:
+            merged.append({"text": carry, "breadcrumb": carry_bc})
+
+    # Split large sections on paragraph boundaries
+    final = []
+    for s in merged:
+        if len(s["text"]) <= MAX_CHUNK_CHARS:
+            final.append(s)
+            continue
+        paragraphs = s["text"].split("\n\n")
+        chunk_text = ""
+        for p in paragraphs:
+            if chunk_text and len(chunk_text) + len(p) > MAX_CHUNK_CHARS:
+                final.append({"text": chunk_text.strip(), "breadcrumb": s["breadcrumb"]})
+                chunk_text = p
+            else:
+                chunk_text = (chunk_text + "\n\n" + p).strip()
+        if chunk_text.strip():
+            final.append({"text": chunk_text.strip(), "breadcrumb": s["breadcrumb"]})
+
+    return final
+
+
+# --- Embedding -----------------------------------------------------------
+
+def openai_embed_batch(texts):
+    """Embed a list of texts via OpenAI. Returns list of float vectors."""
+    client = openai.OpenAI()
+    resp = client.embeddings.create(model=EMBEDDING_MODEL, input=texts)
+    return [item.embedding for item in resp.data]
+
+def local_embed_batch(texts):
+    """Embed a list of texts via lib_llm_ext local embeddings."""
+    if isinstance(texts, str):
+        texts = [texts]
+
+    if not texts:
+        return []
+
+    initLocalEmbedding()
+
+    return [
+        useLocalEmbedding(text)
+        for text in texts
+    ]
+
+# --- Hash sentinel docs --------------------------------------------------
+
+def _hash_id(filename):
+    return f"hash_{filename}"
+
+
+def _get_stored_hash(collection, filename):
+    try:
+        result = collection.get(ids=[_hash_id(filename)], include=["metadatas"])
+        if result["ids"]:
+            return result["metadatas"][0].get("hash")
+    except Exception:
+        pass
+    return None
+
+
+def _store_hash(collection, filename, hash_val, embedding_dim):
+    """Store a hash sentinel doc. Uses a zero-vector as dummy embedding."""
+    collection.upsert(
+        ids=[_hash_id(filename)],
+        embeddings=[[0.0] * embedding_dim],
+        documents=[f"hash sentinel for {filename}"],
+        metadatas=[{"type": "hash", "hash": hash_val, "source": filename}],
+    )
+
+
+# --- Init & Query --------------------------------------------------------
+
+_embedding_dim = None
+_last_query = None
+_last_result = None
+
+
+def init_knowledge(embedding_selection):
+    """Chunk, embed, and store knowledge files. Skips unchanged files."""
+    global _embedding_dim, _last_query, _last_result
+    _last_query = None
+    _last_result = None
+    print(f"Embedding type selected is {embedding_selection}")
+
+    try:
+        collection = _get_collection()
+        knowledge_dir = _resolve_knowledge_dir()
+
+        if not os.path.isdir(knowledge_dir):
+            return f"Knowledge dir not found: {knowledge_dir}, bypassing knowledge load..."
+
+        md_files = sorted(glob.glob(os.path.join(knowledge_dir, "*.md")))
+        if not md_files:
+            return "No markdown .md files found in directory knowledge-priors, bypassing knowledge load..."
+
+        unchanged = 0
+        reindexed = 0
+
+        for filepath in md_files:
+            filename = os.path.basename(filepath)
+            current_hash = _file_hash(filepath)
+            stored_hash = _get_stored_hash(collection, filename)
+
+            if stored_hash == current_hash:
+                print(f"  {filename}: unchanged (skipped)")
+                unchanged += 1
+                continue
+
+            # Delete old chunks for this file
+            try:
+                old = collection.get(where={"source": filename}, include=[])
+                if old["ids"]:
+                    collection.delete(ids=old["ids"])
+            except Exception:
+                pass
+
+            # Chunk and embed
+            text = open(filepath, "r", encoding="utf-8").read()
+            chunks = _chunk_markdown(text, filename)
+            if not chunks:
+                continue
+
+            texts = [c["text"] for c in chunks]
+            if embedding_selection == "Local":
+                embeddings = local_embed_batch(texts)
+            elif embedding_selection == "OpenAI":
+                embeddings = openai_embed_batch(texts)
+            else:
+                raise ValueError(
+                      f"Invalid embedding_selection={embedding_selection!r}. "
+                      "Expected 'Local' or 'OpenAI'.")
+                 
+            if not embeddings:
+                print(f"  {filename}: embedding failed, skipping")
+                continue
+
+            if _embedding_dim is None:
+                _embedding_dim = len(embeddings[0])
+
+            # Store chunks
+            ids = [f"{filename}_chunk_{i}" for i in range(len(chunks))]
+            metadatas = [
+                {
+                    "source": filename,
+                    "breadcrumb": c["breadcrumb"],
+                    "type": "chunk",
+                    "time": "knowledge_prior"
+                }
+                for c in chunks
+            ]
+            collection.upsert(
+                ids=ids,
+                embeddings=embeddings,
+                documents=texts,
+                metadatas=metadatas,
+            )
+
+            # Store hash sentinel
+            _store_hash(collection, filename, current_hash, _embedding_dim)
+
+            print(f"  {filename}: indexed {len(chunks)} chunks")
+            reindexed += 1
+
+        total = unchanged + reindexed
+        return f"Knowledge: {total} files ({unchanged} unchanged, {reindexed} re-indexed)"
+
+    except Exception as e:
+        traceback.print_exc()
+        return f"Knowledge init failed: {e}"
+
+
+def query_knowledge(query_str, k=TOP_K):
+    """Retrieve top-k relevant knowledge chunks for a query string."""
+    global _last_query, _last_result
+
+    if not query_str or query_str in ("", "(@ none)"):
+        return ""
+
+    if query_str == _last_query and _last_result is not None:
+        return _last_result
+
+    try:
+        collection = _get_collection()
+        if collection.count() == 0:
+            return ""
+
+        decoded = _decode_metta(query_str)
+        query_vec = _embed_batch([decoded])[0]
+
+        results = collection.query(
+            query_embeddings=[query_vec],
+            n_results=k,
+            where={"type": "chunk"},
+            include=["documents", "metadatas"],
+        )
+
+        docs = results.get("documents", [[]])[0]
+        metas = results.get("metadatas", [[]])[0]
+
+        parts = []
+        for doc, meta in zip(docs, metas):
+            bc = meta.get("breadcrumb", "")
+            text = doc[:2000] if len(doc) > 2000 else doc
+            parts.append(f"[{bc}] {text}")
+
+        result = "\n---\n".join(parts)
+
+        _last_query = query_str
+        _last_result = result
+        return result
+
+    except Exception as e:
+        logger.warning(f"Knowledge query failed: {e}")
+        return ""


### PR DESCRIPTION
## Description
Add functionality for chunked embeddings to be added to the chromadb memory database. The code has been copied from TG/Oma with some minor tweaks. If .md files are found in a top level dir called 'knowledge-priors' they are loaded.
Embeddings default to Local unless OpenAI is selected. Note: this PR is functionality only -- no knowledge priors are included now.

## How Has This Been Tested?
I did a regression test to see if nothing happens if there is no 'knowledge-priors'. I examined the loaded memory chunks using a python program looking directly at the chromadb memory. I queried on Slack and Max returned the correct information. Note: OpenAI llm calls were not returning anything although OpenAI embeddings work. I think it is the usual OpenAI problem.

## Checklist
- [ X] The code generated by LLM is reviewed by the PR creator
- [ X] Self-review completed
- [X ] Test scenarios above are passed with the version of the code from PR 
