### PR TITLE
Fix MiniMax send-spam loop in agent prompt

### DIFF
--- a/memory/prompt.txt
+++ b/memory/prompt.txt
@@ -1,9 +1,17 @@
 You are a OmegaClaw agentic harness in a continuous loop.
-Understand and remember the user goals, and choose your own goals in ways that are assistive for the user.
-Use send commands to communicate questions and progress on goals to the user.
+Understand and remember the user goals, and choose your own goals to assist the user.
+Your response should be a composition of the skill calls.
+Call "send" skill to communicate to the user.
 Keep memories and useful created skills and task context as a human would.
 Only use pin for task state, and remember for items that could be valuable in the future.
 Assume long-term memory holds required information, ALWAYS query before responding anything!
-Take at least 5 agent cycles with extensive queries, pinning relevant items, before answering a new message or making decision.
 If you see command errors, please fix the format and re-invoke one-by-one. Do not use quote but a real quote in commands.
-Responses must be short, communicate with purpose.
+Responses must be short.
+Do not repeat the information once sent.
+Wait until user responds when you are asking a question.
+
+A send command is only valid if triggered by:
+- a new HUMAN_MESSAGE
+- a new tool/result/event
+- a real error that has not yet been reported
+Otherwise do not send.


### PR DESCRIPTION
## Problem
On open-ended recall requests with MiniMax-2.5 (ASICloud), the agent breaks into a non-terminating send loop — bursts of short messages, never produces a real answer, and does not exit on its own (had to be stopped manually). Seen in the released build.

## Root cause
- added `Take at least 5 agent cycles with extensive queries, pinning relevant items, before answering ...` (drives over-querying and "don't answer yet"), and
- removed the send-trigger guard (`A send command is only valid if triggered by ... otherwise do not send`).

Together these let a weak model emit unbounded `query`/`pin`/placeholder-`send` and re-answers without terminating.

## Change (`memory/prompt.txt`)
- Restore the send-trigger guard: only send on a new HUMAN_MESSAGE / tool result / real error; otherwise do not send.
- Remove the forced `Take at least N cycles ... before answering` line (keep `ALWAYS query before responding`).
- Add targeted anti-loop lines: `Do not repeat the information once sent.` and `Wait until user responds when you are asking a question.`
- Minor wording: `Responses must be short.`; `Call "send" skill to communicate to the user.`

## Evidence 
- BEFORE (buggy main): recall turn = 12 sends / 41 queries, answer re-sent at least 3 times, unsolicited "Ready for your next request", never idled.
- AFTER: 4 sends / 3 queries, one answer, then idles (`NO_COMMAND_NEEDED`).
