### PR TITLE
[OMEGA-132] Freeze Python packages versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,13 +54,14 @@ RUN mkdir -p /PeTTa/repos \
 
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
     --index-url https://download.pytorch.org/whl/cpu \
-    torch \
+    torch==2.5.1 \
  && python3 -m pip install --no-cache-dir --break-system-packages \
-    chromadb \
-    janus-swi \
-    openai \
-    uagents \
-    sentence-transformers
+    chromadb==1.5.9 \
+    janus-swi==1.5.2 \
+    openai==2.38.0 \
+    uagents==0.25.1 \
+    transformers==5.8.0 \
+    sentence-transformers==5.5.1
 
 # Pre-download the sentence-transformers model so runtime does not need network access.
 RUN mkdir -p "${HF_HOME}" "${SENTENCE_TRANSFORMERS_HOME}" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-sentence-transformers
-chromadb
-janus-swi
-openai
-uagents
+torch==2.5.1
+chromadb==1.5.9
+janus-swi==1.5.2
+openai==2.38.0
+uagents==0.25.1
+transformers==5.8.0
+sentence-transformers==5.5.1


### PR DESCRIPTION
## Description
Freeze Python packages versions. Otherwize the latest version of the transformers breaks the build.
Failure example: https://github.com/asi-alliance/OmegaClaw-Core/actions/runs/26898398005/job/79347966333

## How Has This Been Tested?
Build Docker container and run it using IRC and ASICloud LLM provider.

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
