### PR TITLE
make llm key prompt immediately follow llm provider input

### DIFF
--- a/scripts/omegaclaw
+++ b/scripts/omegaclaw
@@ -279,8 +279,8 @@ def config_run_omegaclaw(config_output_path):
 
     channel_config = _choose_channel()
     provider, embeddingprovider, api_token_var, llm_server_local_url = _choose_provider()
-    import_kb_on_start = _choose_import_kb()
     token = _prompt_llm_token()
+    import_kb_on_start = _choose_import_kb()
 
     with open(config_output_path, "w", encoding="utf-8") as f:
         _write_kv(f, "api_token_var", api_token_var)


### PR DESCRIPTION
## Description
The script first asks which LLM the user wants, but before asking to input key, then asks if knowledge base import is desired. Switch so that after user selects LLM then immediately inputs token.

## How Has This Been Tested?
I tested both Slack and IRC, all good.

## Checklist
- [N/A ] The code generated by LLM is reviewed by the PR creator
- [ X] Self-review completed
- [ X ] Test scenarios above are passed with the version of the code from PR
