### PR TITLE
[OMEGA-139] Install libraries using requirements files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,16 +52,11 @@ RUN sh build.sh
 RUN mkdir -p /PeTTa/repos \
  && git clone --depth 1 --branch "${CHROMADB_REF}" "${CHROMADB_REPO}" /PeTTa/repos/petta_lib_chromadb
 
+COPY ./requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
     --index-url https://download.pytorch.org/whl/cpu \
     torch==2.5.1 \
- && python3 -m pip install --no-cache-dir --break-system-packages \
-    chromadb==1.5.9 \
-    janus-swi==1.5.2 \
-    openai==2.38.0 \
-    uagents==0.25.1 \
-    transformers==5.8.0 \
-    sentence-transformers==5.5.1
+ && python3 -m pip install --no-cache-dir --break-system-packages -r /tmp/requirements.txt
 
 # Pre-download the sentence-transformers model so runtime does not need network access.
 RUN mkdir -p "${HF_HOME}" "${SENTENCE_TRANSFORMERS_HOME}" \


### PR DESCRIPTION
## Description
`Dockerfile` and standalone installation uses different lists of dependencies. `Dockerfile` lists dependencies explicitly while standalone installation uses `requirements.txt` file. This PR uses `requirements.txt` in `Dockerfile` thus fixing the difference.

## How Has This Been Tested?
```
docker build -t omegaclaw:latest .
./scripts/omegaclaw omegaclaw:latest
```
Use IRC, Minimax and ask agent the simple question "What is the distance to the Sun?"

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
