### PR TITLE
[OMEGA-140] Web search smoke test in mandatory checks

### DIFF
--- a/Autotests/run_mandatory
+++ b/Autotests/run_mandatory
@@ -29,3 +29,4 @@ mock/test_technical_analysis_mock.py
 mock/test_transition_episodes_after_eviction_mock.py
 mock/test_transition_metta_to_remember_mock.py
 mock/test_transition_pin_to_remember_mock.py
+test_websearch_smoke.py

--- a/Autotests/test_websearch_smoke.py
+++ b/Autotests/test_websearch_smoke.py
@@ -1,0 +1,23 @@
+"""
+Smoke (OMEGA-140): the web search skill actually returns results.
+
+Runs the real `websearch.search_` inside the container against live
+DuckDuckGo (via ddgs), so it catches the OMEGA-138 failure mode where
+DuckDuckGo changed its response format and search silently returned an
+empty list.
+"""
+from helpers import dexec
+
+
+def test_websearch_returns_results():
+    code = (
+        "import os, sys;"
+        "sys.path.insert(0, os.path.join(os.environ['OMEGACLAW_DIR'], 'channels'));"
+        "import websearch;"
+        "print('COUNT', len(websearch.search_('test')))"
+    )
+    res = dexec("python3", "-c", code)
+    assert res.returncode == 0, f"search failed: {res.stderr!r}"
+    count = next((int(l.split()[1]) for l in res.stdout.splitlines()
+                  if l.startswith("COUNT")), 0)
+    assert count > 0, f"search_('test') returned {count}; out={res.stdout!r} err={res.stderr!r}"


### PR DESCRIPTION
## Description

Adds a web search smoke test to the mandatory checks. It runs the real `websearch.search_("test")` inside the container and asserts the result count is greater than zero. This catches the OMEGA-138 failure mode, where DuckDuckGo changed its response format and the search silently returned an empty list with no error.

## How Has This Been Tested?

Ran the test against two images:
- image with the ddgs-based search: `1 passed` (search returned 10 results).
- pre-fix image: `1 failed` — `search_('test') returned 0`.

Same test file in both runs, only the container image differed.

## Note

The test depends on the ddgs-based search (OMEGA-138). Until that fix is in `main`, the image it runs against returns empty and the test is red, so this should merge after OMEGA-138 is in `main`. It also hits live DuckDuckGo, so a registry/network outage can turn it red.
