### PR TITLE
[OMEGA-338] Add lib_directive: dependency-ordered task orchestration

### DIFF
--- a/docs/deontic/README.md
+++ b/docs/deontic/README.md
@@ -1,0 +1,185 @@
+# OmegaClaw Deontic Engine
+
+A **defeasible deontic logic reasoner** with a **task-orchestration layer** on top,
+implemented natively in MeTTa on the PeTTa interpreter. It answers two questions
+that graded-belief engines (NAL/PLN) do not:
+
+- **What defeasibly holds** when rules conflict — conclusions that a later fact can
+  *retract* (non-monotonic), resolved by rule specificity / priority.
+- **What is obligated, permitted, or forbidden** — and whether an action complies,
+  violates, or sits in an unresolved dilemma, including over time.
+
+If you need *retractable* conclusions, *rule priority*, *norms* (O/P/F, compliance,
+deadlines), or *temporal* reasoning (Event Calculus, Allen intervals), this is the
+engine. The **directive** layer then uses it to coordinate tasks: a plan of work
+plus dependency rules, from which the engine derives what is actionable and a
+claim/complete lifecycle is enforced.
+
+---
+
+## What's in the box
+
+| Piece | File | What it does |
+|---|---|---|
+| **Core reasoner** | `lib_deontic.metta` | Defeasible Logic DL(d) + Standard Deontic Logic + Event Calculus + trust |
+| **Directive layer** | `lib_directive.metta` | Task orchestration on top of the reasoner (dependency-ordered work) |
+| Reference | [`reference-lib-deontic.md`](../reference-lib-deontic.md) | Full reasoner API |
+| Reference | [`reference-lib-directive.md`](../reference-lib-directive.md) | Full directive API |
+
+Optional feature layers live on their own branches (see *Layered architecture*).
+
+---
+
+## The theory it implements
+
+- **Defeasible Logic** (Nute; Antoniou et al.) — strict (`->`), defeasible (`=>`),
+  and defeater (`~>`) rules, a **superiority** relation, ambiguity blocking, and the
+  four DL(d) provability tags **±Δ** (definite) / **±∂** (defeasible).
+- **Standard Deontic Logic** (Governatori) — obligation/permission/prohibition with
+  `F p ≡ O ¬p`, **contrary-to-duty** ⊗-reparation chains, and **deontic dilemmas**.
+- **Event Calculus** + the 13 **Allen** interval relations + temporal-deontic
+  **deadlines** (achievement / maintenance).
+- **Weakest-link trust** over multi-source claims, with per-source weights and gates.
+
+Conclusions are a set of `(tag literal)` pairs; tags are `pD`/`nD` (±Δ) and `pd`/`nd`
+(±∂). A literal is `(lit <sign> <mode> <temporal> <functor> <args>)`. See the
+[reasoner reference](../reference-lib-deontic.md) for the full tag/literal model.
+
+---
+
+## Theories and plans are ordinary `.metta` files
+
+There is **no bespoke parser**: a theory/plan is read by PeTTa's own loader, so it is
+just MeTTa atoms. The surface forms:
+
+| form | meaning |
+|---|---|
+| `(given p)` | a fact |
+| `(always L a b)` / `(normally L a b)` / `(except L a b)` | strict / defeasible / defeater rule |
+| `(prefer L1 L2)` | superiority: rule `L1` out-ranks `L2` |
+| `(not p)` · `(must p)` · `(forbidden p)` · `(permitted p)` | negation · deontic O/F/P |
+| `(deadline …)` | temporal-deontic deadline obligation |
+| `(happens e t)` · `(initiates e f t)` · `(terminates e f t)` · `(during LIT ?T)` | Event Calculus / Allen |
+| `(claims src … )` · `(trusts src v)` · `(threshold n v)` | sourced facts / trust weights / gates |
+
+The arrow-syntax `.dfl` format is also accepted (same theory, textbook notation).
+
+---
+
+## Quickstart
+
+`examples/deontic/penguin.metta` — the specific rule defeats the general one:
+
+```metta
+(given bird) (given penguin)
+(normally r1 bird flies)
+(normally r2 penguin (not flies))
+(prefer r2 r1)                 ; penguins are more specific
+```
+
+```metta
+!(import! &self (library OmegaClaw-Core lib_deontic))
+!(dl-run (dl-path examples/deontic/penguin.metta))
+; => includes (pd (lit neg none none flies ()))  — defeasibly NOT flies
+;            and (nd (lit pos none none flies ())) — r2 defeats r1
+```
+
+Key entry points: `(dl-run <path>)` for the conclusion set, `(dl-run-deontic <path>)`
+for the SDL closure, `(dl-run-at <path> <time>)` for as-of reasoning,
+`(deontic-compliance <path>)` / `(deontic-dilemmas <path>)` for norm analysis, and the
+non-monotonic queries `(dl-what-if …)` / `(dl-why-not …)` / `(dl-abduce …)` /
+`(dl-requires …)`. Full tables in the [reference](../reference-lib-deontic.md).
+
+---
+
+## Two reasoning backends — the engine toggle
+
+The same theory runs through either of two interchangeable backends, with
+**identical conclusions**:
+
+| backend | what it is | when |
+|---|---|---|
+| `prolog` *(default)* | the fast indexed Prolog kernel (`grounding.pl` / `reason.pl`) | grounding-heavy theories (variable rules over lots of data) |
+| `native` | the atomspace-native MeTTa engine (`ground.metta` / `reason.metta`) | propositional / coordination plans, and inspection / debugging |
+
+Switch per run with `(dl-engine! native)` or `$OMEGACLAW_DL_ENGINE=native`.
+
+**Why two?** Native reasoning is at parity, but native *grounding* (instantiating
+variable rules) runs ~4–5× slower than the Prolog kernel on grounding-heavy theories
+— the cost is per-operation MeTTa-eval overhead, not the algorithm (semi-naive and
+functor-indexed variants were measured; neither closes it). So `prolog` is the
+default for variable-rule-heavy work, while `native` is free where it matters
+(propositional plans, where grounding is trivial) and keeps every rule/atom
+inspectable in the atomspace. See the perf note in `src/deontic/ground.metta`.
+
+---
+
+## The directive layer — dependency-ordered task coordination
+
+`lib_directive.metta` turns the reasoner into a **task orchestrator**. A plan lists
+tasks and **readiness rules** (a task becomes ready once its dependencies complete);
+the defeasible engine derives what is actionable, and a claim/complete lifecycle is
+enforced so nothing happens out of order.
+
+```metta
+!(import! &self (library OmegaClaw-Core lib_directive))
+!(directive-next   <plan>)     ; the assignments whose dependencies are satisfied
+!(directive-status <plan>)     ; tasks / ready / claimed / blocked / completed
+!(directive-claim    <plan> <task> <agent> False)
+!(directive-complete <plan> <task> <agent>)   ; completing deps unlocks dependents
+```
+
+Claims/completions are **appended** to the plan `.metta` file with version-superiority
+blocks, so the plan is its own durable, auditable state. Blocking propagates through
+the dependency DAG (`directive-block` → downstream `upstream-blocked`). Full API in the
+[directive reference](../reference-lib-directive.md).
+
+---
+
+## Layered architecture
+
+The engine is the base; each capability is an **independently selectable layer**
+(each on its own branch, all building on the core):
+
+| layer | branch | adds |
+|---|---|---|
+| **core reasoner** | `deontic-core` | the DL(d) / SDL / EC / trust engine |
+| **directive** | `deontic-directive` | task orchestration (this branch) |
+| NAL/PLN bridge | `deontic-nal-bridge` | feed graded-belief conclusions into deontic rules |
+| agent skill | `deontic-skill` | expose the reasoner as an agent skill |
+| policy guardrail | `deontic-policy-guardrail` | gate agent actions against a deontic policy |
+| semantic | `deontic-semantic` | semantic retrieval into the reasoning loop |
+
+The reasoner itself is a thin MeTTa facade (`src/deontic/*.metta` — `engine`, `query`,
+`deontic`, `eventcalc`, `trust`, `ground`, `reason`) over a deterministic kernel
+(`src/deontic/platform/*.pl`). `platform.metta` is the only module that knows the
+engine runs on PeTTa.
+
+---
+
+## Running the tests
+
+```sh
+SWIPL=…/swipl    # the PeTTa build
+$SWIPL --stack_limit=8g -q -s PeTTa/src/main.pl -- tests/deontic/test_core.metta --silent
+```
+
+The suite is **139 tests** across `tests/deontic/` (core, CTD, deadline, deontic, dfl,
+eventcalc, incremental, query, temporal, trust) and `tests/integration/` (directive,
+analyze, inspect, mining). It passes identically under **both** engine backends
+(`OMEGACLAW_DL_ENGINE=prolog` and `=native`).
+
+---
+
+## When to use this vs NAL / PLN
+
+| You need… | Use |
+|---|---|
+| Retractable (non-monotonic) conclusions, rule priority | this engine |
+| Norms: O/P/F, compliance, dilemmas, deadlines | this engine |
+| Temporal reasoning (Event Calculus, Allen intervals) | this engine |
+| Dependency-ordered task coordination | the directive layer |
+| Graded belief from noisy multi-source evidence | NAL / PLN |
+
+NAL/PLN decide *how much you believe* a fact; this engine decides *what defeasibly
+holds and what you ought to do* given those facts.

--- a/docs/reference-lib-deontic.md
+++ b/docs/reference-lib-deontic.md
@@ -1,0 +1,133 @@
+# Reference — `lib_deontic.metta`
+
+Defeasible, deontic, and temporal reasoning. Where `lib_nal`/`lib_pln` grade **how much** a fact is believed, `lib_deontic` answers what **defeasibly holds** under conflicting rules and what is **obligated, permitted, or forbidden** — non-monotonic and normative reasoning. It is the engine to reach for when conclusions must be *retractable* (a later fact can overturn an earlier one) or when an action must be checked against norms.
+
+Theory: Nute/Antoniou **Defeasible Logic**, Governatori **defeasible deontic logic**, the **Event Calculus** + the 13 **Allen** interval relations for time. It also fills the gap [reference-lib-nal.md](./reference-lib-nal.md) notes — "real-time / temporal reasoning is not served by a stock engine."
+
+---
+
+## Conclusion tags
+
+Reasoning over a theory yields a set of `(tag literal)` conclusions. Tags are the four standard Defeasible-Logic provability degrees:
+
+| tag | DL notation | meaning |
+|---|---|---|
+| `pD` | +Δ | **definitely** provable (facts + strict rules alone) |
+| `nD` | −Δ | definitely refuted |
+| `pd` | +∂ | **defeasibly** provable (a rule fires and every attacker is defeated or out-ranked) |
+| `nd` | −∂ | defeasibly refuted |
+
+A literal is `(lit <sign> <mode> <temporal> <functor> <args>)`: `sign` ∈ `pos|neg`, `mode` ∈ `none|O|P|F` (obligation / permission / prohibition), `temporal` ∈ `none|(iv <start> <end>)`.
+
+---
+
+## Theory surface syntax (MeTTa / DFL)
+
+A theory is a `.metta` (or arrow-format `.dfl`) file:
+
+| form | meaning |
+|---|---|
+| `(given p)` | a **fact** |
+| `(claims src p)` | a fact asserted **by a source** (carries provenance for trust) |
+| `(always L a b)` | **strict** rule `a -> b` (classical: if `a` then `b`) |
+| `(normally L a b)` | **defeasible** rule `a => b` (`b` unless defeated) |
+| `(except L a b)` | **defeater** `a ~> b` (blocks the opposite of `b` without proving `b`) |
+| `(prefer L1 L2)` | **superiority**: rule `L1` out-ranks `L2` |
+| `(not p)` | classical negation |
+| `(must p)` / `(forbidden p)` / `(permitted p)` | deontic mode O / F / P on `p` (`F p ≡ O ¬p`) |
+| `(deadline …)` | a temporal-deontic deadline obligation (achievement / maintenance) |
+| `(happens e t)` / `(initiates e f t)` / `(terminates e f t)` | Event-Calculus events/effects |
+| `(during LIT ?T)` | bind an interval handle for Allen-relation constraints |
+| `(trusts src v)` / `(threshold name v)` | per-source trust weight / a trust gate |
+
+---
+
+## API
+
+Reach the engine through the `(metta …)` skill. A theory is loaded from a path via `(dl-path <repo-relative-file>)`.
+
+### Defeasible reasoning
+| call | returns |
+|---|---|
+| `(dl-run <path>)` | the full sorted `(tag lit)` conclusion set |
+| `(dl-run-at <path> <ref>)` | conclusions **as of** a reference time (drops temporally-inactive atoms) |
+| `(dl-run-deontic <path>)` | conclusions under the Standard Deontic Logic closure (`F p ≡ O ¬p`, `O p → P p`) |
+| `(dl-print <path>)` | pretty-prints each conclusion (`  +D penguin`) |
+
+### Deontic analysis
+| call | returns |
+|---|---|
+| `(deontic-compliance <path>)` | per-obligation verdict report: fulfilled / violated / pending |
+| `(deontic-dilemmas <path>)` | obligations in conflict (`O p` and `O ¬p` both applicable, neither resolved) |
+| `(deadline-status <path> <now> <functor>)` | deadline verdict (achievement vs maintenance) at time `now` |
+
+### Non-monotonic queries
+| call | returns |
+|---|---|
+| `(dl-what-if <path> <hyps> <goal>)` | the goal's status and newly-provable literals after assuming `<hyps>` |
+| `(dl-why-not <goal>)` | the rules/defeats that block a goal |
+| `(dl-abduce <goal>)` | minimal fact-sets that would make the goal provable |
+| `(dl-requires <path> <goal>)` | support the goal cannot do without |
+
+### Trust & explanation
+| call | returns |
+|---|---|
+| `(trust-of <lit>)` | weakest-link trust over the proof tree, `[0,1]` |
+| `(justify <lit>)` | bundled DL status + proof tree + trust + sources + confidence |
+| `(dl-trust-run <path>)` | conclusions annotated with trust + sources |
+
+### Temporal (Event Calculus)
+`(ec-intervals …)`, `(ec-holds-at …)`, `(ec-violated-at …)`, `(ec-timeline …)`.
+
+---
+
+## Worked examples
+
+### Defeasible: the penguin overrides the bird rule
+`examples/deontic/penguin.metta`:
+```
+(given bird) (given penguin)
+(normally r1 bird flies)
+(normally r2 penguin (not flies))
+(prefer r2 r1)            ; penguins are more specific
+```
+```metta
+!(import! &self (library OmegaClaw-Core lib_deontic))
+!(dl-run (dl-path examples/deontic/penguin.metta))
+```
+Conclusion set includes `(pd (lit neg none none flies ()))` (defeasibly **not** flies) and `(nd (lit pos none none flies ()))` — the specific rule `r2` defeats `r1`.
+
+### Deontic: an unresolved dilemma
+`examples/deontic/deontic_dilemma.metta`:
+```
+(given a)
+(normally r1 a (must p))
+(normally r2 a (forbidden p))
+```
+```metta
+!(deontic-dilemmas (dl-path examples/deontic/deontic_dilemma.metta))
+```
+Returns one dilemma: `O p` and `O ¬p` are both applicable and neither is ranked above the other, so neither obligation is discharged.
+
+---
+
+## When to use `lib_deontic` vs. NAL / PLN
+
+| Situation | Engine |
+|---|---|
+| Conclusions that a later fact can **retract** (non-monotonic) | `lib_deontic` |
+| Rule **priority** / specificity conflicts (superiority) | `lib_deontic` |
+| **Norms**: obligations / permissions / prohibitions, compliance, dilemmas, deadlines | `lib_deontic` |
+| **Temporal** reasoning (Event Calculus, Allen intervals) | `lib_deontic` |
+| Graded **belief** from noisy multi-source evidence | NAL / PLN |
+| Inheritance / implication chains with confidence decay | NAL `\|-` |
+| Property-based categorical inference | PLN `\|~` |
+
+The two are complements: NAL/PLN decide *how much you believe* a fact; `lib_deontic` decides *what defeasibly holds and what you ought to do* given those facts.
+
+---
+
+## See also
+- [reference-lib-nal.md](./reference-lib-nal.md) — evidential (NARS) reasoning.
+- [reference-lib-pln.md](./reference-lib-pln.md) — probabilistic reasoning.
+- [reference-orchestration.md](./reference-orchestration.md) — picking an engine.

--- a/docs/reference-lib-deontic.md
+++ b/docs/reference-lib-deontic.md
@@ -79,6 +79,13 @@ Reach the engine through the `(metta …)` skill. A theory is loaded from a path
 ### Temporal (Event Calculus)
 `(ec-intervals …)`, `(ec-holds-at …)`, `(ec-violated-at …)`, `(ec-timeline …)`.
 
+### Engine backends
+The reasoner ships two interchangeable backends with **identical conclusions**:
+`prolog` (default — the fast indexed kernel) and `native` (the atomspace-native MeTTa
+engine). Switch with `(dl-engine! native)` or `$OMEGACLAW_DL_ENGINE=native`. Use
+`prolog` for grounding-heavy theories and `native` for propositional plans /
+inspection — see [deontic/README.md](./deontic/README.md#two-reasoning-backends--the-engine-toggle).
+
 ---
 
 ## Worked examples

--- a/docs/reference-lib-directive.md
+++ b/docs/reference-lib-directive.md
@@ -1,0 +1,125 @@
+# Reference — `lib_directive.metta`
+
+**Dependency-ordered task orchestration**, built on the defeasible deontic engine
+([`lib_deontic`](./reference-lib-deontic.md)). A *plan* lists tasks and the rules by
+which a task becomes ready; the engine derives what is actionable right now, and a
+claim/complete lifecycle is enforced so work happens in dependency order. Because the
+rules are *defeasible*, the plan can express priorities, blocking, and reversible
+claims — and recover when a task fails.
+
+The orchestration is just deontic reasoning: **readiness and assignment are defeasible
+rules**, so `directive-next` is `dl-run` over the plan, filtered to the assignments
+whose dependencies hold. Lifecycle actions (claim, complete, …) are **appended to the
+plan `.metta` file** as superiority-ranked blocks, so the file *is* the durable,
+auditable state — no external store.
+
+---
+
+## Plan format
+
+A plan is a `.metta` theory ([loaded natively](./reference-lib-deontic.md), no parser)
+using the deontic forms plus a literal-naming convention:
+
+```metta
+(meta plan (id "PROJ-1") (title "Ship v1") (status "active") (author "agent:me"))
+
+(given agent-coder-available)              ; available agents
+(given task-design) (given task-backend)   ; the tasks
+(given no-deps-design)                     ; roots (no dependencies)
+
+; readiness: a task is ready once its dependencies are completed
+(normally r-design  (and task-design no-deps-design)  ready-design)
+(normally r-backend completed-design                  ready-backend)
+
+; assignment: a ready task + an available agent is an actionable assignment
+(normally assign-design (and ready-design agent-coder-available) assign-to-design-coder)
+(prefer assign-design-reviewer assign-design)   ; optional priority between assignments
+
+; blocking defeater (optional)
+(except block-deploy tests-failing (not ready-deploy))
+```
+
+Conventions the layer reads: `task-X`, `ready-X`, `completed-X`, `claimed-X`,
+`blocked-X`, `upstream-blocked-X`, and `assign-to-X-AGENT`. A task `X` is *ready* when
+`ready-X` is concluded and `completed-X` is not.
+
+---
+
+## Lifecycle
+
+Lifecycle calls append a **`(claims supervisor:AGENT …)`** block to the plan file. Each
+block carries a version and a `(prefer …)` that out-ranks the previous block, so the
+newest action wins by superiority (defeasible, hence reversible):
+
+```
+claim   v1   →  claimed-X
+unclaim v2   →  (not claimed-X)     prefer v2 > v1
+reclaim v3   →  claimed-X           prefer v3 > v2
+```
+
+`completed-X` is a fact; completing a task's dependencies makes dependents *ready* on
+the next read. `directive-block` propagates through the dependency DAG — a blocked task
+marks downstream tasks `upstream-blocked-…`, so a failure visibly cascades and the team
+can be rerouted. Completing the final task reports `plan-complete`.
+
+---
+
+## API
+
+A plan is a path (use `(dl-path <repo-relative-file>)` for bundled fixtures, or an
+absolute path for runtime plans).
+
+### Read the actionable state
+| call | returns |
+|---|---|
+| `(directive-next <plan>)` | `(next-actions ((assign <task> <agent> <label>) …))` — assignments whose deps hold |
+| `(directive-status <plan>)` | `(status (tasks …) (ready …) (claimed …) (blocked …) (upstream-blocked …) (completed …))` |
+| `(directive-board <plan>)` | tasks grouped: `(board (backlog …) (ready …) (in-progress …) (blocked …) (done …))` |
+| `(directive-summary <plan>)` | counts: `(summary (total N) (backlog N) (ready N) (in-progress N) (blocked N) (done N) (progress-pct N))` |
+| `(directive-info <plan>)` | the `(meta plan …)` key/values |
+| `(directive-assignments <plan>)` | the current assignment suggestions |
+
+### Mutate (append a lifecycle block)
+| call | returns |
+|---|---|
+| `(directive-claim <plan> <task> <agent> <force>)` | `(claimed <task> <ver>)` · `(already-claimed …)` · `(err not-ready <task>)` |
+| `(directive-complete <plan> <task> <agent>)` | `(completed <task>)` · `(completed <task> plan-complete)` |
+| `(directive-unclaim <plan> <task> <agent>)` | `(unclaimed <task> <ver>)` |
+| `(directive-block <plan> <task> <agent>)` | `(blocked <task> <ver>)` (+ downstream `upstream-blocked`) |
+| `(directive-unblock <plan> <task> <agent>)` | `(unblocked <task> <ver>)` |
+
+`<force> = True` bypasses the readiness check when claiming.
+
+### Inspect / validate
+| call | returns |
+|---|---|
+| `(directive-validate <plan>)` | structural problems (cycles, dangling deps, missing metadata) |
+| `(directive-analyze <plan>)` | a combined structure + readiness report |
+| `(directive-trace <plan> <task>)` | why a task is / isn't actionable (the deriving + defeating rules) |
+| `(directive-upstream <plan> <task>)` | the tasks `<task>` depends on |
+| `(directive-task-state <plan> <task>)` | one of `backlog` / `ready` / `in-progress` / `blocked` / `done` |
+
+---
+
+## Worked example
+
+`tests/deontic/fixtures/basic-tasks.metta` defines tasks `auth`, `models`, `crud`,
+`tests` with `crud ⇐ models` and `tests ⇐ crud ∧ auth`.
+
+```metta
+!(import! &self (library OmegaClaw-Core lib_directive))
+
+!(directive-next "/tmp/plan.metta")                 ; offers auth, models — NOT crud
+!(directive-complete "/tmp/plan.metta" models me)   ; (completed models)
+!(directive-next "/tmp/plan.metta")                 ; NOW offers crud (its dep is done)
+!(directive-claim "/tmp/plan.metta" crud me False)  ; (claimed crud 1)
+```
+
+`crud` is gated until `models` completes — the dependency DAG is enforced by the
+defeasible engine, not by the caller.
+
+---
+
+## See also
+- [reference-lib-deontic.md](./reference-lib-deontic.md) — the reasoner underneath.
+- [deontic/README.md](./deontic/README.md) — the overall engine + layer overview.

--- a/examples/deontic/deadline_demo.metta
+++ b/examples/deontic/deadline_demo.metta
@@ -1,0 +1,5 @@
+;; Temporal-deontic deadlines (Governatori et al. 2007), a temporal-deontic extension.
+;; Achievement: pay by 30 (sanction: fine). Maintenance: no trespass in [0,100].
+(deadline (must pay) achieve 0 30 fine)
+(deadline (forbidden trespass) maintain 0 100 penalty)
+(given (during pay 25 25))

--- a/examples/deontic/deontic_dilemma.metta
+++ b/examples/deontic/deontic_dilemma.metta
@@ -1,0 +1,4 @@
+;; Deontic dilemma: obligation vs prohibition of p, no superiority to resolve.
+(given a)
+(normally r1 a (must p))
+(normally r2 a (forbidden p))

--- a/examples/deontic/penguin.metta
+++ b/examples/deontic/penguin.metta
@@ -1,0 +1,11 @@
+; Classic Tweety/Penguin example
+; Penguins are birds that don't fly
+
+(given bird)
+(given penguin)
+
+(normally r1 bird flies)
+(normally r2 penguin (not flies))
+
+; Penguins are more specific than birds
+(prefer r2 r1)

--- a/lib_deontic.metta
+++ b/lib_deontic.metta
@@ -1,0 +1,28 @@
+; lib_deontic — Defeasible + Deontic + Temporal logic for OmegaClaw.
+;
+; A reasoning library, sibling to lib_nal / lib_pln. Where NAL/PLN grade how much
+; a fact is believed, this library answers what *defeasibly holds* under
+; conflicting rules and what is *obligated / permitted / forbidden* — that is,
+; non-monotonic and normative reasoning (Nute's Defeasible Logic + Standard
+; Deontic Logic, with Event-Calculus temporal grounding). Pure library: it
+; defines vocabulary and inference; it registers no agent skill and does not
+; touch the loop.
+;
+; Theory of operation, end to end:
+;   load   — parse a theory (facts; strict -> / defeasible => / defeater ~> rules;
+;            superiority) into spaces;
+;   ground — instantiate variable rules over the Herbrand base (Datalog join);
+;   reason — DL(d) fixpoints produce four provability tags: +D/-D (definite, the
+;            monotonic core) and +d/-d (defeasible, ambiguity-blocking);
+;   read   — enumerate the tagged conclusion set; the deontic, temporal, and
+;            trust analyses all fold over it.
+!(import! &self (library OmegaClaw-Core src/deontic/platform/platform))
+!(import! &self (library OmegaClaw-Core src/deontic/types))
+!(import! &self (library OmegaClaw-Core src/deontic/ground))
+!(import! &self (library OmegaClaw-Core src/deontic/reason))
+!(import! &self (library OmegaClaw-Core src/deontic/engine))
+!(import! &self (library OmegaClaw-Core src/deontic/query))
+!(import! &self (library OmegaClaw-Core src/deontic/explain))
+!(import! &self (library OmegaClaw-Core src/deontic/trust))
+!(import! &self (library OmegaClaw-Core src/deontic/deontic))
+!(import! &self (library OmegaClaw-Core src/deontic/eventcalc))

--- a/lib_directive.metta
+++ b/lib_directive.metta
@@ -1,0 +1,39 @@
+; lib_directive — Defeasible task-coordination, layered on lib_deontic.
+;
+; Where lib_deontic answers "what defeasibly holds / what is obligated", this
+; library turns that same non-monotonic engine into a coordinator for *work*:
+; a plan is a defeasible theory whose conclusions describe the live state of a
+; set of tasks, and every coordination command is just reasoning over that
+; theory. Pure library — it defines vocabulary and queries, registers no agent
+; skill, and does not touch the loop.
+;
+; What it adds on top of the engine, end to end:
+;   task extraction — read the conclusion set as task / ready / claimed /
+;     blocked / upstream-blocked / completed groups (prefix conventions on
+;     literal names), plus agent assignments;
+;   next-actions   — the assignments whose task is currently `ready`, with a
+;     state-precedence classifier (done > blocked > upstream-blocked >
+;     decomposed > in-progress > ready > backlog) feeding status / board /
+;     summary views;
+;   lifecycle      — claim / unclaim / block / unblock / complete / assert,
+;     each an append-only block of facts and defeasible rules that a later
+;     re-reason resolves (a counter-action defeats the prior chain, so state
+;     transitions are monotone appends with non-monotonic effect), including
+;     failure-propagation rules that block downstream tasks;
+;   inspection     — full reasoning trace, plan-structure validation
+;     (undefined / unreachable literals, consistency), dependency-cycle
+;     (deadlock) detection via SCCs of the support graph, and assignment
+;     listing;
+;   process-mining — recover a defeasible plan from observed event logs: extract
+;     per-case event sequences from claims blocks, compute the directly-follows
+;     footprint, and learn rules with trace-level support / confidence plus
+;     XOR / mutex conflict detection.
+;
+; Opt-in: load this facade (it pulls in lib_deontic) to get the coordination
+; layer. Load order mirrors the dependency chain — core extraction/lifecycle
+; first, then mining and inspection that build on it, then the CLI dispatcher.
+!(import! &self (library OmegaClaw-Core lib_deontic))
+!(import! &self (library OmegaClaw-Core src/directive/directive))
+!(import! &self (library OmegaClaw-Core src/directive/mining))
+!(import! &self (library OmegaClaw-Core src/directive/inspect))
+!(import! &self (library OmegaClaw-Core src/directive/cli))

--- a/lib_omegaclaw.metta
+++ b/lib_omegaclaw.metta
@@ -4,6 +4,7 @@
 !(import! &self (library lib_combinatorics))
 !(import! &self (library OmegaClaw-Core lib_nal))
 !(import! &self (library OmegaClaw-Core lib_pln))
+!(import! &self (library OmegaClaw-Core lib_deontic))
 !(import! &self (library OmegaClaw-Core lib_llm_ext.py))
 !(import! &self (library OmegaClaw-Core ./src/helper.py))
 !(import! &self (library OmegaClaw-Core ./src/agentverse.py))

--- a/src/deontic/deontic.metta
+++ b/src/deontic/deontic.metta
@@ -1,0 +1,117 @@
+; Idiomatic-MeTTa deontic analysis. The SDL bridge that injects grules is
+; grounding-adjacent and stays in Prolog (like mm_ground); the ANALYSIS over the
+; reasoned conclusions is expressed natively here with pattern-match clauses and
+; match/collapse. Verdicts follow deolingo's O^f / O^v / O^u (fulfilled / violated
+; / undetermined). Prolog is called only for primitives: literal rendering
+; (mm_lit_str) and time comparison (mm_tp_le), plus the thin report formatter.
+
+; --- sign flip; the ideal (fulfilling) and violating proposition of a duty ------
+(= (flip-sign pos) neg)
+(= (flip-sign neg) pos)
+
+(= (deontic-ideal (lit $s O $t $f $a)) (lit $s none $t $f $a))            ; O p satisfied by p
+(= (deontic-ideal (lit $s F $t $f $a)) (lit (flip-sign $s) none $t $f $a)); F p satisfied by ¬p
+(= (deontic-viol  (lit $s O $t $f $a)) (lit (flip-sign $s) none $t $f $a)); O p broken by ¬p
+(= (deontic-viol  (lit $s F $t $f $a)) (lit $s none $t $f $a))            ; F p broken by p
+
+; --- compliance verdict for one duty against a conclusion set ------------------
+(= (compliance-in $d $cs)
+   (if (== (is-member (pd (deontic-ideal $d)) $cs) True) complied
+   (if (== (is-member (pd (deontic-viol  $d)) $cs) True) violated
+       pending)))
+(= (compliance-of $d) (compliance-in $d (dl-conclusions)))
+
+; --- the obligations/prohibitions among the +d conclusions --------------------
+(= (deontic-mode? O) True)
+(= (deontic-mode? F) True)
+(= (deontic-mode? $m) False)
+
+(= (obligations-in $cs)
+   (collapse (case (superpose $cs)
+     (((pd (lit $s $m $t $f $a))
+       (if (== (deontic-mode? $m) True) (lit $s $m $t $f $a) (empty)))
+      ($_ (empty))))))
+
+; --- compliance report (logic in MeTTa; Prolog formats pre-rendered lines) -----
+(= (verdict-of $d $cs) (let $ls (mm_lit_str $d) ($ls (compliance-in $d $cs))))
+(= (deontic-compliance $path)
+   (let* (($cs (dl-run $path))
+          ($obls (sort-atom (obligations-in $cs))))
+     (mm_print_verdicts "Deontic Compliance" (map-atom $obls $d (verdict-of $d $cs)))))
+
+; --- deontic dilemmas: O p and O ¬p both applicable, neither resolved ----------
+; an obligation is "applicable" iff some strict/defeasible grule derives it with
+; an all-+d body (it fired) — checked declaratively with match over &ground.
+(= (oblig-applicable $d)
+   (not (== () (collapse (match &ground (grule $l $k $b $d)
+                 (if (and (== (sd-kind? $k) True) (== (body-all-pd $b) True)) $l (empty)))))))
+
+(= (dilemma? $d $cs)
+   (and (== (oblig-applicable (lit-neg $d)) True)
+   (and (== (is-member (pd $d) $cs) False)
+        (== (is-member (pd (lit-neg $d)) $cs) False))))
+
+; candidate obligations are the APPLICABLE positive ones (those whose rule fired)
+; — the dilemma duties are defeated, so they are NOT among the +d conclusions.
+(= (applicable-pos-obligations)
+   (collapse (match &ground (grule $l $k $b (lit pos O $t $f $a))
+     (if (and (== (sd-kind? $k) True) (== (body-all-pd $b) True)) (lit pos O $t $f $a) (empty)))))
+
+(= (dilemmas-in $cs)
+   (filter-atom (applicable-pos-obligations) $d (== (dilemma? $d $cs) True)))
+
+(= (deontic-dilemmas $path)
+   (let $cs (dl-run-deontic $path) (unique-atom (dilemmas-in $cs))))
+(= (deontic-dilemmas-report $path)
+   (let $cs (dl-run-deontic $path)
+     (mm_print_dilemmas2 (unique-atom (dilemmas-in $cs)))))
+
+; --- temporal-deontic deadline compliance (Governatori et al. 2007) -----------
+; A deadline obligation has a window [St,En] and a type: ACHIEVEMENT (target must
+; occur >=once by the deadline) or MAINTENANCE (target must not occur in the
+; window). Evaluated at reference time `now`; occurrence is bounded by now (a
+; future event isn't a breach yet). Metadata lives in &st as deadlineinfo.
+
+; occurrence times of the target proposition among the +d conclusions
+(= (dl-occ-times $sgn $f $a $cs)
+   (collapse (case (superpose $cs)
+     (((pd (lit $sgn none (iv $t $te) $f $a)) $t)
+      ((pd (lit $sgn none none $f $a)) untimed)
+      ($_ (empty))))))
+
+(= (dl-in-window $t $st $en $now)
+   (if (== $t untimed) True
+       (and (== (tp<= $st $t) True) (and (== (tp<= $t $en) True) (== (tp<= $t $now) True)))))
+(= (dl-occurred? $times $st $en $now)
+   (if (== $times ()) False
+       (let $t (car-atom $times)
+         (if (== (dl-in-window $t $st $en $now) True) True
+             (dl-occurred? (cdr-atom $times) $st $en $now)))))
+
+; verdict per type (pattern-matched): achievement vs maintenance
+(= (dl-verdict achieve $occurred $en $now)
+   (if (== $occurred True) fulfilled (if (== (tp<= $now $en) True) pending violated)))
+(= (dl-verdict maintain $occurred $en $now)
+   (if (== $occurred True) violated (if (== (tp<= $now $en) True) pending fulfilled)))
+
+(= (dl-verdict-of $sgn $f $a $type $st $en $now $cs)
+   (dl-verdict $type (dl-occurred? (dl-occ-times $sgn $f $a $cs) $st $en $now) $en $now))
+
+(= (deadline-status $path $now $functor)
+   (let $cs (dl-run $path)
+     (case (once (match &st (deadlineinfo $sgn $mode $functor $a $type $st $en $sanc)
+                   ($sgn $a $type $st $en)))
+       ((($sgn $a $type $st $en)
+         (dl-verdict-of $sgn $functor $a $type $st $en $now $cs))
+        (Empty none)))))
+
+; deadline report: MeTTa builds rows (lit-with-window str, type, status, sanction);
+; Prolog formats. Window carried in the literal so mm_lit_str renders [O]pay[0,30].
+(= (deadline-rows $cs $now)
+   (collapse (match &st (deadlineinfo $sgn $mode $f $a $type $st $en $sanc)
+     ((mm_lit_str (lit $sgn $mode (iv $st $en) $f $a))
+      $type
+      (dl-verdict-of $sgn $f $a $type $st $en $now $cs)
+      $sanc))))
+(= (deontic-deadlines $path $now)
+   (let $cs (dl-run $path) (mm_print_deadlines2 $now (deadline-rows $cs $now))))

--- a/src/deontic/engine.metta
+++ b/src/deontic/engine.metta
@@ -19,21 +19,35 @@
           ($_2 (mm_load_into $path &plan)))
      (collapse (mm_ingest (match &plan $f $f) &theory &ground &herb &st))))
 
-; Grounding and reasoning use the fast indexed Prolog engines (mm_ground /
-; mm_reason); ground.metta and reason.metta remain as readable reference
-; implementations. mm_reason populates &st (defp/dft) for the MeTTa layer.
-(= (dl-ground!) (mm_ground &theory &ground &herb &st))
-(= (dl-reason-only!) (mm_reason &ground &theory &st))
+; Reasoning backend, switchable: prolog (fast indexed kernel, default) | native
+; (the atomspace-native MeTTa engine in ground.metta / reason.metta — identical
+; conclusions, ideal for propositional plans and inspection). Set per run with
+; (dl-engine! native) or $OMEGACLAW_DL_ENGINE=native. Native reasoning is at
+; parity, but native grounding runs ~4-5x the Prolog kernel on grounding-heavy
+; theories (per-operation MeTTa-eval overhead, not algorithmic — see the perf
+; note in ground.metta), so prolog stays the default.
+(= (dl-engine! $m) (mm_dl_engine_set $m))
+
+(= (dl-ground!)
+   (case (mm_dl_engine_get)
+     ((native (ground-sn!))
+      ($_     (mm_ground &theory &ground &herb &st)))))
+(= (dl-reason-only!)
+   (case (mm_dl_engine_get)
+     ((native (reason!))
+      ($_     (mm_reason &ground &theory &st)))))
 
 (= (dl-reason!)
    (let* (($_1 (dl-ground!))
           ($_2 (dl-reason-only!)))
      ()))
 
-; conclusions come from the fast Prolog enumerator (mm_conclusions reads the
-; interned integer-indexed status directly); reason.metta's (conclusions) stays
-; as the reference. sort-atom normalizes ordering to match test expectations.
-(= (dl-conclusions) (sort-atom (mm_conclusions)))
+; conclusions: prolog reads the interned integer-indexed status (mm_conclusions);
+; native reads off reason.metta's (conclusions). sort-atom normalizes ordering.
+(= (dl-conclusions)
+   (case (mm_dl_engine_get)
+     ((native (sort-atom (conclusions)))
+      ($_     (sort-atom (mm_conclusions))))))
 
 (= (dl-run $path)
    (let* (($_1 (dl-load $path))

--- a/src/deontic/engine.metta
+++ b/src/deontic/engine.metta
@@ -1,0 +1,101 @@
+; Engine facade: load a theory -> ground it -> run DL(d) inference -> read off
+; the tagged conclusion set. The single entry point lib_deontic builds on.
+
+; Load a plan/theory file into the engine spaces. dl-load resets engine state
+; first, then dispatches on surface format: .metta plans are read with PeTTa's
+; native loader and each form ingested; .dfl theories use the arrow-syntax parser.
+(= (dl-load $path)
+   (let $_ (dl-reset) (dl-ingest-file $path)))
+
+(= (dl-ingest-file $path)
+   (case (mm_plan_format $path)
+     ((dfl   (mm_load_dfl $path &theory &ground &herb &st))
+      (metta (dl-load-native $path)))))
+
+; Native .metta load: load the file into the scratch &plan space, then ingest
+; every form it holds into the theory / ground / herbrand / status spaces.
+(= (dl-load-native $path)
+   (let* (($_1 (mm_clear_space &plan))
+          ($_2 (mm_load_into $path &plan)))
+     (collapse (mm_ingest (match &plan $f $f) &theory &ground &herb &st))))
+
+; Grounding and reasoning use the fast indexed Prolog engines (mm_ground /
+; mm_reason); ground.metta and reason.metta remain as readable reference
+; implementations. mm_reason populates &st (defp/dft) for the MeTTa layer.
+(= (dl-ground!) (mm_ground &theory &ground &herb &st))
+(= (dl-reason-only!) (mm_reason &ground &theory &st))
+
+(= (dl-reason!)
+   (let* (($_1 (dl-ground!))
+          ($_2 (dl-reason-only!)))
+     ()))
+
+; conclusions come from the fast Prolog enumerator (mm_conclusions reads the
+; interned integer-indexed status directly); reason.metta's (conclusions) stays
+; as the reference. sort-atom normalizes ordering to match test expectations.
+(= (dl-conclusions) (sort-atom (mm_conclusions)))
+
+(= (dl-run $path)
+   (let* (($_1 (dl-load $path))
+          ($_2 (dl-reason!)))
+     (dl-conclusions)))
+
+; As-of reasoning (--at <ref>): ground, drop temporally-inactive atoms at the
+; reference time, then reason. Ref is millis (int) or an ISO-8601 string.
+(= (dl-run-at $path $ref)
+   (let* (($_1 (dl-load $path))
+          ($_2 (dl-ground!))
+          ($_3 (mm_at_filter &ground &herb &st $ref))
+          ($_4 (dl-reason-only!)))
+     (dl-conclusions)))
+
+; --- Standard Deontic Logic reasoning (opt-in) -------------------------------
+; Ground, inject SDL bridge grules (F p ≡ O ¬p; O p → P p), then reason. The
+; default dl-run stays purely classical; this derives the deontic closure
+; (and deontic conflicts fall out via the normal sign-complement attack).
+(= (dl-run-deontic $path)
+   (let* (($_1 (dl-load $path))
+          ($_2 (dl-ground!))
+          ($_3 (mm_deontic_bridge &ground &herb &st))
+          ($_4 (dl-reason-only!)))
+     (dl-conclusions)))
+
+; Deontic compliance + dilemmas live in deontic.metta (deontic-compliance /
+; compliance-of / deontic-dilemmas / deontic-dilemmas-report).
+
+; Event-Calculus obligation lifecycle lives in eventcalc.metta
+; (ec-intervals / ec-holds-at / ec-violated-at / ec-timeline).
+
+; (temporal-deontic deadline compliance — deontic-deadlines / deadline-status —
+;  also lives in deontic.metta.)
+
+; --- incremental (append-only) session ---------------------------------------
+; For workflows that mutate a theory by APPENDING new blocks of facts/rules:
+; load once keeping the materialized base, then each append only
+; grounds the new closure (semi-naive, add-only) instead of re-grounding from
+; scratch. Reasoning is non-monotonic so it re-runs over the grown ground set,
+; but grounding — usually the costly part on large plans — is incremental.
+; Yields IDENTICAL conclusions to a from-scratch load of the concatenated plan.
+
+(= (dl-load-incr $path)
+   (let* (($_1 (dl-reset))
+          ($_2 (dl-ingest-file $path))
+          ($_3 (mm_ground_incr_init &theory &ground &herb &st)))
+     ()))
+
+; Append a delta plan file (new claims/facts/rules), ground only the delta.
+(= (dl-append-incr! $path)
+   (let* (($_1 (dl-ingest-file $path))
+          ($_2 (mm_ground_delta &theory &ground &herb &st)))
+     ()))
+
+; Reason over the current (grown) ground set and read off conclusions.
+(= (dl-reason-incr)
+   (let $_ (mm_reason &ground &theory &st) (dl-conclusions)))
+
+; Pretty printer: one "  +D penguin" line per conclusion, tagged with its
+; defeasible-logic provability tag (+D/-D definite, +d/-d defeasible).
+(= (print-concl $c)
+   (println! (mm_concl_str $c)))
+(= (dl-print $path)
+   (for-each-in-atom (dl-run $path) print-concl))

--- a/src/deontic/eventcalc.metta
+++ b/src/deontic/eventcalc.metta
@@ -1,0 +1,64 @@
+; Event-Calculus obligation lifecycle in idiomatic MeTTa (RTEC/oPIEC style).
+; Obligations are inertial fluents: initiated by an event, persisting until a
+; terminating event. Maximal validity intervals are computed by one-pass
+; amalgamation over the sorted event time-points (O(n log n), not per-time-point).
+; Prolog is used only for the inf-aware time comparison primitive (mm_tp_le) and
+; literal rendering (mm_lit_str); the algorithm itself is native MeTTa recursion.
+
+; (tp<= / tp< — inf-aware time order — are shared helpers in types.metta)
+
+; sorted initiation / termination time-points of a fluent
+(= (ec-inits $f)
+   (sort-atom (collapse (match &theory (ec_init $e $f) (match &theory (happens $e $t) $t)))))
+(= (ec-terms $f)
+   (sort-atom (collapse (match &theory (ec_term $e $f) (match &theory (happens $e $t) $t)))))
+
+; earliest termination strictly after $s, else inf
+(= (first-after $terms $s)
+   (if (== $terms ()) inf
+       (let $t (car-atom $terms)
+         (if (== (tp< $s $t) True) $t (first-after (cdr-atom $terms) $s)))))
+
+; drop leading initiations strictly below $e (re-inits inside an open period)
+(= (drop-below $inits $e)
+   (if (== $inits ()) ()
+       (let $i (car-atom $inits)
+         (if (== (tp< $i $e) True) (drop-below (cdr-atom $inits) $e) $inits))))
+
+; amalgamate sorted inits + terms into maximal [S,E) intervals (E = inf if open)
+(= (amalg $inits $terms)
+   (if (== $inits ()) ()
+       (let* (($s (car-atom $inits))
+              ($e (first-after $terms $s))
+              ($rest (drop-below (cdr-atom $inits) $e)))
+         (cons-atom ($s $e) (amalg $rest $terms)))))
+
+(= (fluent-intervals $f) (amalg (ec-inits $f) (ec-terms $f)))
+
+; T lies in some in-force interval [S,E)
+(= (in-some-interval $ints $t)
+   (if (== $ints ()) False
+       (let ($s $e) (car-atom $ints)
+         (if (and (== (tp<= $s $t) True) (== (tp< $t $e) True))
+             True
+             (in-some-interval (cdr-atom $ints) $t)))))
+
+; --- public queries (fluent given as a deontic s-expr, e.g. (must pay)) --------
+(= (ec-intervals $path $m)
+   (let* (($_ (dl-load $path)) ($f (mm_dlit $m))) (fluent-intervals $f)))
+(= (ec-holds-at $path $m $t)
+   (let* (($_ (dl-load $path)) ($f (mm_dlit $m)))
+     (in-some-interval (fluent-intervals $f) $t)))
+; a violation = the obligation is still in force at its deadline
+(= (ec-violated-at $path $m $d) (ec-holds-at $path $m $d))
+
+; --- timeline: MeTTa builds structured rows; Prolog formats the table ----------
+; row = (LitString IntervalsList StatusSymbol); Prolog renders intervals + status.
+(= (ec-fluents) (unique-atom (collapse (match &theory (ec_init $e $f) $f))))
+(= (timeline-row $f $now)
+   (let* (($ints (fluent-intervals $f))
+          ($held (in-some-interval $ints $now)))
+     ((mm_lit_str $f) $ints (if (== $held True) active inactive))))
+(= (ec-timeline $path $now)
+   (let $_ (dl-load $path)
+     (mm_print_timeline2 $now (map-atom (ec-fluents) $f (timeline-row $f $now)))))

--- a/src/deontic/explain.metta
+++ b/src/deontic/explain.metta
@@ -1,0 +1,49 @@
+; Proof-tree extraction: reconstruct WHY a literal is (un)provable as a tree of
+; rule applications over sub-goals — the justification that deontic verdicts and
+; weakest-link trust both fold over.
+;
+; (explain <lit>) over the current reasoned state:
+;   (proof <lit> (fact <label>))                      fact leaf
+;   (proof <lit> (rule <label> (<sub-proofs...>)))    rule application
+;   (no-proof <lit>)                                  not positively provable
+; Attribution is deterministic: the lexicographically smallest applicable
+; supporting rule (a stable tie-break when several rules support a literal).
+
+(= (explain $lit) (explain-v $lit ()))
+
+(= (explain-v $lit $seen)
+   (if (== (is-member $lit $seen) True)
+       (cycle $lit)
+       (if (== (pos? $lit) True)
+           (let $sup (best-supporter $lit)
+             (if (== $sup ())
+                 (no-proof $lit)
+                 (let ($l $k $b) $sup
+                   (if (== $k fact)
+                       (proof $lit (fact $l))
+                       (proof $lit (rule $l (explain-body $b (cons-atom $lit $seen))))))))
+           (no-proof $lit))))
+
+(= (explain-body $b $seen)
+   (map-atom $b $x (explain-v $x $seen)))
+
+; Smallest-label applicable supporter at the strongest level available:
+; definite supporters (fact/strict with +D bodies) win over defeasible ones.
+(= (best-supporter $lit)
+   (let $def (applicable-supporters $lit def)
+     (if (not (== $def ()))
+         (car-atom (sort-atom $def))
+         (let $sd (applicable-supporters $lit dft)
+           (if (== $sd ()) () (car-atom (sort-atom $sd)))))))
+
+(= (applicable-supporters $lit def)
+   (collapse (match &ground (grule $l $k $b $lit)
+     (if (and (== (def-kind? $k) True) (== (body-all-defp $b) True))
+         ($l $k $b)
+         (empty)))))
+
+(= (applicable-supporters $lit dft)
+   (collapse (match &ground (grule $l $k $b $lit)
+     (if (and (== (sd-kind? $k) True) (== (body-all-pd $b) True))
+         ($l $k $b)
+         (empty)))))

--- a/src/deontic/ground.metta
+++ b/src/deontic/ground.metta
@@ -73,3 +73,142 @@
 (= (ground-pass) (foldall + (ground-instances) 0))
 
 (= (ground!) (if (> (ground-pass) 0) (ground!) ()))
+
+; =====================================================================
+; Semi-naive grounding (the fast path). Instead of re-joining every rule against
+; the whole herbrand base on each pass, join one body literal against the FRONTIER
+; (&herb_new = heads added last round) and the rest against the full base. A rule
+; can only yield a NEW instance if a body atom is new, so stable instances are
+; never re-derived — same ground set as ground!, far fewer derivation attempts.
+;
+; Perf (measured): this is the native engine's grounder. It produces the IDENTICAL
+; ground set as the Prolog kernel (grounding.pl) but runs ~4-5x slower on
+; grounding-heavy theories (≈3000 instances: ~1.5s native vs ~0.3s prolog). The
+; gap is per-operation MeTTa-eval overhead — each derived instance is ~6
+; match/check/add round-trips — not the algorithm. Semi-naive (here) cuts the
+; number of derivation attempts; functor-keying the herbrand base to index the
+; join was also measured and was SLOWER (keying overhead, no scan win). Neither
+; shrinks the per-op constant, so prolog stays the default for variable-rule-heavy
+; theories; native grounding is for propositional plans (grounding is trivial)
+; and inspection.
+; =====================================================================
+
+; gb-sn: ground bodies of $b that use >=1 frontier literal — the pivot matches
+; &herb_new, the others match the base. Constraints evaluate and drop (logic-only
+; output, as in ground-body). Superpose over pivot position. Output is stored
+; reversed: order is irrelevant to the reasoner (body-all-pd folds over it) and
+; processing stays left-to-right so interval/arith bindings still flow in order.
+(= (gb-sn $b) (gb-scan () $b))
+
+; a body item is a logic literal (matches atoms) vs a constraint (evaluated).
+(= (is-logic-lit (lit $s $m $t $f $a)) True)
+(= (is-logic-lit (acmp $o $l $r)) False)
+(= (is-logic-lit (tcmp $o $l $r)) False)
+(= (is-logic-lit (abind $v $x)) False)
+; does the remaining body still hold a logic literal (a later pivot slot)?
+(= (has-logic-lit $b)
+   (if (== $b ()) False
+       (let ($x $rest) (decons-atom $b)
+         (if (== (is-logic-lit $x) True) True (has-logic-lit $rest)))))
+
+; pre-pivot: each logic literal may BE the pivot (frontier) or ground on the base
+; while scanning continues to its right; constraints evaluate and drop.
+(= (gb-scan $acc $rem)
+   (if (== $rem ())
+       (empty)
+       (let ($x $rest) (decons-atom $rem)
+         (gb-scan-item $x $acc $rest))))
+; the LAST logic literal can only be the pivot (matching the base here would just
+; re-derive a delta-free, already-known instance) — so single-literal rules join
+; the small frontier directly, never the full base.
+(= (gb-scan-item (lit $s $m $tv $f $a) $acc $rest)
+   (if (== (has-logic-lit $rest) True)
+       (superpose ((gb-pivot (lit $s $m $tv $f $a) $acc $rest)
+                   (gb-base  (lit $s $m $tv $f $a) $acc $rest)))
+       (gb-pivot (lit $s $m $tv $f $a) $acc $rest)))
+(= (gb-scan-item (acmp $op $l $r) $acc $rest)
+   (if (== (mm_acmp $op $l $r) true) (gb-scan $acc $rest) (empty)))
+(= (gb-scan-item (tcmp $op $l $r) $acc $rest)
+   (if (== (mm_tcmp $op $l $r) true) (gb-scan $acc $rest) (empty)))
+(= (gb-scan-item (abind $v $ax) $acc $rest)
+   (let $v (mm_arith_eval $ax) (gb-scan $acc $rest)))
+
+; pivot: match the literal on the frontier, then ground the suffix on the base.
+(= (gb-pivot (lit $s $m none $f $a) $acc $rest)
+   (match &herb_new (ha (lit $s $m $ht $f $a))
+     (gb-suffix (cons-atom (lit $s $m $ht $f $a) $acc) $rest)))
+(= (gb-pivot (lit $s $m (iv $ts $te) $f $a) $acc $rest)
+   (match &herb_new (ha (lit $s $m (iv $ts $te) $f $a))
+     (gb-suffix (cons-atom (lit $s $m (iv $ts $te) $f $a) $acc) $rest)))
+
+; pre-pivot base match: keep seeking the pivot to the right.
+(= (gb-base (lit $s $m none $f $a) $acc $rest)
+   (match &herb (ha (lit $s $m $ht $f $a))
+     (gb-scan (cons-atom (lit $s $m $ht $f $a) $acc) $rest)))
+(= (gb-base (lit $s $m (iv $ts $te) $f $a) $acc $rest)
+   (match &herb (ha (lit $s $m (iv $ts $te) $f $a))
+     (gb-scan (cons-atom (lit $s $m (iv $ts $te) $f $a) $acc) $rest)))
+
+; suffix: pivot already taken; ground remaining items on the base only.
+(= (gb-suffix $acc $rem)
+   (if (== $rem ())
+       $acc
+       (let ($x $rest) (decons-atom $rem)
+         (gb-suffix-item $x $acc $rest))))
+(= (gb-suffix-item (lit $s $m none $f $a) $acc $rest)
+   (match &herb (ha (lit $s $m $ht $f $a))
+     (gb-suffix (cons-atom (lit $s $m $ht $f $a) $acc) $rest)))
+(= (gb-suffix-item (lit $s $m (iv $ts $te) $f $a) $acc $rest)
+   (match &herb (ha (lit $s $m (iv $ts $te) $f $a))
+     (gb-suffix (cons-atom (lit $s $m (iv $ts $te) $f $a) $acc) $rest)))
+(= (gb-suffix-item (acmp $op $l $r) $acc $rest)
+   (if (== (mm_acmp $op $l $r) true) (gb-suffix $acc $rest) (empty)))
+(= (gb-suffix-item (tcmp $op $l $r) $acc $rest)
+   (if (== (mm_tcmp $op $l $r) true) (gb-suffix $acc $rest) (empty)))
+(= (gb-suffix-item (abind $v $ax) $acc $rest)
+   (let $v (mm_arith_eval $ax) (gb-suffix $acc $rest)))
+
+; add a new instance; a new head feeds both the base and the NEXT frontier.
+(= (grule-add-sn $l $k $b $h)
+   (if (== () (collapse (match &ground (grule $l $k $b $h) yes)))
+       (let* (($_1 (add-atom &ground (grule $l $k $b $h)))
+              ($_2 (herb-add-sn $h))
+              ($_3 (ulit-add $h))
+              ($_4 (ulits-add $b)))
+         1)
+       0))
+(= (herb-add-sn $h)
+   (if (== () (collapse (match &herb (ha $h) yes)))
+       (let* (($_1 (add-atom &herb (ha $h)))
+              ($_2 (add-atom &herb_next (ha $h))))
+         ())
+       ()))
+
+; one round: instantiate every rule against the current frontier.
+(= (ground-sn-instances)
+   (match &theory (rule $l $k $b $h)
+     (let $gb (gb-sn $b)
+       (if (== (is-ground ($gb $h)) true)
+           (grule-add-sn $l $k $gb $h)
+           (empty)))))
+
+; copy a (ha ...) space into the frontier &herb_new (clearing it first).
+(= (frontier-load $from)
+   (let* (($_c (mm_clear_space &herb_new))
+          ($_m (collapse (match $from (ha $h) (add-atom &herb_new (ha $h))))))
+     ()))
+
+(= (ground-sn-round)
+   (let* (($_clr (mm_clear_space &herb_next))
+          ($n    (foldall + (ground-sn-instances) 0))
+          ($_swp (frontier-load &herb_next)))
+     $n))
+
+(= (ground-sn-loop!)
+   (let $n (ground-sn-round) (if (> $n 0) (ground-sn-loop!) ())))
+
+; entry: seed the frontier with the whole initial base, iterate to fixpoint.
+(= (ground-sn!)
+   (let* (($_1 (frontier-load &herb))
+          ($_2 (ground-sn-loop!)))
+     ()))

--- a/src/deontic/ground.metta
+++ b/src/deontic/ground.metta
@@ -1,0 +1,75 @@
+; Grounding: instantiate variable rules over the Herbrand base by Datalog-style
+; conjunctive matching, so the propositional DL(d) engine only sees ground rules.
+;
+; Var rules live in &theory with real Prolog variables (the platform loader
+; converted ?x). Retrieving a rule atom from the space yields a fresh copy,
+; so matching its body literals against the herbrand space (&herb) performs
+; the substitution natively; arithmetic constraints are evaluated inline and
+; dropped from the instantiated body, leaving logic-only ground instances.
+;
+; The herbrand space grows with every new ground head (bottom-up fixpoint
+; over derivable atoms), and every new instance registers its literals in
+; the reporting universe.
+
+; Instantiate one body: nondeterministic over substitutions.
+(= (ground-body $b)
+   (if (== $b ())
+       ()
+       (let ($x $rest) (decons-atom $b)
+         (gb-item $x $rest))))
+
+; Logic literal: match against herbrand atoms (same sign/mode/functor/args),
+; binding any variables. Temporal uses a base-family wildcard:
+;   - body temporal `none` matches ANY temporal variant of the atom; the ground
+;     body literal carries the herbrand atom's actual temporal ($ht), so the
+;     reasoner's status lookups align with the concrete fact.
+;   - body temporal `(iv ?s ?e)` unifies with the herbrand interval, BINDING the
+;     endpoint vars natively — those bindings flow to later Allen constraints.
+(= (gb-item (lit $s $m none $f $a) $rest)
+   (match &herb (ha (lit $s $m $ht $f $a))
+     (cons-atom (lit $s $m $ht $f $a) (ground-body $rest))))
+(= (gb-item (lit $s $m (iv $ts $te) $f $a) $rest)
+   (match &herb (ha (lit $s $m (iv $ts $te) $f $a))
+     (cons-atom (lit $s $m (iv $ts $te) $f $a) (ground-body $rest))))
+
+(= (gb-item (acmp $op $l $r) $rest)
+   (if (== (mm_acmp $op $l $r) true)
+       (ground-body $rest)
+       (empty)))
+
+(= (gb-item (tcmp $op $l $r) $rest)
+   (if (== (mm_tcmp $op $l $r) true)
+       (ground-body $rest)
+       (empty)))
+
+(= (gb-item (abind $v $ax) $rest)
+   (let $v (mm_arith_eval $ax)
+     (ground-body $rest)))
+
+; Add a ground instance if new; feeds the herbrand base and the universe.
+(= (grule-add $l $k $b $h)
+   (if (== () (collapse (match &ground (grule $l $k $b $h) yes)))
+       (let* (($_1 (add-atom &ground (grule $l $k $b $h)))
+              ($_2 (herb-add $h))
+              ($_3 (ulit-add $h))
+              ($_4 (ulits-add $b)))
+         1)
+       0))
+
+(= (herb-add $h)
+   (if (== () (collapse (match &herb (ha $h) yes)))
+       (let $_ (add-atom &herb (ha $h)) ())
+       ()))
+
+; One pass: try to instantiate every theory rule against the current herbrand
+; base; returns the number of NEW ground instances added.
+(= (ground-instances)
+   (match &theory (rule $l $k $b $h)
+     (let $gb (ground-body $b)
+       (if (== (is-ground ($gb $h)) true)
+           (grule-add $l $k $gb $h)
+           (empty)))))
+
+(= (ground-pass) (foldall + (ground-instances) 0))
+
+(= (ground!) (if (> (ground-pass) 0) (ground!) ()))

--- a/src/deontic/platform/deontic.pl
+++ b/src/deontic/platform/deontic.pl
@@ -1,0 +1,98 @@
+% Optional Standard Deontic Logic (SDL) inference layer (beyond plain defeasible
+% logic).
+%
+% The base Defeasible Logic carries deontic modes O/P/F on literals but does not
+% infer with them. This module adds the Standard Deontic Logic bridges so
+% obligations, permissions and prohibitions interact (Governatori's defeasible
+% deontic logic). The canonical SDL relationships:
+%
+%   im p = ob ¬p   ->   F p ≡ O ¬p     (forbidden = obligatory-not)
+%   pe p = ¬ob ¬p  ->   O p → P p      ("ought implies may", under the D axiom)
+%
+% DEFEASIBLE INTERACTION: the equivalences are injected as parallel grules that
+% reuse the SOURCE RULE'S LABEL, kind, and body — not fresh strict rules. Because
+% the DL(d) engine keys superiority and applicability by rule LABEL, a deontic
+% consequence then inherits the source rule's strength and superiorities. So two
+% defeasible rules concluding conflicting deontic literals (O p from r1, F p from
+% r2) resolve under `prefer r1 r2` exactly like an ordinary p/¬p conflict: F p is
+% rewritten to O¬p under r2, O p (r1) attacks O¬p (r2), and r1 > r2 decides it.
+% Deontic CONFLICT thus falls out of the normal sign-complement defeat machinery.
+%
+% Runs to a fixpoint (a bridged head can trigger further bridges) and registers
+% new heads in the universe. OPT-IN: the default reason path never calls this, so
+% plain defeasible reasoning is left completely untouched.
+
+mm_deontic_bridge(GS, HS, SS, true) :- once(mm_deo_fix(GS, HS, SS)).
+
+mm_deo_fix(GS, HS, SS) :-
+    findall(rule(L, OK, B, Head),
+      ( mm_deo_q(GS, [grule, L, K, B, H]), mm_deo_rule(K, H, OK, Head),
+        \+ mm_deo_q(GS, [grule, L, OK, B, Head]) ),
+      New),
+    ( New == [] -> true
+    ; forall(member(rule(L, OK, B, Head), New), mm_deo_emit(GS, HS, SS, L, OK, B, Head)),
+      mm_deo_fix(GS, HS, SS) ).
+
+mm_deo_q(Sp, [R|As]) :- G =.. [Sp, R | As], catch(call(G), _, fail).
+
+% (InKind, Head) -> (OutKind, NewHead). Sign flip = proposition ¬.
+%   F p ⊢ O ¬p   ;   O p ⊢ F ¬p   (the F↔O equivalence) ;   O p ⊢ P p   (same kind)
+%   STRONG PERMISSION: P p emits a DEFEATER concluding O p, which blocks the
+%   contrary prohibition O ¬p (= F p) without proving the obligation — an explicit
+%   permission undercuts a defeasible prohibition (beaten only by a superior one).
+% F↔O equivalence applies to every kind (so a permission's defeater blocks the
+% prohibition in BOTH its F and O¬ forms; terminates via dedup):
+mm_deo_rule(K, [lit, S, 'F', T, F, A], K, [lit, Sn, 'O', T, F, A]) :- mm_deo_flip(S, Sn).
+mm_deo_rule(K, [lit, S, 'O', T, F, A], K, [lit, Sn, 'F', T, F, A]) :- mm_deo_flip(S, Sn).
+% O→P and P→defeater(O) only from genuine (non-defeater) duties:
+mm_deo_rule(K, [lit, S, 'O', T, F, A], K, [lit, S, 'P', T, F, A]) :- K \== defeater.
+mm_deo_rule(K, [lit, S, 'P', T, F, A], defeater, [lit, S, 'O', T, F, A]) :- K \== defeater.
+
+mm_deo_flip(pos, neg).
+mm_deo_flip(neg, pos).
+
+% Inject the equivalent grule under the SAME label/kind/body, and register its
+% head (and any body literals) in the universe + Herbrand base for the reasoner.
+mm_deo_emit(GS, HS, SS, L, K, B, Head) :-
+    ( mm_deo_q(GS, [grule, L, K, B, Head]) -> true
+    ; G =.. [GS, grule, L, K, B, Head], assertz(G),
+      mm_deo_reg(HS, [ha, Head]),
+      mm_deo_reg(SS, [ulit, Head]),
+      forall(member(Bl, B), mm_deo_reg(SS, [ulit, Bl])) ).
+
+mm_deo_reg(Sp, [R|As]) :- G =.. [Sp, R | As], ( catch(call(G), _, fail) -> true ; assertz(G) ).
+
+% (compliance/dilemma AND deadline compliance LOGIC now live in idiomatic MeTTa —
+%  src/deontic/deontic.metta. This module keeps the grule-level SDL bridge + thin
+%  report formatters. Deadline metadata is stored at ingest as [deadlineinfo Sgn
+%  Mode F A Type St En Sanc] in &st; the MeTTa layer reads it via match.)
+
+% deadline report formatter. Rows = [[LitWindowStr, Type, Status, Sanc], ...]
+mm_print_deadlines2(Now, Rows, true) :-
+    once(( with_output_to(string(O), (
+             format("Deadline Compliance (now=~w)~n", [Now]),
+             format("===========================~n", []),
+             ( Rows == [] -> format("  (no deadline obligations)~n", [])
+             ; forall(member([L, Type, St, Sanc], Rows),
+                 ( ( St == violated, Sanc \== none )
+                   -> format("  ~w (~w): ~w  -> sanction OBL ~w~n", [L, Type, St, Sanc])
+                   ;  format("  ~w (~w): ~w~n", [L, Type, St]) )) ) )),
+           write(O) )).
+
+% --- thin report formatters (LOGIC lives in src/deontic/deontic.metta; these only
+%     format pre-computed results, like format/2 over a MeTTa-built list) ---------
+mm_print_verdicts(Title, Vs, true) :-
+    once(( with_output_to(string(O), (
+             format("~w~n", [Title]), string_length(Title, N), forall(between(1, N, _), write("=")), nl,
+             ( Vs == [] -> format("  (none)~n", [])
+             ; forall(member([L, S], Vs), format("  ~w: ~w~n", [L, S])) ) )),
+           write(O) )).
+
+mm_print_dilemmas2(Ls, true) :-
+    once(( with_output_to(string(O), (
+             format("Deontic Dilemmas~n================~n", []),
+             ( Ls == [] -> format("  none~n", [])
+             ; forall(member([lit, _, _, T, F, A], Ls),
+                 ( mm_lit_str([lit, pos, none, T, F, A], P),
+                   format("  dilemma: O ~w vs O ~~~w  (unresolved — add a superiority)~n", [P, P]) )) ) )),
+           write(O) )).

--- a/src/deontic/platform/directive.pl
+++ b/src/deontic/platform/directive.pl
@@ -1,0 +1,209 @@
+%%% Task-coordination kernel: literal-name conventions, version scanning, and
+%%% chain-cancellation block generation ('-' separator format) for the
+%%% claim/unclaim/block/unblock/complete lifecycle.
+%%% All exported predicates are deterministic (once/1).
+
+%% ---- name helpers ----
+
+% strip leading task- / task_ if present
+dir_strip_task(Raw, Task) :-
+    once(( ( atom_concat('task-', T, Raw) ; atom_concat('task_', T, Raw) )
+           -> Task = T ; Task = Raw )).
+
+% compose PREFIX-TASK
+dir_lit(Prefix, Task, Lit) :- once(atomic_list_concat([Prefix, '-', Task], Lit)).
+
+% decompose NAME into Prefix-Task (accepts - or _ separator); fails cleanly -> 'nil
+dir_prefix_task(Name, Prefix, Task) :-
+    once(( ( atom_concat(Prefix, Rest, Name),
+             ( atom_concat('-', T, Rest) ; atom_concat('_', T, Rest) ) )
+           -> Task = T ; Task = nil )).
+
+% parse an assignment name with context: returns [Task, Agent] or nil
+dir_parse_assignment(Name, KnownTasks, Out) :-
+    once(dir_parse_assignment_(Name, KnownTasks, Out)).
+dir_parse_assignment_(Name, Known, Out) :-
+    ( atom_concat('assignTo_', Rest, Name)
+      -> atomic_list_concat(Segs, '_', Rest),
+         ( Segs = [_,_|_] -> append(TaskSegs, [Agent], Segs),
+                             atomic_list_concat(TaskSegs, '_', Task),
+                             Out = [Task, Agent]
+         ; Segs = [T] -> Out = [T, '']
+         ; Out = nil )
+    ; atom_concat('assign-to-', Rest, Name) -> dir_kebab_assignment(Rest, Known, Out)
+    ; atom_concat('assign-', Rest, Name)    -> dir_kebab_assignment(Rest, Known, Out)
+    ; Out = nil ).
+
+dir_kebab_assignment(Rest, Known, Out) :-
+    ( is_list(Known), Known \= [],
+      findall(L-T, ( member(T, Known), atom(T),
+                     atom_concat(T, Suffix, Rest), atom_concat('-', _, Suffix),
+                     atom_length(T, L) ), Cands0),
+      sort(0, @>=, Cands0, [_-Task|_])
+      -> atom_concat(Task, Suffix1, Rest), atom_concat('-', Agent, Suffix1),
+         Agent \= '', Out = [Task, Agent]
+    ;  atomic_list_concat(Segs, '-', Rest),
+       ( Segs = [_,_|_] -> append(TaskSegs, [Agent], Segs),
+                           atomic_list_concat(TaskSegs, '-', Task),
+                           Out = [Task, Agent]
+       ; Segs = [T] -> Out = [T, '']
+       ; Out = nil ) ).
+
+%% ---- version scanning (find_versions) ----
+%% Names: list of positive literal-name atoms.
+%% Out = [MaxVer, Last, MaxActionVer, MaxCounterVer]; Last in {action, counter, none}
+dir_find_versions(Names, Action, Counter, Task, Out) :-
+    once(( findall(V, ( member(N, Names), dir_ver_of(N, Action, Task, V) ), AVs),
+           findall(V, ( member(N, Names), dir_ver_of(N, Counter, Task, V) ), CVs),
+           max_list([0|AVs], MA), max_list([0|CVs], MC),
+           MaxVer is max(MA, MC),
+           ( MaxVer =:= 0 -> Last = none
+           ; MA >= MC -> Last = action
+           ; Last = counter ),
+           Out = [MaxVer, Last, MA, MC] )).
+
+% NAME =?= ACTION-vN-TASK
+dir_ver_of(Name, Action, Task, V) :-
+    atom_concat(Action, Rest0, Name),
+    atom_concat('-v', Rest1, Rest0),
+    atom_concat(VA, Rest2, Rest1),
+    atom_concat('-', Task, Rest2),
+    atom_number(VA, V), integer(V), V >= 0.
+
+%% ---- chain-cancellation block generation ----
+
+dir_label_prefix(claim, 'cl-'). dir_label_prefix(unclaim, 'ucl-').
+dir_label_prefix(block, 'bl-'). dir_label_prefix(unblock, 'ubl-').
+dir_label_prefix(_, '').
+
+% generate_action_block; PrevCounterVer = -1 when none.
+dir_action_block(Agent, Ts, Task, NewVer, PrevCounterVer,
+              Action, State, CounterState, CounterAction, Block) :-
+    once(( dir_label_prefix(Action, P), dir_label_prefix(CounterAction, CP),
+           format(string(Hdr), "~n(claims agent:~w~n  :at \"~w\"", [Agent, Ts]),
+           format(string(L1), "~n  (given ~w-v~w-~w)", [Action, NewVer, Task]),
+           format(string(L2), "~n  (normally r-~wstate-v~w-~w ~w-v~w-~w state-~w-v~w-~w)",
+                  [P, NewVer, Task, Action, NewVer, Task, State, NewVer, Task]),
+           format(string(L3), "~n  (normally r-~wchain-v~w-~w state-~w-v~w-~w ~w-~w)",
+                  [P, NewVer, Task, State, NewVer, Task, State, Task]),
+           ( PrevCounterVer >= 0
+             -> format(string(L4), "~n  (normally r-~wcancel-v~w-~w ~w-v~w-~w (not state-~w-v~w-~w))",
+                       [P, PrevCounterVer, Task, Action, NewVer, Task, CounterState, PrevCounterVer, Task]),
+                format(string(L5), "~n  (prefer r-~wcancel-v~w-~w r-~wstate-v~w-~w)",
+                       [P, PrevCounterVer, Task, CP, PrevCounterVer, Task]),
+                format(string(L6), "~n  (prefer r-~wchain-v~w-~w r-~w~w-v~w-~w)",
+                       [P, NewVer, Task, CP, CounterState, PrevCounterVer, Task]),
+                Tail = [L4, L5, L6]
+             ;  Tail = [] ),
+           append([[Hdr, L1, L2, L3], Tail, [")\n"]], Parts),
+           atomics_to_string(Parts, Block) )).
+
+% generate_counter_block; PrevActionVer = -1 when none.
+dir_counter_block(Agent, Ts, Task, NewVer, PrevActionVer,
+               Counter, CounterState, ActionState, NegLit, Action, Block) :-
+    once(( dir_label_prefix(Counter, CP), dir_label_prefix(Action, P),
+           format(string(Hdr), "~n(claims agent:~w~n  :at \"~w\"", [Agent, Ts]),
+           format(string(L1), "~n  (given ~w-v~w-~w)", [Counter, NewVer, Task]),
+           format(string(L2), "~n  (normally r-~wstate-v~w-~w ~w-v~w-~w state-~w-v~w-~w)",
+                  [CP, NewVer, Task, Counter, NewVer, Task, CounterState, NewVer, Task]),
+           ( PrevActionVer >= 0
+             -> format(string(L3), "~n  (normally r-~wcancel-v~w-~w ~w-v~w-~w (not state-~w-v~w-~w))",
+                       [CP, PrevActionVer, Task, Counter, NewVer, Task, ActionState, PrevActionVer, Task]),
+                format(string(L4), "~n  (prefer r-~wcancel-v~w-~w r-~wstate-v~w-~w)",
+                       [CP, PrevActionVer, Task, P, PrevActionVer, Task]),
+                Mid = [L3, L4]
+             ;  Mid = [] ),
+           format(string(L5), "~n  (normally r-~w~w-v~w-~w ~w-v~w-~w (not ~w-~w))",
+                  [CP, CounterState, NewVer, Task, Counter, NewVer, Task, NegLit, Task]),
+           ( PrevActionVer >= 0
+             -> format(string(L6), "~n  (prefer r-~w~w-v~w-~w r-~wchain-v~w-~w)",
+                       [CP, CounterState, NewVer, Task, P, PrevActionVer, Task]),
+                Tail = [L6]
+             ;  Tail = [] ),
+           append([[Hdr, L1, L2], Mid, [L5], Tail, [")\n"]], Parts),
+           atomics_to_string(Parts, Block) )).
+
+% completion claims block
+dir_complete_block(Agent, Ts, Task, Block) :-
+    once(format(string(Block),
+        "~n(claims agent:~w~n  :at \"~w\"~n  (given completed-~w))~n",
+        [Agent, Ts, Task])).
+
+% wrap MeTTa text in an attributed claims block
+dir_assert_block(Agent, Ts, FormText, Block) :-
+    once(format(string(Block),
+        "~n(claims agent:~w~n  :at \"~w\"~n  ~w)~n",
+        [Agent, Ts, FormText])).
+
+%% ---- failure propagation (generate_propagation_rules) ----
+%% Scans the theory space for readiness rules:
+%%   (rule _ _ Body [lit,pos,ready-T,_]) with [lit,pos,completed-D,_] in Body
+%% reverse map: D -> dependents Ts. Emits one block of propagation rules so that
+%% a failure in an upstream task blocks its downstream dependents (transitively).
+
+dir_reverse_deps(TheorySp, Reverse) :-
+    findall(Dep-T,
+            ( call_sexp_h(TheorySp, [rule, _, Kind, Body, [lit, pos, _, _, Head, _]]),
+              Kind \= fact,
+              dir_prefix_task(Head, ready, T), T \= nil,
+              member([lit, pos, _, _, BL, _], Body),
+              dir_prefix_task(BL, completed, Dep), Dep \= nil ),
+            Pairs0),
+    sort(Pairs0, Pairs),
+    findall(D-Ts, ( member(D-_, Pairs), \+ (member(D2-_, Pairs), D2 == D, fail),
+                    findall(T, member(D-T, Pairs), Ts0), sort(Ts0, Ts) ), Rev0),
+    sort(Rev0, Reverse).
+
+call_sexp_h(Space, [Rel|Args]) :- Term =.. [Space, Rel|Args], catch(Term, _, fail).
+
+dir_existing_labels(TheorySp, Labels) :-
+    findall(L, call_sexp_h(TheorySp, [rule, L, _, _, _]), Ls),
+    sort(Ls, Labels).
+
+dir_propagation_block(TheorySp, Task, Ver, Block) :-
+    once(( dir_reverse_deps(TheorySp, Reverse),
+           ( member(Task-Dependents, Reverse)
+             -> dir_existing_labels(TheorySp, Existing),
+                format(string(Hd), "~n;; Propagation rules: failures in '~w' block downstream tasks~n", [Task]),
+                findall(S, ( member(Dep, Dependents),
+                             dir_prop_lines(Task, Dep, Ver, Existing, S) ), Per),
+                dir_transitive_lines(Reverse, Task, Dependents, Existing, TransLines),
+                append([[Hd], Per, TransLines], Parts),
+                atomics_to_string(Parts, Block)
+             ;  Block = "" ) )).
+
+dir_prop_lines(Task, Dep, Ver, Existing, S) :-
+    format(atom(L1l), "r-propagate-~w-from-~w-failed", [Dep, Task]),
+    ( memberchk(L1l, Existing) -> S1 = ""
+    ; format(string(S1), "(normally ~w failed-~w upstream-blocked-~w)~n", [L1l, Task, Dep]) ),
+    format(atom(L2l), "r-propagate-~w-from-~w-permanently-failed", [Dep, Task]),
+    ( memberchk(L2l, Existing) -> S2 = ""
+    ; format(string(S2), "(normally ~w permanently-failed-~w upstream-blocked-~w)~n", [L2l, Task, Dep]) ),
+    format(string(S3), "(normally r-propagate-~w-from-~w-stale-v~w stale-v~w-~w upstream-blocked-~w)~n",
+           [Dep, Task, Ver, Ver, Task, Dep]),
+    format(string(S4), "(normally r-propagate-~w-from-~w-timeout-v~w timeout-v~w-~w upstream-blocked-~w)~n",
+           [Dep, Task, Ver, Ver, Task, Dep]),
+    format(atom(L5l), "r-propagate-~w-from-~w-blocked", [Dep, Task]),
+    ( memberchk(L5l, Existing) -> S5 = ""
+    ; format(string(S5), "(normally ~w upstream-blocked-~w upstream-blocked-~w)~n", [L5l, Task, Dep]) ),
+    atomics_to_string([S1, S2, S3, S4, S5], S).
+
+dir_transitive_lines(Reverse, Task, Direct, Existing, Lines) :-
+    dir_bfs(Reverse, Direct, [Task|Direct], Existing, [], Lines0),
+    ( Lines0 == [] -> Lines = []
+    ; format(string(THdr), "~n;; Transitive propagation: upstream-blocked cascades through dependency chain~n", []),
+      Lines = [THdr | Lines0] ).
+
+dir_bfs(_, [], _, _, Acc, Lines) :- reverse(Acc, Lines).
+dir_bfs(Reverse, [Cur|Queue], Visited, Existing, Acc, Lines) :-
+    ( member(Cur-NextDeps, Reverse) -> true ; NextDeps = [] ),
+    foldl(dir_bfs_edge(Cur, Existing), NextDeps, Acc-Queue-Visited, Acc1-Queue1-Visited1),
+    dir_bfs(Reverse, Queue1, Visited1, Existing, Acc1, Lines).
+
+dir_bfs_edge(Cur, Existing, Next, Acc-Q-V, Acc1-Q1-V1) :-
+    format(atom(Lbl), "r-propagate-~w-from-~w-blocked", [Next, Cur]),
+    ( memberchk(Lbl, Existing)
+      -> Acc1 = Acc
+      ;  format(string(S), "(normally ~w upstream-blocked-~w upstream-blocked-~w)~n", [Lbl, Cur, Next]),
+         Acc1 = [S|Acc] ),
+    ( memberchk(Next, V) -> Q1 = Q, V1 = V ; append(Q, [Next], Q1), V1 = [Next|V] ).

--- a/src/deontic/platform/eventcalc.pl
+++ b/src/deontic/platform/eventcalc.pl
@@ -1,0 +1,27 @@
+% Event-Calculus support primitives. The EC engine (interval amalgamation,
+% holdsAt, violation) now lives in idiomatic MeTTa — src/deontic/eventcalc.metta.
+% Prolog provides only: parsing a deontic-literal s-expr to the 6-slot lit, and
+% the timeline table formatter (MeTTa builds the structured rows).
+
+% parse a deontic-literal s-expr (e.g. (must pay)) to the 6-slot lit (mm_lit in io.pl)
+mm_dlit(M, Lit) :- once(mm_lit(M, Lit)).
+
+% Render the obligation timeline. Rows = [[LitStr, Intervals, StatusSym], ...]
+% with Intervals = [[S,E], ...] (E may be the atom inf) and Status active|inactive.
+mm_print_timeline2(Now, Rows, true) :-
+    once(( with_output_to(string(O), (
+             format("Obligation Timeline (now=~w)~n", [Now]),
+             format("===========================~n", []),
+             ( Rows == [] -> format("  (no event-driven obligations)~n", [])
+             ; forall(member([L, Ints, St], Rows),
+                 ( mm_ec_ivs(Ints, IvS), mm_ec_stat(St, StS),
+                   format("  ~w: ~w  [~w]~n", [L, IvS, StS]) )) ) )),
+           write(O) )).
+
+mm_ec_ivs([], "never in force").
+mm_ec_ivs([I|Is], S) :- maplist(mm_ec_iv, [I|Is], Ss), atomic_list_concat(Ss, ", ", S).
+mm_ec_iv([Sa, inf], A) :- !, format(atom(A), "[~w,inf)", [Sa]).
+mm_ec_iv([Sa, E], A) :- format(atom(A), "[~w,~w)", [Sa, E]).
+
+mm_ec_stat(active, "in force (undischarged)") :- !.
+mm_ec_stat(_, "discharged/inactive").

--- a/src/deontic/platform/grounding.pl
+++ b/src/deontic/platform/grounding.pl
@@ -1,0 +1,181 @@
+%%% Fast Datalog grounding (replaces the naive MeTTa fixpoint).
+%%%
+%%% The naive bottom-up grounding in ground.metta re-grounds every rule each
+%%% pass and dedups with an O(existing) space scan, so transitive closure goes
+%%% O(N^4) (anc100 ~ 36s). This computes the SAME ground instances by:
+%%%   1. computing the Herbrand base ONCE with a TABLED least-fixpoint (mm_hb/1);
+%%%   2. MATERIALIZING it into mm_hbf/5, keyed on the literal's functor so SWI
+%%%      first-argument indexing makes body joins O(1) per probe (the list
+%%%      representation [lit,...] is opaque to indexing, hence the projection);
+%%%   3. emitting instances by indexed join, with term_hash O(1) dedup.
+%%% Semantics are identical to the naive ground.metta fixpoint — same set of
+%%% ground rule instances, just computed far more cheaply.
+%%%
+%%% Contract: mm_ground(TheorySp, GroundSp, HerbSp, StatSp, true), called AFTER
+%%% the plan is ingested. The space anchors are stashed in module globals so the tabled
+%%% mm_hb/1 keys only on the literal (avoids per-call-pattern table variants).
+
+:- dynamic mm_seen_g/1, mm_hbf/5, mm_g_ts/1, mm_g_hs/1.
+% incremental (append-only) grounding state — kept alive between delta calls:
+%   mm_rule_done/1  term_hash of a rule already joined against the base
+%   mm_delta/5      current frontier of new base atoms (semi-naive)
+%   mm_newdelta/5   atoms derived this round (next frontier)
+:- dynamic mm_rule_done/1, mm_delta/5, mm_newdelta/5.
+
+% --- tabled Herbrand base (least fixpoint over the theory's rules) ---------
+:- table mm_hb/1.
+mm_hb(Lit)  :- mm_g_hs(HS), mm_call_space(HS, [ha, Lit]).        % ground seeds
+mm_hb(Head) :- mm_g_ts(TS), mm_call_space(TS, [rule, _L, _K, Body, Head]),
+               mm_hb_body(Body), ground(Head).
+
+mm_call_space(Space, [Rel|Args]) :- G =.. [Space, Rel | Args], catch(call(G), _, fail).
+
+mm_hb_body([]).
+mm_hb_body([I|R]) :- mm_hb_item(I), mm_hb_body(R).
+
+% Interval-variable temporal: bind the handle to a temporal variant in the base.
+mm_hb_item([lit, S, M, T, F, A]) :- var(T), !, mm_hb([lit, S, M, T, F, A]).
+% Base-family wildcard: a non-temporal body lit matches any temporal variant.
+mm_hb_item([lit, S, M, none, F, A]) :- !, mm_hb([lit, S, M, _T, F, A]).
+mm_hb_item([lit, S, M, [iv, Ts, Te], F, A]) :- !, mm_hb([lit, S, M, [iv, Ts, Te], F, A]).
+mm_hb_item([acmp, Op, L, R]) :- !, mm_acmp(Op, L, R, true).
+mm_hb_item([tcmp, Rel, L, R]) :- !, mm_tcmp(Rel, L, R, true).
+mm_hb_item([abind, V, Ax]) :- !, mm_ax_eval(Ax, V).
+
+% --- driver ---------------------------------------------------------------
+% Default (one-shot path): full from-scratch ground, base dropped at the end.
+mm_ground(TS, GS, HS, SS, true) :- once(mm_ground_run(TS, GS, HS, SS, drop)).
+% Incremental session init: same full ground, but KEEP the materialized base
+% (mm_hbf), per-rule completion marks, and dedup set alive for later deltas.
+mm_ground_incr_init(TS, GS, HS, SS, true) :- once(mm_ground_run(TS, GS, HS, SS, keep)).
+
+mm_ground_run(TS, GS, HS, SS, Mode) :-
+    retractall(mm_seen_g(_)), retractall(mm_hbf(_,_,_,_,_)),
+    retractall(mm_rule_done(_)), retractall(mm_delta(_,_,_,_,_)),
+    retractall(mm_newdelta(_,_,_,_,_)),
+    retractall(mm_g_ts(_)), retractall(mm_g_hs(_)),
+    assertz(mm_g_ts(TS)), assertz(mm_g_hs(HS)),
+    abolish_all_tables,
+    % 1. compute the tabled Herbrand base once, materialize functor-indexed
+    forall(mm_hb([lit, S, M, T, F, A]),
+           ( mm_hbf(F, A, S, M, T) -> true ; assertz(mm_hbf(F, A, S, M, T)) )),
+    abolish_all_tables,
+    % 2. seed dedup with grules already emitted by mm_add_rule (ground rules)
+    forall(mm_call_space(GS, [grule, L0, K0, B0, H0]),
+           ( term_hash(g(L0, K0, B0, H0), GH0),
+             ( mm_seen_g(GH0) -> true ; assertz(mm_seen_g(GH0)) ) )),
+    % 3. emit every satisfiable instance by indexed join over mm_hbf
+    forall(( mm_call_space(TS, [rule, L, K, Body, Head]),
+             ( Mode == keep -> mm_mark_rule(L, K, Body, Head) ; true ),
+             mm_inst_body(Body, GBody0),
+             exclude(==(dropped), GBody0, GBody),
+             ground([GBody, Head]) ),
+           mm_store_grule(GS, HS, SS, L, K, GBody, Head)),
+    ( Mode == drop -> retractall(mm_hbf(_,_,_,_,_)) ; true ).
+
+% mark a rule as already joined against the base (so deltas know it is "old").
+% Rules carry variables (?x), so a variant-stable ground hash is needed —
+% term_hash/2 leaves the hash UNBOUND on non-ground terms (which would make every
+% rule compare equal). copy_term+numbervars grounds it up to variable renaming.
+mm_rule_hash(L, K, B, H, RH) :-
+    copy_term(r(L, K, B, H), T), numbervars(T, 0, _), term_hash(T, RH).
+mm_mark_rule(L, K, B, H) :-
+    mm_rule_hash(L, K, B, H, RH), ( mm_rule_done(RH) -> true ; assertz(mm_rule_done(RH)) ).
+mm_rule_old(L, K, B, H) :- mm_rule_hash(L, K, B, H, RH), mm_rule_done(RH).
+
+% --- incremental (semi-naive, add-only) delta grounding --------------------
+% After new facts/rules are appended to the theory + herb seeds, derive ONLY
+% the new closure: new seed atoms form the frontier; brand-new rules are joined
+% against the full base; existing rules are re-joined only where >=1 body literal
+% comes from the frontier. Pure assertz — the base is never retracted.
+mm_ground_delta(TS, GS, HS, SS, true) :-
+    once(( retractall(mm_delta(_,_,_,_,_)), retractall(mm_newdelta(_,_,_,_,_)),
+           % dedup against grules mm_add_rule already emitted for appended ground
+           % facts (else the new-rule join re-emits them as duplicates)
+           forall(mm_call_space(GS, [grule, L0, K0, B0, H0]),
+                  ( term_hash(g(L0, K0, B0, H0), GH0),
+                    ( mm_seen_g(GH0) -> true ; assertz(mm_seen_g(GH0)) ) )),
+           % new herb seeds (appended facts) -> base + initial frontier
+           forall(( mm_call_space(HS, [ha, [lit, S, M, T, F, A]]),
+                    \+ mm_hbf(F, A, S, M, T) ),
+                  ( assertz(mm_hbf(F, A, S, M, T)), mm_add_delta(F, A, S, M, T) )),
+           mm_delta_loop(TS, GS, HS, SS) )).
+
+mm_add_delta(F, A, S, M, T) :- ( mm_delta(F, A, S, M, T) -> true ; assertz(mm_delta(F, A, S, M, T)) ).
+
+mm_delta_loop(TS, GS, HS, SS) :-
+    ( ( \+ mm_delta(_,_,_,_,_), \+ mm_new_rule_exists(TS) ) -> true
+    ; retractall(mm_newdelta(_,_,_,_,_)),
+      % brand-new rules: full join against the whole base
+      forall(( mm_call_space(TS, [rule, L, K, B, H]), \+ mm_rule_old(L, K, B, H),
+               mm_mark_rule(L, K, B, H),
+               mm_inst_body(B, GB0), exclude(==(dropped), GB0, GB), ground([GB, H]) ),
+             mm_store_grule_d(GS, HS, SS, L, K, GB, H)),
+      % existing rules: semi-naive join (>=1 body literal from the frontier)
+      forall(( mm_call_space(TS, [rule, L, K, B, H]), mm_rule_old(L, K, B, H),
+               mm_inst_body_d(B, GB0, true), exclude(==(dropped), GB0, GB), ground([GB, H]) ),
+             mm_store_grule_d(GS, HS, SS, L, K, GB, H)),
+      % swap frontier := newly derived atoms
+      retractall(mm_delta(_,_,_,_,_)),
+      forall(mm_newdelta(F, A, S, M, T), mm_add_delta(F, A, S, M, T)),
+      retractall(mm_newdelta(_,_,_,_,_)),
+      mm_delta_loop(TS, GS, HS, SS) ).
+
+mm_new_rule_exists(TS) :- mm_call_space(TS, [rule, L, K, B, H]), \+ mm_rule_old(L, K, B, H), !.
+
+% body instantiation that also reports whether any literal came from the frontier.
+mm_inst_body_d([], [], false).
+mm_inst_body_d([I|R], [GI|GR], Used) :-
+    mm_inst_item_d(I, GI, U1), mm_inst_body_d(R, GR, U2),
+    ( U1 == true -> Used = true ; Used = U2 ).
+mm_inst_item_d([lit, S, M, T, F, A], [lit, S, M, T, F, A], U) :- var(T), !,
+    mm_hbf(F, A, S, M, T), ( mm_delta(F, A, S, M, T) -> U = true ; U = false ).
+mm_inst_item_d([lit, S, M, none, F, A], [lit, S, M, T, F, A], U) :- !,
+    mm_hbf(F, A, S, M, T), ( mm_delta(F, A, S, M, T) -> U = true ; U = false ).
+mm_inst_item_d([lit, S, M, [iv, Ts, Te], F, A], [lit, S, M, [iv, Ts, Te], F, A], U) :- !,
+    mm_hbf(F, A, S, M, [iv, Ts, Te]),
+    ( mm_delta(F, A, S, M, [iv, Ts, Te]) -> U = true ; U = false ).
+mm_inst_item_d([acmp, Op, L, R], dropped, false) :- !, mm_acmp(Op, L, R, true).
+mm_inst_item_d([tcmp, Rel, L, R], dropped, false) :- !, mm_tcmp(Rel, L, R, true).
+mm_inst_item_d([abind, V, Ax], dropped, false) :- !, mm_ax_eval(Ax, V).
+
+% store a delta grule; a newly derivable head joins the base and next frontier.
+mm_store_grule_d(GS, HS, SS, L, K, B, H) :-
+    term_hash(g(L, K, B, H), GH),
+    ( mm_seen_g(GH) -> true
+    ; assertz(mm_seen_g(GH)),
+      St =.. [GS, grule, L, K, B, H], assertz(St),
+      mm_store_atom(HS, [ha, H]),
+      mm_store_atom(SS, [ulit, H]),
+      forall(member(Lit, B), mm_store_atom(SS, [ulit, Lit])),
+      H = [lit, S, M, T, F, A],
+      ( mm_hbf(F, A, S, M, T) -> true ; assertz(mm_hbf(F, A, S, M, T)) ),
+      ( mm_newdelta(F, A, S, M, T) -> true ; assertz(mm_newdelta(F, A, S, M, T)) ) ).
+
+% Instantiate a body against the materialized base (mm_hbf is functor-indexed,
+% so F bound => fast probe), dropping constraints (they fold out of the body).
+mm_inst_body([], []).
+mm_inst_body([I|R], [GI|GR]) :- mm_inst_item(I, GI), mm_inst_body(R, GR).
+
+mm_inst_item([lit, S, M, T, F, A], [lit, S, M, T, F, A]) :- var(T), !,
+    mm_hbf(F, A, S, M, T).                              % bind interval handle from base
+mm_inst_item([lit, S, M, none, F, A], [lit, S, M, T, F, A]) :- !,
+    mm_hbf(F, A, S, M, T).                              % concrete temporal from base
+mm_inst_item([lit, S, M, [iv, Ts, Te], F, A], [lit, S, M, [iv, Ts, Te], F, A]) :- !,
+    mm_hbf(F, A, S, M, [iv, Ts, Te]).                  % match exact interval
+mm_inst_item([acmp, Op, L, R], dropped) :- !, mm_acmp(Op, L, R, true).
+mm_inst_item([tcmp, Rel, L, R], dropped) :- !, mm_tcmp(Rel, L, R, true).
+mm_inst_item([abind, V, Ax], dropped) :- !, mm_ax_eval(Ax, V).
+
+mm_store_grule(GS, HS, SS, L, K, B, H) :-
+    term_hash(g(L, K, B, H), GH),
+    ( mm_seen_g(GH) -> true
+    ; assertz(mm_seen_g(GH)),
+      St =.. [GS, grule, L, K, B, H], assertz(St),
+      mm_store_atom(HS, [ha, H]),
+      mm_store_atom(SS, [ulit, H]),
+      forall(member(Lit, B), mm_store_atom(SS, [ulit, Lit])) ).
+
+mm_store_atom(Space, [Rel|Args]) :-
+    G =.. [Space, Rel | Args],
+    ( catch(call(G), _, fail) -> true ; assertz(G) ).

--- a/src/deontic/platform/inspect.pl
+++ b/src/deontic/platform/inspect.pl
@@ -1,0 +1,213 @@
+% Plan-inspection renderers — `trace` and `validate` (plan structure).
+%
+% Both read the loaded theory space (atoms [rule,Label,Kind,Body,Head], [sup,W,L])
+% plus the reasoned conclusion list, and emit their Facts:/Rules:/warning lines as
+% a STABLE sorted set, so the output is reproducible across runs.
+%
+% Self-contained apart from the space atom passed in from MeTTa.
+
+% ---- generic space query: Space(Rel, Arg1, ...) ----
+mn_q(Space, [Rel|Args]) :- G =.. [Space, Rel | Args], catch(call(G), _, fail).
+
+% literal name = its functor; negation flag from the sign slot.
+mn_litname([lit, S, _, _, F, _], S, F).
+
+% ============================================================================
+% trace — facts / rules (DFL arrows) / superiorities / positive conclusions
+% ============================================================================
+mm_print_trace(TheorySp, Concls, true) :-
+    once(( with_output_to(string(Out), mn_trace(TheorySp, Concls)), write(Out) )).
+
+mn_trace(TS, Concls) :-
+    mn_sep, format("Full Reasoning Trace~n"), mn_sep, nl,
+    % Facts:  [label] >> name
+    format("Facts:~n"),
+    findall(L-N, ( mn_q(TS, [rule, L, fact, _, H]), mn_litname(H, _, N) ), Fs0),
+    sort(Fs0, Fs),
+    forall(member(L-N, Fs), format("  [~w] >> ~w~n", [L, N])), nl,
+    % Rules:  [label] body  arrow  head    (¬ marks negated literals)
+    format("Rules:~n"),
+    findall(L-Line, ( mn_q(TS, [rule, L, K, B, H]), K \== fact,
+                      mn_rule_line(L, K, B, H, Line) ), Rs0),
+    sort(Rs0, Rs),
+    forall(member(_-Line, Rs), ( write(Line), nl )), nl,
+    % Superiorities:  W > L
+    findall(W-L, mn_q(TS, [sup, W, L]), Sup0), sort(Sup0, Sups),
+    ( Sups == [] -> true
+    ; format("Superiorities:~n"),
+      forall(member(W-L, Sups), format("  ~w > ~w~n", [W, L])), nl ),
+    % Conclusions: positive (+D/+d) only
+    format("Conclusions:~n"),
+    findall(CL, ( member([Tag, Lit], Concls), mn_pos_sym(Tag, Sym),
+                  mn_litname(Lit, S, N), mn_signed(S, N, SN),
+                  format(atom(CL), "  ~w ~w", [Sym, SN]) ), Cs0),
+    sort(Cs0, Cs),
+    forall(member(C, Cs), ( write(C), nl )), nl.
+
+mn_sep :- forall(between(1, 63, _), write("=")), nl.
+
+mn_pos_sym(pD, "+D"). mn_pos_sym(pd, "+d").
+
+mn_signed(neg, N, S) :- !, atom_concat('~', N, S).
+mn_signed(_, N, N).
+
+mn_arrow(strict, "->"). mn_arrow(defeasible, "=>"). mn_arrow(defeater, "~>").
+
+mn_rule_line(L, K, Body, Head, Line) :-
+    mn_lit_names(Body, BNs), atomic_list_concat(BNs, ', ', BStr),
+    ( is_list(Head) , Head = [lit|_] -> mn_lit_names([Head], HNs)
+    ; mn_lit_names(Head, HNs) ),
+    atomic_list_concat(HNs, ', ', HStr),
+    mn_arrow(K, Arr),
+    format(atom(Line), "  [~w] ~w ~w ~w", [L, BStr, Arr, HStr]).
+
+% names of the literal body/head items (¬ for negated); non-lit items skipped.
+mn_lit_names([], []).
+mn_lit_names([It|Its], [Nm|Ns]) :- mn_litname(It, S, N), !, mn_signed_neg(S, N, Nm), mn_lit_names(Its, Ns).
+mn_lit_names([_|Its], Ns) :- mn_lit_names(Its, Ns).
+mn_signed_neg(neg, N, M) :- !, atom_concat('¬', N, M).
+mn_signed_neg(_, N, N).
+
+% ============================================================================
+% validate — plan structure checks (default = non-strict)
+% ============================================================================
+mm_print_plan_validate(TheorySp, Concls, FmtStr, Strict, Valid) :-
+    once(( mn_validate(TheorySp, Concls, FmtStr, Strict, Valid, Out), write(Out) )).
+
+mn_validate(TS, Concls, FmtStr, Strict, Valid, Out) :-
+    % defined literals: heads of facts + heads of rules
+    findall(N, ( mn_q(TS, [rule, _, _, _, H]), mn_litname(H, _, N) ), Def0),
+    sort(Def0, Defined),
+    % concluded literals: positive conclusions
+    findall(N, ( member([Tag, Lit], Concls), mn_pos_sym(Tag, _), mn_litname(Lit, _, N) ), Con0),
+    sort(Con0, Concluded),
+    % scan non-fact rule bodies for undefined / unreachable literals
+    findall(undef(N, L),
+      ( mn_q(TS, [rule, L, K, B, _]), K \== fact,
+        member(It, B), mn_litname(It, _, N),
+        \+ memberchk(N, Defined), \+ mn_lifecycle_lit(N) ),
+      Undef0),
+    sort(Undef0, Undef),
+    findall(unreach(N, L),
+      ( mn_q(TS, [rule, L, K, B, _]), K \== fact,
+        % rule has some body literal that is neither concluded nor defined
+        ( member(X, B), mn_litname(X, _, XN),
+          \+ memberchk(XN, Concluded), \+ memberchk(XN, Defined), \+ mn_lifecycle_lit(XN) ),
+        member(It, B), mn_litname(It, _, N),
+        \+ memberchk(N, Concluded), \+ memberchk(N, Defined), \+ mn_lifecycle_lit(N) ),
+      Unr0),
+    sort(Unr0, Unreach),
+    % consistency: circular superiorities + contradictory definite conclusions
+    mn_consistency(TS, Concls, Cons),
+    % build warning lines (sorted set; non-strict -> all are warnings, valid=true)
+    findall(W, ( member(unreach(N, L), Unreach),
+                 format(atom(W), "Literal '~w' in rule '~w' can never be derived (body unsatisfiable)", [N, L]) ), W1),
+    findall(W, ( member(undef(N, _), Undef),
+                 format(atom(W), "Literal '~w' used in rule body but never defined", [N]) ), W2),
+    ( Strict == true -> mn_strict_warnings(TS, FmtStr, W3) ; W3 = [] ),
+    append([W1, W2, W3, Cons], Ws0), sort(Ws0, Warns),
+    % strict: undefined-literal warnings are errors
+    ( Strict == true -> Errs = W2 ; Errs = [] ),
+    ( Errs == [] -> Valid = true ; Valid = false ),
+    with_output_to(string(Out), (
+      ( Valid == true -> format("Valid ~w plan.~n", [FmtStr])
+      ; format("Invalid ~w plan:~n", [FmtStr]) ),
+      forall(member(E, Errs), format("  ERROR: ~w~n", [E])),
+      ( Strict == true -> mn_warn_set(Warns, W2, Out2) ; Out2 = Warns ),
+      forall(member(Wn, Out2), format("  WARNING: ~w~n", [Wn]))
+    )).
+
+% in strict mode the undefined-literal lines are reported as errors, not warnings
+mn_warn_set(All, ErrLines, Rest) :- subtract(All, ErrLines, Rest).
+
+mn_consistency(TS, Concls, Lines) :-
+    % circular superiority pairs (W>L and L>W)
+    findall(Line,
+      ( mn_q(TS, [sup, A, B]), mn_q(TS, [sup, B, A]), A @< B,
+        format(atom(Line), "Circular superiority: prefer(~w,~w) and prefer(~w,~w)", [A, B, B, A]) ),
+      Circ0),
+    sort(Circ0, Circ),
+    % contradictory definite conclusions: +D lit and +D complement
+    findall([S, N], ( member([pD, Lit], Concls), mn_litname(Lit, S, N) ), Defs),
+    findall(Line,
+      ( member([pos, N], Defs), memberchk([neg, N], Defs),
+        format(atom(Line), "Contradictory definite conclusions: both +D ~w and +D ~~~w", [N, N]) ),
+      Contra0),
+    sort(Contra0, Contra),
+    append(Circ, Contra, Lines).
+
+mn_strict_warnings(TS, FmtStr, Ws) :-
+    findall(W, ( mn_q(TS, [rule, L, K, _, _]), K \== fact, \+ mn_lifecycle_rule(L),
+                 format(atom(W), "Rule '~w' has no source annotation (defaults to anonymous)", [L]) ), W1),
+    ( FmtStr == 'MeTTa', \+ mn_q(TS, [metainfo, plan, _])
+      -> W2 = ['Missing (meta plan ...) block'] ; W2 = [] ),
+    append(W1, W2, Ws).
+
+% lifecycle literal / rule-label prefixes (asserted at runtime by claim/etc.)
+mn_lifecycle_lit(N) :- atom(N),
+    member(P, ['completed-','completed_','claimed-','claimed_','blocked-','blocked_',
+               'unblocked-','unblocked_','claim-v','claim_v','unclaim-v','unclaim_v',
+               'block-v','block_v','unblock-v','unblock_v','state-claimed-','state-claimed_',
+               'state-blocked-','state-blocked_','state-unclaimed-','state-unclaimed_',
+               'state-unblocked-','state-unblocked_']),
+    atom_concat(P, _, N), !.
+mn_lifecycle_rule(L) :- atom(L),
+    member(P, ['r-cl-','r-cl_','r-ucl-','r-ucl_','r-bl-','r-bl_','r-ubl-','r-ubl_']),
+    atom_concat(P, _, L), !.
+
+% ============================================================================
+% assign — agent assignment lines
+% ============================================================================
+mm_print_assign(Agent, Names, true) :-
+    once(( with_output_to(string(Out), (
+             ( Agent == "" -> format("Agent assignments:~n")
+             ; format("Assignments for ~w:~n", [Agent]) ),
+             ( Names == [] -> format("  (no assignments)~n")
+             ; forall(member(N, Names), format("  +d ~w~n", [N])) )
+           )), write(Out) )).
+
+% optional CLI positional (user index N), or Default if absent.
+mm_argn_or(N, Default, Val) :-
+    once(( current_prolog_flag(argv, Argv), Idx is N + 2,
+           ( nth0(Idx, Argv, A) -> Val = A ; Val = Default ) )).
+
+% plan format label from the path extension (.dfl -> DFL, else MeTTa).
+mm_plan_fmt(Path, Fmt) :-
+    once(( ( atom(Path) -> P = Path ; atom_string(P, Path) ),
+           ( sub_atom(P, _, _, 0, '.dfl') -> Fmt = 'DFL' ; Fmt = 'MeTTa' ) )).
+
+% ============================================================================
+% plan analysis — dependency cycles (deadlocks) + self-inconsistency
+% ============================================================================
+% The cycle ALGORITHM and the consistency BOOLEAN live in idiomatic MeTTa
+% (src/directive/inspect.metta): cycles are SCCs of the support-dependency graph
+% (defeaters excluded — they block, don't support); a cyclic literal can never be
+% grounded from facts -> a deadlock. This module keeps only the report formatter
+% plus the consistency LINES, the same lines `validate` emits (mn_consistency).
+
+% analyze report. Groups = MeTTa-computed list of SCC literal-lists.
+mm_print_analyze2(Groups, TheorySp, Concls, true) :-
+    once(( mn_consistency(TheorySp, Concls, Cons),
+           with_output_to(string(Out), (
+             format("Plan Analysis~n=============~n", []),
+             ( Groups == []
+             -> format("Dependency cycles: none~n", [])
+             ;  length(Groups, NC), format("Dependency cycles: ~w~n", [NC]),
+                forall(member(G, Groups),
+                       ( maplist(mn_litname_str, G, Ns), atomic_list_concat(Ns, ' -> ', S),
+                         format("  cycle: ~w~n", [S]) )) ),
+             ( Cons == []
+             -> format("Consistency: consistent~n", [])
+             ;  format("Consistency: INCONSISTENT~n", []),
+                forall(member(C, Cons), format("  ~w~n", [C])) )
+           )), write(Out) )).
+
+% literal name for display (functor; ~ for negated; mode bracket if modal)
+mn_litname_str([lit, S, M, _, F, _], Str) :-
+    ( M == none -> MS = '' ; atom_concat('[', M, M0), atom_concat(M0, ']', MS) ),
+    ( S == neg -> atomic_list_concat([MS, '~', F], Str) ; atomic_list_concat([MS, F], Str) ).
+
+% honest stub for commands requiring external services (LLM / OS / net / crypto).
+mm_print_stub(Cmd, Needs, true) :-
+    once(( format("Command '~w' is not available in this pure-logic engine.~n", [Cmd]),
+           format("It requires ~w, outside the reasoning and task-coordination core.~n", [Needs]) )).

--- a/src/deontic/platform/io.pl
+++ b/src/deontic/platform/io.pl
@@ -1,0 +1,700 @@
+%%% lib_deontic platform kernel (the SWI-Prolog side of the MeTTa engine).
+%%%
+%%% A small deterministic Prolog kernel behind stable MeTTa-callable predicates
+%%% (last argument is the output; pure side effects return true). MeTTa surface
+%%% syntax is normalized HERE because its heads (not/and/arith/comparison)
+%%% collide with registered MeTTa functions.
+%%%
+%%% HARD RULE: every exported predicate is deterministic (once/1) — PeTTa wraps
+%%% runnables in findall, which would exhaustively backtrack stray choicepoints.
+
+:- dynamic mm_label_counter/2.
+
+%%% ----------------------------------------------------------------------
+%%% Generic file / misc helpers
+%%% ----------------------------------------------------------------------
+
+% Plan/theory files are .metta source, read via PeTTa's native loader
+% (load_metta_file/3 in mm_load_into below); no separate s-expression reader.
+
+% Reconstruct the exact source float of a tagged decimal (identical to what the
+% reader produced before tagging), or pass a non-decimal value through unchanged.
+mm_decf([dec, M, Sc], V) :- !, mm_dec_str(M, Sc, Str), atom_number(Str, V).
+mm_decf(X, X).
+
+mm_path(Path, P) :- ( atom(Path) -> P = Path ; atom_string(P, Path) ).
+
+mm_append_file(Path, Str, true) :-
+    once(( mm_path(Path, P), open(P, append, Out), write(Out, Str), close(Out) )).
+
+mm_write_file(Path, Str, true) :-
+    once(( mm_path(Path, P), open(P, write, Out), write(Out, Str), close(Out) )).
+
+mm_read_file(Path, Str) :-
+    once(( mm_path(Path, P), read_file_to_string(P, Str, []) )).
+
+mm_exists(Path, R) :-
+    once(( mm_path(Path, P), ( exists_file(P) -> R = true ; R = false ) )).
+
+mm_now_iso(Iso) :-
+    once(( get_time(T), stamp_date_time(T, DT, 'UTC'),
+           format_time(string(Iso), '%FT%TZ', DT) )).
+
+mm_clear_space(Space, true) :-
+    once(forall(( current_predicate(Space/A), functor(H, Space, A) ), retractall(H))).
+
+mm_gensym(Prefix, Sym) :-
+    once(( ( retract(mm_label_counter(Prefix, N)) -> true ; N = 0 ),
+           N1 is N + 1, assertz(mm_label_counter(Prefix, N1)),
+           format(atom(Sym), '~w~w', [Prefix, N1]) )).
+
+mm_reset_labels :- retractall(mm_label_counter(f, _)),
+                   retractall(mm_label_counter(r, _)).
+
+mm_halt(Code, true) :- halt(Code).
+
+% Seed the global RNG (for reproducible Structural Random Indexing embeddings).
+mm_srand(N, true) :- once(set_random(seed(N))).
+
+% Raw print (no quotes around strings, unlike println! of a string).
+mm_print(S, true) :- once(( write(S), nl )).
+
+% Bulk-print a conclusion tuple list in ONE Prolog call (avoids per-line MeTTa
+% eval overhead — ~0.3s on an 8k-conclusion theory). Cs = [[Tag,Lit], ...].
+mm_print_concls(Cs, true) :-
+    once(( with_output_to(string(Buf),
+             forall(member(C, Cs), ( mm_concl_str(C, S), write(S), nl ))),
+           write(Buf) )).
+
+% Same for trust-annotated conclusions [tconcl,...].
+mm_print_tconcls(Cs, true) :-
+    once(( with_output_to(string(Buf),
+             forall(member(C, Cs), ( mm_trust_str(C, S), write(S), nl ))),
+           write(Buf) )).
+
+% Parse a CLI literal token into an internal 6-slot lit:
+%   "flies" -> [lit,pos,none,none,flies,[]]
+%   "~flies"/"-flies" -> [lit,neg,none,none,flies,[]]
+%   "(flies tweety)" -> [lit,pos,none,none,flies,[tweety]]
+%   "(must pay)" / "(during meeting 10 20)" route through mm_lit.
+mm_parse_lit(Tok, Lit) :-
+    once(( ( atom(Tok) -> A = Tok ; atom_string(A, Tok) ),
+           atom_chars(A, Cs),
+           ( Cs = ['~'|Rest] -> Neg = neg, atom_chars(Body, Rest)
+           ; Cs = ['-'|Rest] -> Neg = neg, atom_chars(Body, Rest)
+           ; Neg = pos, Body = A ),
+           ( sub_atom(Body, 0, 1, _, '(')
+             -> sread(Body, Sexpr), mm_lit(Sexpr, [lit, S0, M, T, F, Args]),
+                ( Neg == neg -> mm_flip(S0, S1) ; S1 = S0 ),
+                Lit = [lit, S1, M, T, F, Args]
+             ;  Lit = [lit, Neg, none, none, Body, []] ) )).
+
+%% Standard MeTTa stdlib file API (handle-based), backed by Prolog streams.
+'file-open!'(Path, Opts, Handle) :-
+    once(( mm_path(Path, P), mm_open_mode(Opts, Mode), open(P, Mode, Handle) )).
+mm_open_mode(Opts, Mode) :-
+    ( sub_string(Opts, _, _, _, "a") -> Mode = append
+    ; sub_string(Opts, _, _, _, "w") -> Mode = write
+    ; Mode = read ).
+'file-close!'(Handle, true) :- once(close(Handle)).
+'file-read-to-string!'(Handle, Str) :- once(read_string(Handle, _, Str)).
+'file-write!'(Handle, Str, true) :- once(write(Handle, Str)).
+'file-get-size!'(Handle, Size) :- once(stream_property(Handle, file_name(F))), size_file(F, Size).
+'file-seek!'(Handle, Pos, true) :- once(seek(Handle, Pos, bof, _)).
+
+%% Minimal logger (same spirit as petta_lib_logger, zero external deps).
+:- dynamic mm_log_level/1, mm_log_path/1.
+mm_log_level(info).
+mm_log_path("").
+mm_level_num(trace, 0). mm_level_num(debug, 1). mm_level_num(info, 2).
+mm_level_num(warn, 3).  mm_level_num(error, 4). mm_level_num(fatal, 5).
+
+mm_log_set_level(L, true) :-
+    once(( retractall(mm_log_level(_)), assertz(mm_log_level(L)) )).
+mm_log_set_path(P, true) :-
+    once(( retractall(mm_log_path(_)), assertz(mm_log_path(P)) )).
+mm_log(Level, Msg, true) :-
+    once(( mm_log_level(Cur), mm_level_num(Cur, CN), mm_level_num(Level, LN),
+           ( LN < CN -> true
+           ; swrite(Msg, S),
+             get_time(T), format_time(atom(TS), '%T', T),
+             string_upper(Level, UL),
+             format(user_error, "[~w] [~w] ~w~n", [TS, UL, S]),
+             mm_log_path(LP),
+             ( LP == "" -> true
+             ; open(LP, append, Out), format(Out, "[~w] [~w] ~w~n", [TS, UL, S]), close(Out) ) ) )).
+
+%%% ----------------------------------------------------------------------
+%%% Arithmetic (MeTTa arithmetic semantics, mapped onto SWI numbers)
+%%%   Integer  -> SWI integer (arbitrary precision)
+%%%   Decimal  -> SWI rational (exact)
+%%%   Float    -> SWI float (contagious)
+%%% Errors (div by zero, type mismatch, unbound var) FAIL silently: a body
+%%% constraint that fails simply discards the candidate substitution, so the
+%%% offending rule instance is never grounded.
+%%% Expressions arrive as [ax, Op, Args] trees built by the MeTTa normalizer.
+%%% ----------------------------------------------------------------------
+
+mm_ax_eval(X, _) :- var(X), !, fail.
+mm_ax_eval(X, X) :- number(X), !.
+mm_ax_eval([dec, M, Sc], V) :- !, mm_decf([dec, M, Sc], V).
+mm_ax_eval([ax, Op, Args], Out) :- !,
+    maplist(mm_ax_eval, Args, Vals),
+    mm_ax_apply(Op, Vals, Out0),
+    mm_finite(Out0),
+    Out = Out0.
+mm_ax_eval(_, _) :- fail.
+
+mm_finite(X) :- ( float(X) -> X =:= X, abs(X) =\= inf ; true ).
+
+mm_ax_apply('+', [V|Vs], Out) :- foldl([A,B,C]>>(C is B + A), Vs, V, Out).
+mm_ax_apply('-', [V], Out) :- !, Out is -V.
+mm_ax_apply('-', [V|Vs], Out) :- foldl([A,B,C]>>(C is B - A), Vs, V, Out).
+mm_ax_apply('*', [V|Vs], Out) :- foldl([A,B,C]>>(C is B * A), Vs, V, Out).
+mm_ax_apply('/', [A,B], Out) :- B =\= 0,
+    ( (integer(A), integer(B)) -> Out is A rdiv B   % exact "Decimal" division
+    ; Out is A / B ).
+mm_ax_apply(div, [A,B], Out) :- integer(A), integer(B), B =\= 0, Out is A div B.
+mm_ax_apply(rem, [A,B], Out) :- integer(A), integer(B), B =\= 0, Out is A - (A div B) * B.
+mm_ax_apply('**',  [A,B], Out) :-
+    ( integer(A), integer(B), B >= 0 -> Out is A ** B
+    ; integer(A), integer(B) -> Out is 1 rdiv (A ** (-B))
+    ; Out is A ** B ).
+mm_ax_apply(abs, [V], Out) :- Out is abs(V).
+mm_ax_apply(min, [V|Vs], Out) :- foldl([A,B,C]>>(C is min(A,B)), Vs, V, Out).
+mm_ax_apply(max, [V|Vs], Out) :- foldl([A,B,C]>>(C is max(A,B)), Vs, V, Out).
+
+mm_cmp_op('=',  '=:='). mm_cmp_op('!=', '=\\='). mm_cmp_op('<', '<'). mm_cmp_op('>', '>').
+mm_cmp_op('<=', '=<').  mm_cmp_op('>=', '>=').
+
+%% MeTTa-callable: evaluate an [ax|...] tree (fails -> branch pruned).
+mm_arith_eval(Ax, Out) :- once(mm_ax_eval(Ax, Out)).
+
+%% MeTTa-callable: comparison constraint, returns true/false (fail-free).
+mm_acmp(Op, L, R, Out) :-
+    once(( mm_ax_eval(L, LV), mm_ax_eval(R, RV), mm_cmp_op(Op, P)
+           -> ( call(P, LV, RV) -> Out = true ; Out = false )
+           ;  Out = false )).
+
+%% Numeric cross-type equality for grounding (Integer 2 == Decimal 2.0 ...).
+mm_num_eq(A0, B0, Out) :-
+    once(( mm_decf(A0, A), mm_decf(B0, B),
+           number(A), number(B), A =:= B -> Out = true ; Out = false )).
+
+% Integer percentage (done*100/total, floor division).
+mm_pct(D, T, P) :- once(( T > 0 -> P is (D * 100) // T ; P = 0 )).
+
+%%% ----------------------------------------------------------------------
+%%% MeTTa ingestion: forms -> theory atoms in a space
+%%%
+%%% Theory space atoms:
+%%%   [rule, Label, Kind, Body, Head]   Kind: fact|strict|defeasible|defeater
+%%%       Body: list of [lit,S,F,Args] | [acmp,Op,AxL,AxR] | [abind,Var,Ax]
+%%%       Head: [lit, pos|neg, Functor, Args]
+%%%   [sup, Winner, Loser]
+%%%   [metainfo, Label, KVs]
+%%%   [trustinfo, Form]                 (trusts/claims-attr/decays/threshold, raw)
+%%%   [claiminfo, Source, At, Note]     provenance of appended claims blocks
+%%% Ground rules additionally seed (in their own spaces):
+%%%   GroundSpace: [grule, Label, Kind, LogicBody, Head]  (constraints folded)
+%%%   HerbSpace:   [ha, Head]
+%%%   StatSpace:   [ulit, Lit] for every ground literal occurring
+%%% Rules whose constant constraints are false get body [[lit,pos,'%never%',[]]]
+%%% so they stay in the universe but can never fire.
+%%% ----------------------------------------------------------------------
+
+%% Load a plan/theory .metta file into Space via PeTTa's native loader: each
+%% top-level form is added to Space as for any .metta source. Rule labels are
+%% reset per load; the loader's per-form trace output is discarded. The MeTTa
+%% layer (dl-load-native) then enumerates Space and ingests each form.
+mm_load_into(Path, Space, true) :-
+    once(( mm_reset_labels, mm_path(Path, P),
+           with_output_to(string(_), load_metta_file(P, _, Space)) )).
+
+%% Surface format of a plan/theory path: dfl (arrow syntax) or metta (s-expr).
+mm_plan_format(Path, Format) :-
+    once(( mm_path(Path, P), string_lower(P, PL),
+           ( sub_string(PL, _, 4, 0, ".dfl") -> Format = dfl ; Format = metta ) )).
+
+%%% ----------------------------------------------------------------------
+%%% DFL (Defeasible Logic Format) — arrow syntax, propositional. A textbook-style
+%%% surface notation for defeasible theories (Nute; Antoniou et al.), offered in
+%%% addition to the s-expression MeTTa syntax. Grammar:
+%%%   facts       >> p              |  label: >> p
+%%%   strict      label: a, b -> q
+%%%   defeasible  label: a, b => q
+%%%   defeater    label: a, b ~> q
+%%%   superiority  r1 > r2
+%%%   negation    -p  /  ¬p
+%%%   conjunction comma-separated body literals
+%%%   comments    # to end of line
+%%%   front-matter --- ... --- annotation blocks (metadata; skipped for reasoning)
+%%% Maps to the SAME theory representation as the MeTTa ingester.
+%%% ----------------------------------------------------------------------
+mm_load_dfl(Path, TS, GS, HS, SS, Count) :-
+    once(( mm_reset_labels,
+           mm_path(Path, P), read_file_to_string(P, S, []),
+           split_string(S, "\n", "", Lines),
+           foldl(mm_dfl_line(TS, GS, HS, SS), Lines, fm(none)-0, fm(_)-Count) )).
+
+% State threads a front-matter flag (in/out of a --- block) and the count.
+mm_dfl_line(TS, GS, HS, SS, Line0, FM0-N0, FM-N) :-
+    mm_dfl_strip(Line0, L),
+    ( L == "" -> FM = FM0, N = N0
+    ; L == "---" -> ( FM0 = fm(in) -> FM = fm(none) ; FM = fm(in) ), N = N0
+    ; FM0 = fm(in) -> FM = FM0, N = N0                     % annotation line: skip
+    ; FM = fm(none),
+      ( mm_dfl_stmt(L, TS, GS, HS, SS) -> N is N0 + 1
+      ; mm_log(warn, ["dfl skipped", L], _), N = N0 ) ).
+
+% strip a # comment (to EOL) and trim surrounding whitespace
+mm_dfl_strip(Line0, Trimmed) :-
+    ( sub_string(Line0, B, _, _, "#") -> sub_string(Line0, 0, B, _, NoComment) ; NoComment = Line0 ),
+    normalize_space(string(Trimmed), NoComment).
+
+% one DFL statement -> theory. Check 2-char ops before the 1-char '>'.
+mm_dfl_stmt(L, TS, GS, HS, SS) :-
+    ( sub_string(L, _, _, _, "->") -> mm_dfl_rule(L, "->", strict, TS, GS, HS, SS)
+    ; sub_string(L, _, _, _, "=>") -> mm_dfl_rule(L, "=>", defeasible, TS, GS, HS, SS)
+    ; sub_string(L, _, _, _, "~>") -> mm_dfl_rule(L, "~>", defeater, TS, GS, HS, SS)
+    ; sub_string(L, _, _, _, ">>") -> mm_dfl_fact(L, TS, GS, HS, SS)
+    ; sub_string(L, _, _, _, ">")  -> mm_dfl_sup(L, TS) ).
+
+% label: body OP head   (label optional)
+mm_dfl_rule(L, Op, Kind, TS, GS, HS, SS) :-
+    mm_split_once(L, Op, LeftS, RightS),
+    mm_dfl_label_body(LeftS, Label, BodyS),
+    mm_dfl_body(BodyS, Body),
+    mm_dfl_lit(RightS, Head),
+    mm_add_rule(TS, GS, HS, SS, Label, Kind, Body, Head).
+
+% [label:] >> head
+mm_dfl_fact(L, TS, GS, HS, SS) :-
+    mm_split_once(L, ">>", _LeftS, RightS),
+    mm_dfl_lit(RightS, Lit), ground(Lit),
+    mm_gensym(f, Label),
+    mm_add_rule(TS, GS, HS, SS, Label, fact, [], Lit).
+
+% r1 > r2  (superiority)
+mm_dfl_sup(L, TS) :-
+    mm_split_once(L, ">", LeftS, RightS),
+    normalize_space(atom(W), LeftS), normalize_space(atom(Lo), RightS),
+    add_sexp(TS, [sup, W, Lo]).
+
+% split "LABEL: BODY" -> Label (gensym if absent), BodyString
+mm_dfl_label_body(S, Label, Body) :-
+    ( sub_string(S, _, _, _, ":")
+      -> mm_split_once(S, ":", LabS, Body), normalize_space(atom(Label), LabS)
+      ;  mm_gensym(r, Label), Body = S ).
+
+% comma-separated body literals
+mm_dfl_body(S, Lits) :-
+    split_string(S, ",", " ", Parts0),
+    exclude(==(""), Parts0, Parts),
+    maplist(mm_dfl_lit, Parts, Lits).
+
+% a DFL literal: name | -name | ¬name | pred(a, b) | -pred(a, b)
+mm_dfl_lit(S0, Lit) :-
+    normalize_space(string(S), S0),
+    ( ( sub_string(S, 0, 1, _, "-") ; sub_string(S, 0, 1, _, "¬") )
+      -> sub_string(S, 1, _, 0, Rest), mm_dfl_atom(Rest, [lit, P, none, none, F, A]),
+         mm_flip(P, P2), Lit = [lit, P2, none, none, F, A]
+      ;  mm_dfl_atom(S, Lit) ).
+
+% pred(a, b) -> functor+args; flat name -> 0-arity
+mm_dfl_atom(S0, [lit, pos, none, none, F, Args]) :-
+    normalize_space(string(S), S0),
+    ( split_string(S, "(", "", [FS, Rest]), string_concat(ArgsS, ")", Rest)
+      -> normalize_space(atom(F), FS),
+         split_string(ArgsS, ",", " ", AParts0), exclude(==(""), AParts0, AParts),
+         maplist(mm_dfl_arg, AParts, Args)
+      ;  atom_string(F, S), Args = [] ).
+
+mm_dfl_arg(S, A) :- ( atom_number(S, N) -> A = N ; atom_string(A, S) ).
+
+% split a string on the first occurrence of a separator substring
+mm_split_once(S, Sep, Left, Right) :-
+    sub_string(S, B, _, _, Sep), !,
+    sub_string(S, 0, B, _, Left),
+    string_length(Sep, SL), AfterB is B + SL,
+    sub_string(S, AfterB, _, 0, Right).
+
+%% Ingest a single already-parsed form (for REPL/assert paths).
+mm_ingest(Form, TheorySp, GroundSp, HerbSp, StatSp, true) :-
+    once(mm_ingest_form(TheorySp, GroundSp, HerbSp, StatSp, Form, 0, _)).
+
+%% --at <ref>: drop temporal ground rules / herbrand atoms / universe literals
+%% whose temporal interval is not active at the reference time (s =< t =< e).
+%% Ref is millis (int) or an ISO-8601 string. Non-temporal entries are kept.
+mm_at_filter(GroundSp, HerbSp, StatSp, Ref, true) :-
+    once(( mm_ref_millis(Ref, T),
+           mm_retract_inactive(GroundSp, [grule, _, _, _, H], H, T),
+           mm_retract_inactive(GroundSp, [grule, _, _, B, _], B, T),
+           mm_retract_inactive(HerbSp, [ha, H], H, T),
+           mm_retract_inactive(StatSp, [ulit, H], H, T) )).
+
+mm_ref_millis(Ref, T) :- ( number(Ref) -> T = Ref
+                         ; ( atom(Ref) -> A = Ref ; atom_string(A, Ref) ),
+                           parse_time(A, iso_8601, E) -> T is round(E * 1000)
+                         ; atom_number(Ref, T) ).
+
+%% Retract space atoms matching Pattern where the literal(s) at Sel are temporally
+%% inactive at T. Sel is either a single [lit|...] or a body-list of them.
+mm_retract_inactive(Space, Pattern, Sel, T) :-
+    findall(Pattern,
+            ( call_sexp_all(Space, Pattern), mm_sel_inactive(Sel, T) ),
+            Dead),
+    forall(member(P, Dead), ( P = [Rel|Args], G =.. [Space, Rel|Args], retract(G) )).
+
+call_sexp_all(Space, [Rel|Args]) :- Term =.. [Space, Rel|Args], call(Term).
+
+mm_sel_inactive([lit|L], T) :- !, mm_lit_inactive([lit|L], T).
+mm_sel_inactive(Body, T) :- is_list(Body),
+    member(Lit, Body), Lit = [lit|_], mm_lit_inactive(Lit, T), !.
+
+mm_lit_inactive([lit, _, _, [iv, S, E], _, _], T) :-
+    \+ ( mm_tp_le(S, T, true), mm_tp_le(T, E, true) ).
+
+%% Add an INTERNAL literal as a fact with a unique hypothesis label
+%% (used by the what-if and requires query operators when injecting hypotheses).
+mm_add_fact(Lit, TheorySp, GroundSp, HerbSp, StatSp, Label) :-
+    once(( mm_gensym('__hyp_', Label),
+           mm_add_rule(TheorySp, GroundSp, HerbSp, StatSp, Label, fact, [], Lit) )).
+
+mm_ingest_form(TS, GS, HS, SS, Form, N0, N) :-
+    ( mm_ingest_form_(TS, GS, HS, SS, Form) -> N is N0 + 1
+    ; mm_log(warn, ["skipped form", Form], _), N = N0 ).
+
+mm_ingest_form_(TS, GS, HS, SS, [given, L]) :- !,
+    mm_lit(L, Lit), ground(Lit),
+    mm_gensym(f, Lbl),
+    mm_add_rule(TS, GS, HS, SS, Lbl, fact, [], Lit).
+% Deadline obligation (temporal modal defeasible logic — Governatori et al. 2007):
+%   (deadline (must pay) achieve 0 30)            achievement: O pay by 30
+%   (deadline (forbidden trespass) maintain 0 100) maintenance: keep ¬trespass in [0,100]
+%   (deadline (must pay) achieve 0 30 fine)        + sanction "fine" on violation
+% Asserts the deontic literal as an in-force obligation, and records deadline
+% metadata for the time-aware compliance analysis (deontic.pl).
+mm_ingest_form_(TS, GS, HS, SS, [deadline, M, Type | Rest]) :- !,
+    mm_lit(M, [lit, Sg, Mode, _, F, A]),
+    mm_gensym(f, Lbl),
+    mm_add_rule(TS, GS, HS, SS, Lbl, fact, [], [lit, Sg, Mode, none, F, A]),
+    mm_dl_times(Rest, S0, E0, Sanc),
+    mm_tp(S0, St), mm_tp(E0, En),
+    add_sexp(SS, [deadlineinfo, Sg, Mode, F, A, Type, St, En, Sanc]).
+% Event-Calculus obligation lifecycle (oPIEC/Mantenoglou; Governatori init/term):
+%   (happens invoice 5)   (initiates invoice (must pay))   (terminates pay (must pay))
+% Events occur at time-points; an obligation fluent is in force from initiation
+% until termination (inertia). Stored for the interval-based EC engine.
+mm_ingest_form_(TS, _, _, _, [happens, E, T0]) :- !, mm_tp(T0, T), add_sexp(TS, [happens, E, T]).
+mm_ingest_form_(TS, _, _, _, [initiates, E, M]) :- !, mm_lit(M, L), add_sexp(TS, [ec_init, E, L]).
+mm_ingest_form_(TS, _, _, _, [terminates, E, M]) :- !, mm_lit(M, L), add_sexp(TS, [ec_term, E, L]).
+mm_ingest_form_(TS, GS, HS, SS, [always | R])   :- !, mm_rule_form(TS, GS, HS, SS, strict, R).
+mm_ingest_form_(TS, GS, HS, SS, [normally | R]) :- !, mm_rule_form(TS, GS, HS, SS, defeasible, R).
+mm_ingest_form_(TS, GS, HS, SS, [except | R])   :- !, mm_rule_form(TS, GS, HS, SS, defeater, R).
+mm_ingest_form_(TS, _, _, _, [prefer | Ls]) :- !,
+    mm_sup_pairs(Ls, TS).
+mm_ingest_form_(TS, _, _, _, [meta, Label | KVs]) :- !,
+    add_sexp(TS, [metainfo, Label, KVs]).
+mm_ingest_form_(TS, _, _, SS, [trusts, S, V]) :- !,
+    add_sexp(TS, [trustinfo, [trusts, S, V]]),
+    mm_decf(V, NV),
+    ( call_sexp(SS, [trustval, S, _]) -> true ; add_sexp(SS, [trustval, S, NV]) ).
+mm_ingest_form_(TS, _, _, _, [decays | R])    :- !, add_sexp(TS, [trustinfo, [decays | R]]).
+mm_ingest_form_(TS, _, _, SS, [threshold, N, V]) :- !,
+    add_sexp(TS, [trustinfo, [threshold, N, V]]),
+    mm_decf(V, NV),
+    add_sexp(SS, [threshval, N, NV]).
+mm_ingest_form_(TS, GS, HS, SS, [claims, Source | R]) :- !,
+    mm_claims_attrs(R, At, Note, Forms),
+    add_sexp(TS, [claiminfo, Source, At, Note]),
+    forall(member(F, Forms),
+           ( ( mm_ingest_form_(TS, GS, HS, SS, F)
+               -> mm_record_source(SS, Source, F) ; true ) )).
+mm_ingest_form_(_, _, _, _, _) :- fail.
+
+%% Attribute a claimed fact's literal to its source (for trust weighting).
+mm_record_source(SS, Source, [given, L]) :- !,
+    ( mm_lit(L, Lit), ground(Lit)
+      -> ( call_sexp(SS, [src, Lit, Source]) -> true ; add_sexp(SS, [src, Lit, Source]) )
+      ; true ).
+mm_record_source(_, _, _).
+
+mm_claims_attrs([':at', At | R], At2, Note, Forms) :- !,
+    mm_claims_attrs(R, _, Note, Forms), At2 = At.
+mm_claims_attrs([':note', Note | R], At, Note2, Forms) :- !,
+    mm_claims_attrs(R, At, _, Forms), Note2 = Note.
+mm_claims_attrs(Forms, "", "", Forms).
+
+mm_sup_pairs([A, B | R], TS) :- !,
+    add_sexp(TS, [sup, A, B]),
+    mm_sup_pairs([B | R], TS).
+mm_sup_pairs(_, _).
+
+%% (always|normally|except) [Label] Body Head — label optional by arity.
+mm_rule_form(TS, GS, HS, SS, Kind, [Label, B, H]) :- atom(Label), !,
+    mm_rule_build(TS, GS, HS, SS, Kind, Label, B, H).
+mm_rule_form(TS, GS, HS, SS, Kind, [B, H]) :- !,
+    mm_gensym(r, Label),
+    mm_rule_build(TS, GS, HS, SS, Kind, Label, B, H).
+
+mm_rule_build(TS, GS, HS, SS, Kind, Label, B0, H0) :-
+    mm_planvars([B0, H0], [B1, H1]),
+    mm_body(B1, Body),
+    ( H1 = [otherwise | Ds]
+    -> mm_ctd_expand(TS, GS, HS, SS, Kind, Label, Body, Ds)   % ⊗-chain head
+    ;  mm_lit(H1, Head),
+       mm_add_rule(TS, GS, HS, SS, Label, Kind, Body, Head) ).
+
+%%% Contrary-to-duty (CTD) reparation chains — Governatori's ⊗ operator.
+%%% A head (otherwise D1 D2 ... Dn) means O(D1 ⊗ D2 ⊗ ... ⊗ Dn): D1 is the
+%%% primary obligation; if D1 is VIOLATED its reparation D2 becomes obligatory;
+%%% if D2 is then violated D3 activates; etc. Compiled to ordinary defeasible
+%%% rules whose bodies accumulate the violation literals of the prior duties:
+%%%   Label      : Body                          ⇒ D1
+%%%   Label_rep1 : Body, viol(D1)                ⇒ D2
+%%%   Label_rep2 : Body, viol(D1), viol(D2)      ⇒ D3
+%%% so the normal DL(d) engine derives whichever reparation is currently active.
+%%% viol(O p)=¬p ; viol(F p)=p (F p ≡ O¬p, ideal ¬p, violated by p). A permission
+%%% terminates the chain (it cannot be violated).
+mm_ctd_expand(TS, GS, HS, SS, Kind, Label, Body, Ds) :-
+    maplist(mm_lit, Ds, Lits),
+    mm_ctd_rules(TS, GS, HS, SS, Kind, Label, Body, Lits, 0, []).
+
+mm_ctd_rules(_, _, _, _, _, _, _, [], _, _).
+mm_ctd_rules(TS, GS, HS, SS, Kind, Label, Body, [D|Ds], I, Viols) :-
+    append(Body, Viols, FullBody),
+    ( I =:= 0 -> RLabel = Label
+    ; atom_concat(Label, '_rep', L0), atom_concat(L0, I, RLabel) ),
+    mm_add_rule(TS, GS, HS, SS, RLabel, Kind, FullBody, D),
+    ( Ds == [] -> true
+    ; mm_viol(D, V)
+      -> append(Viols, [V], Viols1), I1 is I + 1,
+         mm_ctd_rules(TS, GS, HS, SS, Kind, Label, Body, Ds, I1, Viols1)
+      ; true ).   % D is a permission (no violation) -> chain ends here
+
+% violation literal of a deontic literal (non-modal proposition that breaches it)
+mm_viol([lit, S, 'O', T, F, A], [lit, S2, none, T, F, A]) :- mm_flip(S, S2).
+mm_viol([lit, S, 'F', T, F, A], [lit, S,  none, T, F, A]).
+
+%% Add a rule: ground rules are compiled straight into the ground space
+%% (constants constraints folded); var rules go to the theory space for the
+%% MeTTa grounding fixpoint. All ground literals are registered as ulits.
+mm_add_rule(TS, GS, HS, SS, Label, Kind, Body, Head) :-
+    add_sexp(TS, [rule, Label, Kind, Body, Head]),
+    ( ground([Body, Head])
+    -> mm_fold_constraints(Body, LogicBody, Ok),
+       ( Ok == true -> FinalBody = LogicBody
+       ; FinalBody = [[lit, pos, none, none, '%never%', []]] ),
+       add_sexp(GS, [grule, Label, Kind, FinalBody, Head]),
+       mm_herb_add(HS, Head),
+       mm_ulit_add(SS, Head),
+       forall(( member(L, FinalBody), L = [lit|_] ), mm_ulit_add(SS, L))
+    ;  true ).   % var rules contribute to the universe ONLY via their actual
+                 % ground instances (emitted by mm_ground) — pre-adding a ground
+                 % head here would put literals like a never-firing rule's head
+                 % into the universe, but grounding only admits literals that
+                 % actually occur in some derivable instance.
+
+%% Evaluate constant constraints; keep logic literals only.
+mm_fold_constraints([], [], true).
+mm_fold_constraints([[lit|L] | R], [[lit|L] | R1], Ok) :- !, mm_fold_constraints(R, R1, Ok).
+mm_fold_constraints([[acmp, Op, L, Rx] | R], R1, Ok) :- !,
+    ( mm_acmp(Op, L, Rx, true) -> mm_fold_constraints(R, R1, Ok) ; R1 = [], Ok = false ).
+mm_fold_constraints([[tcmp, Op, L, Rx] | R], R1, Ok) :- !,
+    ( mm_tcmp(Op, L, Rx, true) -> mm_fold_constraints(R, R1, Ok) ; R1 = [], Ok = false ).
+mm_fold_constraints([[abind, V, Ax] | R], R1, Ok) :- !,
+    ( mm_ax_eval(Ax, Val), V == Val -> mm_fold_constraints(R, R1, Ok)
+    ; R1 = [], Ok = false ).
+mm_fold_constraints([_ | R], R1, Ok) :- mm_fold_constraints(R, R1, Ok).
+
+mm_herb_add(HS, L) :-
+    ( call_sexp(HS, [ha, L]) -> true ; add_sexp(HS, [ha, L]) ).
+mm_ulit_add(SS, L) :-
+    ( call_sexp(SS, [ulit, L]) -> true ; add_sexp(SS, [ulit, L]) ).
+
+call_sexp(Space, [Rel|Args]) :- Term =.. [Space, Rel | Args], catch(Term, _, fail), !.
+
+%% Body normalization: (and a b c) -> items; single item -> [item].
+mm_body([and | Items], Body) :- !, maplist(mm_body_item, Items, Body).
+mm_body(X, [Item]) :- mm_body_item(X, Item).
+
+mm_body_item([bind, V, Ax], [abind, V, Ax1]) :- var(V), !, mm_ax(Ax, Ax1).
+mm_body_item([Op, L, R], [acmp, Op, L1, R1]) :- atom(Op), mm_cmp_op(Op, _), !,
+    mm_ax(L, L1), mm_ax(R, R1).
+mm_body_item([Rel, L, R], [tcmp, Rel, L, R]) :- atom(Rel), mm_allen(Rel), !.
+mm_body_item(X, Lit) :- mm_lit(X, Lit).
+
+%% Allen interval relation: L and R bind to interval handles [iv, S, E] (from
+%% (during LIT ?T) body literals). Implements all 13 Allen interval relations.
+%% Returns true/false (fail-free) so it gates grounding like a comparison.
+mm_tcmp(Rel, L, R, Out) :-
+    once(( ( mm_iallen(Rel, L, R) -> Out = true ; Out = false ) )).
+
+% T = [iv,T1,T2], S = [iv,S1,S2]; mm_tp_lt strict, mm_tp_eq equality (inf-aware)
+mm_iallen(before,         [iv,_,T2],  [iv,S1,_])  :- mm_tp_lt(T2, S1).
+mm_iallen(after,          [iv,T1,_],  [iv,_,S2])  :- mm_tp_lt(S2, T1).
+mm_iallen(meets,          [iv,_,T2],  [iv,S1,_])  :- mm_tp_eq(T2, S1).
+mm_iallen('met-by',       [iv,T1,_],  [iv,_,S2])  :- mm_tp_eq(T1, S2).
+mm_iallen(overlaps,       [iv,T1,T2], [iv,S1,S2]) :- mm_tp_lt(T1,S1), mm_tp_lt(S1,T2), mm_tp_lt(T2,S2).
+mm_iallen('overlapped-by',[iv,T1,T2], [iv,S1,S2]) :- mm_tp_lt(S1,T1), mm_tp_lt(T1,S2), mm_tp_lt(S2,T2).
+mm_iallen(starts,         [iv,T1,T2], [iv,S1,S2]) :- mm_tp_eq(T1,S1), mm_tp_lt(T2,S2).
+mm_iallen('started-by',   [iv,T1,T2], [iv,S1,S2]) :- mm_tp_eq(T1,S1), mm_tp_lt(S2,T2).
+mm_iallen(within,         [iv,T1,T2], [iv,S1,S2]) :- mm_tp_lt(S1,T1), mm_tp_lt(T2,S2).
+mm_iallen(contains,       [iv,T1,T2], [iv,S1,S2]) :- mm_tp_lt(T1,S1), mm_tp_lt(S2,T2).
+mm_iallen(finishes,       [iv,T1,T2], [iv,S1,S2]) :- mm_tp_eq(T2,S2), mm_tp_lt(S1,T1).
+mm_iallen('finished-by',  [iv,T1,T2], [iv,S1,S2]) :- mm_tp_eq(T2,S2), mm_tp_lt(T1,S1).
+mm_iallen(equals,         [iv,T1,T2], [iv,S1,S2]) :- mm_tp_eq(T1,S1), mm_tp_eq(T2,S2).
+
+%% Timepoint order: ninf below, pinf above every moment.
+mm_tp_le(ninf, _, true) :- !.
+mm_tp_le(_, pinf, true) :- !.
+mm_tp_le(pinf, X, R) :- !, ( X == pinf -> R = true ; R = false ).
+mm_tp_le(X, ninf, R) :- !, ( X == ninf -> R = true ; R = false ).
+mm_tp_le(A, B, R) :- number(A), number(B), ( A =< B -> R = true ; R = false ).
+
+mm_tp_eq(A, B) :- mm_tp_le(A, B, true), mm_tp_le(B, A, true).
+mm_tp_lt(A, B) :- mm_tp_le(A, B, true), \+ mm_tp_eq(A, B).
+
+%% Arithmetic expression normalization -> [ax, Op, Args] tree.
+mm_ax(X, X) :- ( var(X) ; number(X) ), !.
+mm_ax([Op | Args], [ax, Op, Args1]) :- atom(Op), mm_ax_op(Op), !,
+    maplist(mm_ax, Args, Args1).
+mm_ax(X, X).
+
+mm_ax_op('+'). mm_ax_op('-'). mm_ax_op('*'). mm_ax_op('/'). mm_ax_op(div).
+mm_ax_op(rem). mm_ax_op('**'). mm_ax_op(abs). mm_ax_op(min). mm_ax_op(max).
+
+%% Literal normalization to the 6-slot functor [lit, Sign, Mode, Temporal, Functor, Args]
+%% — the canonical literal record (negation, deontic mode, temporal qualifier,
+%% predicate name, argument list).
+%%   Sign     : pos | neg               (classical negation)
+%%   Mode     : none | 'O' | 'P' | 'F'  (deontic must/may/forbidden)
+%%   Temporal : none | [iv, Start, End] (Start/End: ninf | pinf | int | var)
+%% Modal and temporal wrappers compose; matching/identity then falls out of
+%% the structure (two lits differing in any slot are distinct atoms).
+mm_lit([not, L], [lit, S2, M, T, F, A]) :- !,
+    mm_lit(L, [lit, S, M, T, F, A]), mm_flip(S, S2).
+mm_lit([must, L], [lit, S, 'O', T, F, A]) :- !, mm_lit(L, [lit, S, _, T, F, A]).
+mm_lit([may, L], [lit, S, 'P', T, F, A]) :- !, mm_lit(L, [lit, S, _, T, F, A]).
+mm_lit([forbidden, L], [lit, S, 'F', T, F, A]) :- !, mm_lit(L, [lit, S, _, T, F, A]).
+% (during LIT S E) — explicit interval bounds (the form facts use).
+mm_lit([during, L, S0, E0], [lit, Sg, M, [iv, S1, E1], F, A]) :- !,
+    mm_lit(L, [lit, Sg, M, _, F, A]),
+    mm_tp(S0, S1), mm_tp(E0, E1).
+% (during LIT ?T) — interval-variable form (rule bodies): the temporal slot is
+% the interval handle ?T, which unifies with the matched fact's [iv,S,E] during
+% grounding and is then read by the Allen relation. This is the interval-variable
+% binding mechanism. The handle may also be an already-built [iv,S,E].
+mm_lit([during, L, T], [lit, Sg, M, T, F, A]) :- !,
+    mm_lit(L, [lit, Sg, M, _, F, A]).
+mm_lit(X, [lit, pos, none, none, X, []]) :- atom(X), !.
+mm_lit([F | Args], [lit, pos, none, none, F, Args]) :- atom(F), \+ mm_reserved(F), !.
+mm_lit(_, _) :- fail.
+
+mm_flip(pos, neg). mm_flip(neg, pos).
+
+%% TimePoint normalization. inf/-inf are sentinels; (moment "RFC3339") -> millis.
+mm_tp(V, V) :- var(V), !.
+mm_tp(inf, pinf) :- !.
+mm_tp('-inf', ninf) :- !.
+mm_tp(N, N) :- number(N), !.
+mm_tp([moment, S], Ms) :- !,
+    ( atom(S) -> A = S ; atom_string(A, S) ),
+    ( parse_time(A, iso_8601, Epoch) -> Ms is round(Epoch * 1000) ; Ms = A ).
+mm_tp(X, X).
+
+mm_reserved(F) :- mm_ax_op(F).
+mm_reserved(F) :- mm_cmp_op(F, _).
+mm_reserved(F) :- mm_allen(F).
+mm_reserved(and). mm_reserved(not). mm_reserved(bind).
+mm_reserved(must). mm_reserved(may). mm_reserved(forbidden). mm_reserved(during).
+mm_reserved(given). mm_reserved(always). mm_reserved(normally).
+mm_reserved(except). mm_reserved(prefer). mm_reserved(meta).
+mm_reserved(otherwise). mm_reserved(deadline).
+mm_reserved(happens). mm_reserved(initiates). mm_reserved(terminates).
+
+% deadline times: (... S E) or (... S E Sanction)
+mm_dl_times([S, E], S, E, none).
+mm_dl_times([S, E, Sanc], S, E, Sanc).
+
+%% The 13 Allen interval relations (body constraints over interval handles).
+mm_allen(before). mm_allen(after). mm_allen(meets). mm_allen('met-by').
+mm_allen(overlaps). mm_allen('overlapped-by'). mm_allen(starts). mm_allen('started-by').
+mm_allen(within). mm_allen(contains). mm_allen(finishes). mm_allen('finished-by').
+mm_allen(equals).
+
+%% Convert MeTTa ?vars to fresh shared Prolog vars (one map per call).
+mm_planvars(In, Out) :- once(mm_planv(In, Out, [], _)).
+mm_planv(X, V, M0, M) :- atom(X), atom_concat('?', _, X), !,
+    ( memberchk(X-V, M0) -> M = M0 ; M = [X-V | M0] ).
+mm_planv(X, X, M, M) :- \+ is_list(X), !.
+mm_planv([], [], M, M) :- !.
+mm_planv([H|T], [H1|T1], M0, M) :- mm_planv(H, H1, M0, M1), mm_planv(T, T1, M1, M).
+
+%%% ----------------------------------------------------------------------
+%%% Output formatting
+%%% ----------------------------------------------------------------------
+
+%% [lit, Sign, Mode, Temporal, Functor, Args] -> canonical display string:
+%%   "f", "~f", "f(a, b)", "[O]pay", "meeting[10,20]", "ev(a)[10,20]"
+%% (the literal rendering used by the CLI and the golden tests).
+mm_lit_str(Lit, Str) :- once(mm_lit_str_(Lit, Str)).
+mm_lit_str_([lit, S, M, T, F, Args], Str) :-
+    ( Args == [] -> Core = F
+    ; maplist(mm_arg_str, Args, ArgStrs),
+      atomic_list_concat(ArgStrs, ', ', Joined),
+      format(atom(Core), "~w(~w)", [F, Joined]) ),
+    mm_mode_str(M, MS),
+    mm_temporal_str(T, TS),
+    ( S == neg -> Neg = "~" ; Neg = "" ),
+    % mode bracket precedes the proposition negation: [O]~p, not ~[O]p — the
+    % deontic mode scopes over the negated proposition. For non-modal lits MS=""
+    % so this is just ~p as before.
+    format(string(Str), "~w~w~w~w", [MS, Neg, Core, TS]).
+
+mm_mode_str(none, "") :- !.
+mm_mode_str(M, S) :- format(string(S), "[~w]", [M]).
+
+mm_temporal_str(none, "") :- !.
+mm_temporal_str([iv, A, B], S) :- mm_tp_str(A, AS), mm_tp_str(B, BS),
+                                  format(string(S), "[~w,~w]", [AS, BS]).
+mm_tp_str(ninf, "-inf") :- !.
+mm_tp_str(pinf, "inf") :- !.
+mm_tp_str(X, X).
+
+%% Nested args render as S-expressions; scalars verbatim; Decimals keep scale.
+mm_arg_str([dec, M, Sc], S) :- !, mm_dec_str(M, Sc, S).
+mm_arg_str(A, S) :- ( is_list(A) -> swrite(A, S) ; format(atom(S), "~w", [A]) ).
+
+%% Render a (mantissa, scale) Decimal preserving trailing zeros, e.g.
+%% 90/2 -> "0.90", 20/1 -> "2.0", 5/1 -> "0.5", 150/2 -> "1.50".
+mm_dec_str(M, Sc, Str) :-
+    ( M < 0 -> Sign = '-', Abs is -M ; Sign = '', Abs = M ),
+    atom_number(AbsA, Abs), atom_length(AbsA, L0),
+    MinLen is Sc + 1,
+    ( L0 < MinLen -> PadN is MinLen - L0, mm_zeros(PadN, Z), atom_concat(Z, AbsA, Digs)
+    ; Digs = AbsA ),
+    atom_length(Digs, L), Ip is L - Sc,
+    sub_atom(Digs, 0, Ip, _, IntPart),
+    sub_atom(Digs, Ip, Sc, _, FracPart),
+    atomic_list_concat([Sign, IntPart, '.', FracPart], Str).
+mm_zeros(0, '') :- !.
+mm_zeros(N, Z) :- N > 0, N1 is N - 1, mm_zeros(N1, Z1), atom_concat('0', Z1, Z).
+
+mm_tag_str(pD, "+D"). mm_tag_str(nD, "-D"). mm_tag_str(pd, "+d"). mm_tag_str(nd, "-d").
+
+%% [tconcl Tag Lit Trust Sources] -> "+D rain (trust: 0.90) [alice]"
+%% (the trust-annotated conclusion line format; sources omitted when empty).
+mm_trust_str([tconcl, Tag, Lit, Trust, Sources], Str) :-
+    once(( mm_tag_str(Tag, TS), mm_lit_str(Lit, LS),
+           T is float(Trust),
+           ( Sources == [] -> SS = ""
+           ; atomic_list_concat(Sources, ', ', SJoin),
+             format(string(SS), " [~w]", [SJoin]) ),
+           format(string(Str), "~w ~w (trust: ~2f)~w", [TS, LS, T, SS]) )).
+
+%% [Tag, Lit] -> "  +D penguin" style line.
+mm_concl_str([Tag, Lit], Str) :-
+    once(( mm_tag_str(Tag, TS), mm_lit_str(Lit, LS),
+           format(string(Str), "~w ~w", [TS, LS]) )).

--- a/src/deontic/platform/io.pl
+++ b/src/deontic/platform/io.pl
@@ -102,6 +102,17 @@ mm_open_mode(Opts, Mode) :-
 'file-get-size!'(Handle, Size) :- once(stream_property(Handle, file_name(F))), size_file(F, Size).
 'file-seek!'(Handle, Pos, true) :- once(seek(Handle, Pos, bof, _)).
 
+%% DL reasoning backend: native (atomspace MeTTa engine) | prolog (fast kernel).
+%% Default reads $OMEGACLAW_DL_ENGINE (else prolog); a runtime set overrides it.
+%% The same theory runs through either path with identical conclusions.
+:- dynamic mm_dl_engine_mode/1.
+mm_dl_engine_get(M) :-
+    ( mm_dl_engine_mode(M0) -> M = M0
+    ; getenv('OMEGACLAW_DL_ENGINE', E), downcase_atom(E, native) -> M = native
+    ; M = prolog ).
+mm_dl_engine_set(M, true) :-
+    once(( retractall(mm_dl_engine_mode(_)), assertz(mm_dl_engine_mode(M)) )).
+
 %% Minimal logger (same spirit as petta_lib_logger, zero external deps).
 :- dynamic mm_log_level/1, mm_log_path/1.
 mm_log_level(info).

--- a/src/deontic/platform/mining.pl
+++ b/src/deontic/platform/mining.pl
@@ -1,0 +1,440 @@
+% Process-mining kernel — the `learn` commands (extract-log / rules /
+% validate-rules).
+%
+% Event logs are extracted from MeTTa `(claims CAT:NAME :at "TS" ... (given F) ...)`
+% blocks (a string scan over the claims/at/given syntax), then the Alpha-style
+% footprint + directly-follows relations drive rule learning with trace-level
+% support/confidence and XOR/mutex conflict detection.
+%
+% NOTE on determinism: rules, conflicts, and `r_mined_N` numbering are emitted as
+% a STABLE sorted set, so the output is reproducible across runs.
+%
+% Self-contained: depends only on SWI builtins (no cross-file predicate calls),
+% so it loads cleanly via import_prolog_functions_from_file.
+
+% ============================================================================
+% Event-log extraction
+% ============================================================================
+
+% mm_event_log(+Files, -Cases)
+%   Files : list of path atoms/strings (one case per file)
+%   Cases : list of [CaseId, Events];  Events : list of [TS, Activity, Actor]
+%           (Activity, Actor : atoms;  TS : string), stable-sorted by TS.
+mm_event_log(Files, Cases) :-
+    once(maplist(mn_file_case, Files, Cases)).
+
+mn_file_case(File, [CaseId, Events]) :-
+    ( atom(File) -> P = File ; atom_string(P, File) ),
+    mn_case_id(P, CaseId),
+    read_file_to_string(P, Content, []),
+    mn_extract_events(Content, Events).
+
+mn_case_id(Path, Id) :-
+    file_base_name(Path, Base),
+    ( file_name_extension(Stem, _, Base), Stem \== '' -> true ; Stem = Base ),
+    ( atom(Stem) -> Id = Stem ; atom_string(Id, Stem) ).
+
+% Split each `(claims ...)` block; the first split fragment is pre-amble (skip).
+mn_extract_events(Content, Sorted) :-
+    mn_split(Content, "(claims ", Frags),
+    ( Frags = [_|Parts] -> true ; Parts = [] ),
+    mn_parts_events(Parts, Events0),
+    mn_stable_by_ts(Events0, Sorted).
+
+mn_parts_events([], []).
+mn_parts_events([P|Ps], Events) :-
+    mn_one_part(P, Es),
+    mn_parts_events(Ps, Rest),
+    append(Es, Rest, Events).
+
+% One claims block: leading [\w:]+ actor, first `:at "..."` timestamp, every
+% `(given [\w-]+)` fact in scope (the fragment ends at the next `(claims `).
+mn_one_part(Part, Events) :-
+    mn_lead_word(Part, Actor),
+    mn_find_ts(Part, TS),
+    findall([TS, Fact, Actor], mn_given_in(Part, Fact), Events).
+
+% ---- string helpers (scan the claims/at/given syntax) ----
+
+% Split String on literal substring Sep.
+mn_split(Str, Sep, [Pre|Rest]) :-
+    ( sub_string(Str, B, _, _, Sep)
+    -> sub_string(Str, 0, B, _, Pre),
+       string_length(Sep, L), Skip is B + L,
+       sub_string(Str, Skip, _, 0, Post),
+       mn_split(Post, Sep, Rest)
+    ; Pre = Str, Rest = [] ).
+
+% Leading run of [\w:]  ->  the claim actor (e.g. agent:coder).
+mn_lead_word(Str, Word) :-
+    string_chars(Str, Cs), mn_take_word(Cs, Wc), atom_chars(Word, Wc).
+mn_take_word([C|Cs], [C|Ws]) :- mn_wordc(C), !, mn_take_word(Cs, Ws).
+mn_take_word(_, []).
+mn_wordc(C) :- ( char_type(C, csym) -> true ; C == ':' ).
+
+% First `:at` followed by whitespace and a quoted string  ->  timestamp ("" if absent).
+mn_find_ts(Part, TS) :-
+    once(( sub_string(Part, B, _, _, ":at"),
+           After is B + 3, sub_string(Part, After, _, 0, R0),
+           mn_skip_ws(R0, R1),
+           sub_string(R1, 0, 1, _, "\""),
+           sub_string(R1, 1, _, 0, R2),
+           sub_string(R2, E, _, _, "\""),
+           sub_string(R2, 0, E, _, TS)
+         ) -> true ; TS = "" ).
+
+% Every `(given [\w-]+)` fact (atom) in the fragment.
+mn_given_in(Part, Fact) :-
+    sub_string(Part, B, _, _, "(given"),
+    After is B + 6, sub_string(Part, After, _, 0, R0),
+    mn_skip_ws1(R0, R1),
+    mn_lead_fact(R1, FactStr, Rest),
+    FactStr \== "",
+    sub_string(Rest, 0, 1, _, ")"),
+    atom_string(Fact, FactStr).
+
+mn_skip_ws(S, R) :-
+    ( sub_string(S, 0, 1, _, C), mn_ws(C)
+    -> sub_string(S, 1, _, 0, S1), mn_skip_ws(S1, R) ; R = S ).
+mn_skip_ws1(S, R) :-
+    sub_string(S, 0, 1, _, C), mn_ws(C),
+    sub_string(S, 1, _, 0, S1), mn_skip_ws(S1, R).
+mn_ws(" "). mn_ws("\t"). mn_ws("\n"). mn_ws("\r").
+
+mn_lead_fact(Str, Fact, Rest) :-
+    string_chars(Str, Cs), mn_take_fact(Cs, Fc, Rc),
+    string_chars(Fact, Fc), string_chars(Rest, Rc).
+mn_take_fact([C|Cs], [C|Fs], R) :- mn_factc(C), !, mn_take_fact(Cs, Fs, R).
+mn_take_fact(Cs, [], Cs).
+mn_factc(C) :- ( char_type(C, csym) -> true ; C == '-' ).
+
+% Stable sort of events by timestamp (keysort is stable; ISO-8601 sorts lexically).
+mn_stable_by_ts(Events, Sorted) :-
+    findall(TS-E, ( member(E, Events), E = [TS|_] ), Pairs),
+    keysort(Pairs, SortedP),
+    pairs_values(SortedP, Sorted).
+
+% ============================================================================
+% Footprint / directly-follows
+% ============================================================================
+
+mn_case_seq([_Id, Events], Seq) :- maplist([E, A]>>(E = [_, A, _]), Events, Seq).
+
+mn_activities(Cases, Acts) :-
+    findall(A, ( member(C, Cases), mn_case_seq(C, S), member(A, S) ), As),
+    sort(As, Acts).
+
+% directly-follows relation as a sorted set of A-B pairs (consecutive in a case).
+mn_df_set(Cases, DF) :-
+    findall(A-B, ( member(C, Cases), mn_case_seq(C, S), mn_adj(S, A, B) ), Ps),
+    sort(Ps, DF).
+mn_adj([A, B|_], A, B).
+mn_adj([_|T], A, B) :- mn_adj(T, A, B).
+
+% causal pairs: A->B observed but B->A not  (sorted for determinism).
+mn_causal(DF, Causal) :-
+    findall(A-B, ( member(A-B, DF), \+ memberchk(B-A, DF) ), C0),
+    sort(C0, Causal).
+
+mn_is_causal(DF, A, B)    :- memberchk(A-B, DF), \+ memberchk(B-A, DF).
+mn_is_unrelated(DF, A, B) :- \+ memberchk(A-B, DF), \+ memberchk(B-A, DF).
+
+% ---- trace-level support & confidence ----
+
+% support(a,b): # cases where a directly precedes b at least once.
+mn_support(Cases, A, B, Sup) :-
+    aggregate_all(count, ( member(C, Cases), mn_case_has_adj(C, A, B) ), Sup).
+mn_case_has_adj(C, A, B) :- mn_case_seq(C, S), ( mn_adj_eq(S, A, B) -> true ).
+mn_adj_eq([X, Y|_], A, B) :- X == A, Y == B, !.
+mn_adj_eq([_|T], A, B) :- mn_adj_eq(T, A, B).
+
+% confidence(a,b): support / (# cases where a has any outgoing transition).
+mn_confidence(Cases, A, B, Conf) :-
+    mn_support(Cases, A, B, Sup),
+    aggregate_all(count, ( member(C, Cases), mn_has_out(C, A) ), D),
+    ( D =:= 0 -> Conf = 0.0 ; Conf is float(Sup) / float(D) ).
+mn_has_out(C, A) :- mn_case_seq(C, S), ( append(_, [A, _|_], S) -> true ).
+
+% ============================================================================
+% Rule learning
+% ============================================================================
+
+% mm_mine_rules(+Files, +MinSup, +MinConf, -Rules)
+%   Rules : list of [Body, Head, Support, ConfStr] (ConfStr = "%.2f"),
+%           sorted by (Body,Head) — deterministic.
+mm_mine_rules(Files, MinSup, MinConf, Rules) :-
+    once(( mm_event_log(Files, Cases),
+           mn_rules_full(Cases, MinSup, MinConf, Full),
+           findall([A, B, Sup, CS], member([A, B, Sup, _, CS], Full), Rules) )).
+
+% internal: full 5-tuple [Body, Head, Support, ConfFloat, ConfStr], sorted.
+mn_rules_full(Cases, MinSup, MinConf, Full) :-
+    mn_df_set(Cases, DF),
+    mn_causal(DF, Causal),
+    findall([A, B, Sup, Conf, CS],
+      ( member(A-B, Causal),
+        mn_support(Cases, A, B, Sup),
+        mn_confidence(Cases, A, B, Conf),
+        Sup >= MinSup, Conf >= MinConf,
+        format(string(CS), "~2f", [Conf]) ),
+      Full).
+
+% ---- dfl render (default `directive learn rules` output) ----
+mm_mine_dfl(Files, MinSup, MinConf, Out) :-
+    once(( mm_event_log(Files, Cases),
+           mn_rules_full(Cases, MinSup, MinConf, Full),
+           with_output_to(string(Out),
+             forall(nth1(I, Full, [A, B, Sup, _, CS]),
+               format("r_mined_~w: ~w >> ~w  ; support=~w, confidence=~w~n",
+                      [I, A, B, Sup, CS]))) )).
+
+% ---- summary render ----
+mm_mine_summary(Files, MinSup, MinConf, Out) :-
+    once(( mm_event_log(Files, Cases),
+           mn_rules_full(Cases, MinSup, MinConf, Full),
+           mn_conflicts(Cases, Conflicts),
+           length(Cases, NC), length(Full, NR), length(Conflicts, NK),
+           with_output_to(string(Out), (
+             format("Mining Results~n==============~n", []),
+             format("Traces: ~w~n", [NC]),
+             format("Rules learned: ~w~n", [NR]),
+             format("Conflicts detected: ~w~n~n", [NK]),
+             ( Full == [] -> true
+             ; format("Learned Rules:~n", []),
+               forall(nth1(I, Full, R), ( mn_rule_block_line(I, R, 1, L), write(L), nl )) ),
+             ( Conflicts == [] -> true
+             ; nl, format("Conflicts:~n", []),
+               forall(member(K, Conflicts), ( mn_conflict_line(K, L), write(L), nl )) )
+           )) )).
+
+% MeTTa line for a learned rule; Gap = #spaces between the rule and "(support...".
+mn_rule_block_line(I, [A, B, Sup, _, CS], Gap, Line) :-
+    ( Gap =:= 2 -> Sp = "  " ; Sp = " " ),
+    format(string(Line),
+      "  (normally r_mined_~w (~w) (~w))~w(support: ~w, confidence: ~w)",
+      [I, A, B, Sp, Sup, CS]).
+
+% ============================================================================
+% Conflict detection (Alpha Petri-net structure: XOR-choice + mutex)
+% ============================================================================
+
+mn_conflicts(Cases, Conflicts) :-
+    mn_df_set(Cases, DF),
+    mn_causal(DF, Causal),
+    mn_activities(Cases, Acts),
+    mn_start_acts(Cases, Start),
+    mn_maximal_pairs(DF, Acts, Causal, Maximal),
+    % XOR-choice groups: >1 start activities, or a maximal-pair B-set with >1 member
+    findall(G, ( ( Start = [_, _|_], G = Start )
+               ; ( member(_-B, Maximal), B = [_, _|_], G = B ) ), Choices),
+    findall([choice, G], member(G, Choices), ChoiceConf),
+    mn_mutex(Cases, Acts, Choices, Mutex),
+    findall([mutex, P], member(P, Mutex), MutexConf),
+    append(ChoiceConf, MutexConf, Conflicts).
+
+mn_start_acts(Cases, S) :-
+    findall(A, ( member(C, Cases), mn_case_seq(C, [A|_]) ), As), sort(As, S).
+mn_end_acts(Cases, E) :-
+    findall(A, ( member(C, Cases), mn_case_seq(C, Seq), last(Seq, A) ), As), sort(As, E).
+
+% pairs (a,b) of activities (a@<b) that never co-occur and aren't a known choice.
+mn_mutex(Cases, Acts, Choices, Pairs) :-
+    findall([A, B],
+      ( mn_ordpair(Acts, A, B),
+        \+ mn_co_occur(Cases, A, B),
+        \+ ( member(G, Choices), memberchk(A, G), memberchk(B, G) ) ),
+      Pairs).
+mn_ordpair(Acts, A, B) :- append(_, [A|Rest], Acts), member(B, Rest).
+mn_co_occur(Cases, A, B) :-
+    once(( member(C, Cases), mn_case_seq(C, S), memberchk(A, S), memberchk(B, S) )).
+
+% ---- Alpha maximal-pair discovery (sorted sets for determinism) ----
+mn_maximal_pairs(DF, Acts, Causal, Maximal) :-
+    findall(As-Bs,
+      ( member(A-B, Causal),
+        mn_extend(DF, Acts, [A], [B], a, A1),
+        mn_extend(DF, Acts, A1, [B], b, B1),
+        sort(A1, As), sort(B1, Bs) ),
+      Extended0),
+    sort(Extended0, Unique),
+    include(mn_is_maximal(Unique), Unique, Maximal).
+
+mn_is_maximal(All, A-B) :-
+    \+ ( member(A2-B2, All), (A2-B2) \== (A-B),
+         ord_subset(A, A2), ord_subset(B, B2) ).
+
+mn_extend(DF, Acts, Set0, Other, Which, Set) :-
+    foldl(mn_try_add(DF, Other, Which), Acts, Set0, Set).
+mn_try_add(DF, B, a, Act, Ain, Aout) :-
+    ( \+ memberchk(Act, Ain), New = [Act|Ain],
+      mn_all_unrelated(DF, New), mn_all_causal(DF, New, B)
+    -> Aout = New ; Aout = Ain ).
+mn_try_add(DF, A, b, Act, Bin, Bout) :-
+    ( \+ memberchk(Act, Bin), New = [Act|Bin],
+      mn_all_unrelated(DF, New), mn_all_causal(DF, A, New)
+    -> Bout = New ; Bout = Bin ).
+
+mn_all_unrelated(DF, Set) :-
+    forall( ( member(X, Set), member(Y, Set), X @< Y ), mn_is_unrelated(DF, X, Y) ).
+mn_all_causal(DF, SetA, SetB) :-
+    forall( ( member(A, SetA), member(B, SetB) ), mn_is_causal(DF, A, B) ).
+
+mn_conflict_line([choice, G], Line) :-
+    atomic_list_concat(G, ', ', Acts),
+    format(string(Line), "  Choice: ~w", [Acts]).
+mn_conflict_line([mutex, [A, B]], Line) :-
+    format(string(Line), "  Mutex: ~w, ~w", [A, B]).
+
+% ============================================================================
+% extract-log renders
+% ============================================================================
+
+mm_extract_summary(Files, Out) :-
+    once(( mm_event_log(Files, Cases),
+           aggregate_all(sum(N), ( member([_, Es], Cases), length(Es, N) ), Total0),
+           ( Total0 == '' -> Total = 0 ; Total = Total0 ),
+           length(Cases, NC),
+           with_output_to(string(Out), (
+             format("Event Log Summary~n=================~n", []),
+             format("Cases: ~w~n", [NC]),
+             format("Total events: ~w~n~n", [Total]),
+             forall(member([Id, Es], Cases), (
+               length(Es, NE),
+               format("Case: ~w (~w events)~n", [Id, NE]),
+               forall(member([TS, Act, Actor], Es),
+                 format("  ~w: ~w (~w)~n", [TS, Act, Actor]))
+             ))
+           )) )).
+
+% events as MeTTa-friendly tuples for tests: [CaseId, [[TS,Act,Actor],...]]
+mm_extract_events_list(Files, Cases) :- mm_event_log(Files, Cases).
+
+% ---- extract-log JSON (the DEFAULT `extract-log` format; deterministic) ----
+% Pretty JSON (2-space indent) with keys in a fixed sorted order:
+% activity<actor<annotations<bindings<timestamp within an event, events<id within
+% a case, cases<metadata at the top level.
+mm_extract_json(Files, Out) :-
+    once(( mm_event_log(Files, Cases),
+           with_output_to(string(Out), mn_json_log(Cases)) )).
+
+mn_json_log(Cases) :-
+    format("{~n  \"cases\": ", []),
+    mn_json_cases(Cases, 2),
+    format(",~n  \"metadata\": {}~n}", []).
+
+mn_json_cases([], _)  :- write("[]").
+mn_json_cases([C|Cs], Ind) :-
+    format("[~n", []), I1 is Ind + 2,
+    mn_json_seq([C|Cs], I1, mn_json_case),
+    nl, mn_indent(Ind), write("]").
+
+mn_json_case([Id, Events], Ind) :-
+    mn_indent(Ind), format("{~n", []), I1 is Ind + 2,
+    mn_indent(I1), write("\"events\": "), mn_json_events(Events, I1),
+    format(",~n", []),
+    mn_indent(I1), write("\"id\": "), mn_jstr(Id), nl,
+    mn_indent(Ind), write("}").
+
+mn_json_events([], _) :- write("[]").
+mn_json_events([E|Es], Ind) :-
+    format("[~n", []), I1 is Ind + 2,
+    mn_json_seq([E|Es], I1, mn_json_event),
+    nl, mn_indent(Ind), write("]").
+
+mn_json_event([TS, Act, Actor], Ind) :-
+    mn_indent(Ind), format("{~n", []), I1 is Ind + 2,
+    mn_indent(I1), write("\"activity\": "), mn_jstr(Act), write(","), nl,
+    mn_indent(I1), write("\"actor\": "), mn_jstr(Actor), write(","), nl,
+    mn_indent(I1), write("\"annotations\": {},"), nl,
+    mn_indent(I1), write("\"bindings\": {},"), nl,
+    mn_indent(I1), write("\"timestamp\": "), mn_jstr(TS), nl,
+    mn_indent(Ind), write("}").
+
+% JSON string literal with " and \ escaped.
+mn_jstr(V) :-
+    ( atom(V) -> atom_string(V, S) ; ( string(V) -> S = V ; term_string(V, S) ) ),
+    write("\""), string_chars(S, Cs),
+    forall(member(C, Cs),
+      ( C == '"'  -> write("\\\"")
+      ; C == '\\' -> write("\\\\")
+      ; write(C) )),
+    write("\"").
+
+% comma-separated JSON array body, one Goal(Item, Indent) per element.
+mn_json_seq([X], Ind, Goal)      :- !, call(Goal, X, Ind).
+mn_json_seq([X|Xs], Ind, Goal)   :- call(Goal, X, Ind), format(",~n", []), mn_json_seq(Xs, Ind, Goal).
+
+mn_indent(N) :- forall(between(1, N, _), write(" ")).
+
+% ---- validate-rules render ----
+% ExistingCount is computed MeTTa-side (non-fact rules in the `against` theory).
+mm_mine_validate(Traces, ExistingCount, Out) :-
+    once(( mm_event_log(Traces, Cases),
+           mn_rules_full(Cases, 1, 0.0, Full),
+           length(Cases, NC), length(Full, NLearned),
+           include(mn_high_conf, Full, High),
+           exclude(mn_high_conf, Full, Low),
+           length(High, NHigh), length(Low, NLow),
+           with_output_to(string(Out), (
+             format("Validation Report~n=================~n", []),
+             format("Traces analyzed: ~w~n", [NC]),
+             format("Rules learned: ~w~n", [NLearned]),
+             format("Existing rules: ~w~n~n", [ExistingCount]),
+             format("Confidence:~n", []),
+             format("  High confidence (>=0.70): ~w rules~n", [NHigh]),
+             format("  Low confidence (<0.70): ~w rules (review recommended)~n~n", [NLow]),
+             ( Full == [] -> true
+             ; format("Learned Rules:~n", []),
+               forall(nth1(I, Full, R), ( mn_rule_block_line(I, R, 2, L), write(L), nl )) ),
+             ( Low == [] -> true
+             ; nl, format("Low Confidence Rules (review recommended):~n", []),
+               forall(member(R, Low), ( nth1(I, Full, R), mn_rule_block_line(I, R, 2, L), write(L), nl )) )
+           )) )).
+mn_high_conf([_, _, _, Conf, _]) :- Conf >= 0.7.
+
+% ---- side-effecting printers (write EXACT CLI bytes; no added newline) ----
+mm_print_extract_summary(Files, true) :-
+    once(( mm_extract_summary(Files, S), write(S) )).
+mm_print_extract_json(Files, true) :-
+    once(( mm_extract_json(Files, S), write(S), nl )).
+mm_print_mine_dfl(Files, MinSup, MinConf, true) :-
+    once(( mm_mine_dfl(Files, MinSup, MinConf, S), write(S) )).
+mm_print_mine_summary(Files, MinSup, MinConf, true) :-
+    once(( mm_mine_summary(Files, MinSup, MinConf, S), write(S) )).
+mm_print_validate(Traces, ExistingCount, true) :-
+    once(( mm_mine_validate(Traces, ExistingCount, S), write(S) )).
+
+% Count non-fact rules in a theory space (for validate-rules "Existing rules").
+mm_count_nonfact(TheorySp, N) :-
+    once(aggregate_all(count,
+      ( G =.. [TheorySp, rule, _, Kind, _, _], catch(G, _, fail), Kind \== fact ),
+      N)).
+
+% ---- CLI argv parsing for the `learn` namespace ----
+% argv layout (run.sh): 0=entry file, 1=--silent, 2=top command, 3..=args.
+mn_learn_args(Args) :-
+    current_prolog_flag(argv, Argv),
+    findall(A, ( nth0(I, Argv, A), I >= 3 ), Args).
+
+mm_learn_files(Files)  :- once(( mn_learn_args(A), mn_files(A, Files) )).
+mm_learn_format(Def, V):- once(( mn_learn_args(A), mn_flag(A, '--format', Def, V) )).
+mm_learn_against(Def, V):- once(( mn_learn_args(A), mn_flag(A, '--against', Def, V0),
+                                  ( atom(V0) -> V = V0 ; atom_string(V, V0) ) )).
+mm_learn_minsup(Def, V):- once(( mn_learn_args(A), mn_flag_num(A, '--min-support', Def, V) )).
+mm_learn_minconf(Def, V):- once(( mn_learn_args(A), mn_flag_num(A, '--min-confidence', Def, V) )).
+
+mn_files([], []).
+mn_files([A|As], Fs) :-
+    ( mn_is_flag(A)
+    -> ( mn_takes_val(A) -> mn_drop_val(As, Rest) ; Rest = As ), mn_files(Rest, Fs)
+    ;  atom_string(A, S), Fs = [S|Fs1], mn_files(As, Fs1) ).
+mn_drop_val([_|R], R).
+mn_drop_val([], []).
+mn_is_flag(A) :- atom(A), sub_atom(A, 0, 2, _, '--').
+mn_takes_val('--format').
+mn_takes_val('--min-support').
+mn_takes_val('--min-confidence').
+mn_takes_val('--against').
+mn_flag(Args, F, Def, Val) :- ( append(_, [F, V|_], Args) -> Val = V ; Val = Def ).
+mn_flag_num(Args, F, Def, Val) :-
+    ( append(_, [F, V|_], Args), atom_number(V, N) -> Val = N ; Val = Def ).

--- a/src/deontic/platform/platform.metta
+++ b/src/deontic/platform/platform.metta
@@ -44,6 +44,33 @@
    (library OmegaClaw-Core src/deontic/platform/eventcalc.pl)
    (mm_dlit mm_print_timeline2))
 
+; Task-coordination kernel: literal-name conventions (task-/ready-/claimed- …
+; prefixes), version scanning, and append-only chain-cancellation block
+; generation for the claim/unclaim/block/unblock/complete lifecycle.
+!(import_prolog_functions_from_file
+   (library OmegaClaw-Core src/deontic/platform/directive.pl)
+   (dir_strip_task dir_lit dir_prefix_task dir_parse_assignment dir_find_versions
+    dir_action_block dir_counter_block dir_complete_block dir_assert_block dir_propagation_block))
+
+; Process-mining kernel: event-log extraction from claims blocks, the Alpha
+; footprint / directly-follows relations, trace-level support & confidence rule
+; learning, and XOR/mutex conflict detection (+ the report/JSON renderers).
+!(import_prolog_functions_from_file
+   (library OmegaClaw-Core src/deontic/platform/mining.pl)
+   (mm_event_log mm_extract_events_list mm_mine_rules mm_extract_summary
+    mm_extract_json mm_mine_dfl mm_mine_summary mm_mine_validate
+    mm_print_extract_summary mm_print_extract_json mm_print_mine_dfl
+    mm_print_mine_summary mm_print_validate mm_count_nonfact
+    mm_learn_files mm_learn_format mm_learn_against mm_learn_minsup mm_learn_minconf))
+
+; Plan-inspection renderers: reasoning trace, plan-structure validation, and
+; agent-assignment listing (deterministic sorted output), plus the analyze
+; report formatter and CLI positional/format helpers.
+!(import_prolog_functions_from_file
+   (library OmegaClaw-Core src/deontic/platform/inspect.pl)
+   (mm_print_trace mm_print_plan_validate mm_print_assign mm_argn_or
+    mm_plan_fmt mm_print_stub mm_print_analyze2))
+
 ; Repo-rooted path helper for data files: (dl-path tests/deontic/x.metta)
 (= (dl-path $rel) (library OmegaClaw-Core $rel))
 

--- a/src/deontic/platform/platform.metta
+++ b/src/deontic/platform/platform.metta
@@ -13,6 +13,7 @@
    (mm_append_file mm_write_file mm_read_file mm_exists
     mm_now_iso mm_clear_space mm_gensym mm_halt mm_print mm_parse_lit mm_srand
     mm_log mm_log_set_level mm_log_set_path
+    mm_dl_engine_get mm_dl_engine_set
     mm_arith_eval mm_acmp mm_num_eq mm_tcmp mm_pct mm_tp_le
     mm_load_into mm_plan_format mm_load_dfl mm_ingest mm_add_fact mm_at_filter
     mm_lit_str mm_concl_str mm_trust_str

--- a/src/deontic/platform/platform.metta
+++ b/src/deontic/platform/platform.metta
@@ -1,0 +1,55 @@
+; Platform layer: registers the deterministic Prolog kernel (io.pl and the fast
+; grounding / reasoning / deontic / event-calculus engines) as MeTTa functions.
+; This is the only module that knows the engine runs on PeTTa (SWI-Prolog).
+;
+; Paths resolve through PeTTa's own (library OmegaClaw-Core <file>) helper, since
+; the engine ships as a repo inside the PeTTa tree — no environment variable and
+; no impl-specific root logic.
+
+!(import! &self (library lib_import))
+
+!(import_prolog_functions_from_file
+   (library OmegaClaw-Core src/deontic/platform/io.pl)
+   (mm_append_file mm_write_file mm_read_file mm_exists
+    mm_now_iso mm_clear_space mm_gensym mm_halt mm_print mm_parse_lit mm_srand
+    mm_log mm_log_set_level mm_log_set_path
+    mm_arith_eval mm_acmp mm_num_eq mm_tcmp mm_pct mm_tp_le
+    mm_load_into mm_plan_format mm_load_dfl mm_ingest mm_add_fact mm_at_filter
+    mm_lit_str mm_concl_str mm_trust_str
+    mm_print_concls mm_print_tconcls
+    file-open! file-close! file-read-to-string! file-write! file-get-size! file-seek!))
+
+; A few SWI builtins that already follow the function convention:
+!(import_prolog_function string_length)
+!(import_prolog_function string_concat)
+
+; fast tabled Datalog grounding (+ semi-naive add-only incremental grounding)
+!(import_prolog_functions_from_file
+   (library OmegaClaw-Core src/deontic/platform/grounding.pl)
+   (mm_ground mm_ground_incr_init mm_ground_delta))
+
+; fast indexed DL(d) reasoner + conclusion enumerator
+!(import_prolog_functions_from_file
+   (library OmegaClaw-Core src/deontic/platform/reason.pl)
+   (mm_reason mm_conclusions))
+
+; Standard Deontic Logic bridges + report formatters
+!(import_prolog_functions_from_file
+   (library OmegaClaw-Core src/deontic/platform/deontic.pl)
+   (mm_deontic_bridge mm_print_verdicts mm_print_dilemmas2 mm_print_deadlines2))
+
+; Event-Calculus obligation lifecycle (obligations as inertial fluents)
+!(import_prolog_functions_from_file
+   (library OmegaClaw-Core src/deontic/platform/eventcalc.pl)
+   (mm_dlit mm_print_timeline2))
+
+; Repo-rooted path helper for data files: (dl-path tests/deontic/x.metta)
+(= (dl-path $rel) (library OmegaClaw-Core $rel))
+
+; Reset all engine spaces (theory, ground rules, herbrand base, statuses).
+(= (dl-reset)
+   (let* (($_1 (mm_clear_space &theory))
+          ($_2 (mm_clear_space &ground))
+          ($_3 (mm_clear_space &herb))
+          ($_4 (mm_clear_space &st)))
+     ()))

--- a/src/deontic/platform/reason.pl
+++ b/src/deontic/platform/reason.pl
@@ -1,0 +1,243 @@
+%%% Fast DL(d) reasoner — WORKLIST algorithm over INTERNED
+%%% integer literal-ids (an integer-id interning of literals).
+%%%
+%%% Every literal is interned to a small integer ONCE (term_hash computed once,
+%%% at intern time); all subsequent indexing — status, rule-by-head, rule-by-
+%%% body-occurrence, the worklist, complements — is keyed on that integer, which
+%%% SWI first-argument-indexes perfectly. This removes the repeated term_hash of
+%%% list-structured literals that dominated the per-probe constant.
+%%%
+%%% Algorithm = the standard DL(d) fixed-point procedure: per-rule body counters
+%%% (mm_pend/mm_disc) maintained incrementally, only affected literals re-examined.
+%%% It reaches the same least fixpoint as the textbook definition, so the proof
+%%% tags it assigns are identical to a naive evaluation.
+%%% Exports (defp Lit)/(dft Lit V) into the status space.
+%%%
+%%% Contract: mm_reason(GroundSp, TheorySp, StatSp, true), after grounding.
+
+:- dynamic mm_idlit/2, mm_litid/3, mm_ulitid/1, mm_compl/2,
+           mm_rd/5, mm_rfh/2, mm_rfb/2,
+           mm_d/2, mm_dd/2, mm_pend/2, mm_disc/1, mm_sup_i/2, mm_wlq/1.
+
+mm_reason(GS, TS, SS, true) :-
+    once(( mm_reason_clear,
+           mm_reason_index(GS, TS, SS),
+           mm_phase1,
+           mm_phase2,
+           mm_phase3,
+           mm_reason_export(SS) )).
+
+mm_reason_clear :-
+    retractall(mm_idlit(_,_)), retractall(mm_litid(_,_,_)), retractall(mm_ulitid(_)),
+    retractall(mm_compl(_,_)), retractall(mm_rd(_,_,_,_,_)),
+    retractall(mm_rfh(_,_)), retractall(mm_rfb(_,_)),
+    retractall(mm_d(_,_)), retractall(mm_dd(_,_)),
+    retractall(mm_pend(_,_)), retractall(mm_disc(_)),
+    retractall(mm_sup_i(_,_)), retractall(mm_wlq(_)),
+    nb_setval(mm_idc, 0).
+
+% --- interning: literal <-> integer id (term_hash computed once) -----------
+mm_intern(Lit, Id) :-
+    term_hash(Lit, H),
+    ( mm_litid(H, Lit, Id0) -> Id = Id0
+    ; nb_getval(mm_idc, N), Id is N + 1, nb_setval(mm_idc, Id),
+      assertz(mm_litid(H, Lit, Id)), assertz(mm_idlit(Id, Lit)),
+      mm_lit_compl(Lit, CLit), mm_intern_compl(CLit, Id) ).
+
+% intern the complement and link both ways (so mm_compl is a pure integer hop)
+mm_intern_compl(CLit, Id) :-
+    term_hash(CLit, CH),
+    ( mm_litid(CH, CLit, CId)
+    -> assertz(mm_compl(Id, CId)), assertz(mm_compl(CId, Id))
+    ;  nb_getval(mm_idc, N), CId is N + 1, nb_setval(mm_idc, CId),
+       assertz(mm_litid(CH, CLit, CId)), assertz(mm_idlit(CId, CLit)),
+       assertz(mm_compl(Id, CId)), assertz(mm_compl(CId, Id)) ).
+
+mm_lit_compl([lit, pos, M, T, F, A], [lit, neg, M, T, F, A]).
+mm_lit_compl([lit, neg, M, T, F, A], [lit, pos, M, T, F, A]).
+
+mm_reason_index(GS, TS, SS) :-
+    % universe first, so every occurring literal (and its complement) is interned
+    forall(mm_space(SS, [ulit, Lit]),
+           ( mm_intern(Lit, Id), ( mm_ulitid(Id) -> true ; assertz(mm_ulitid(Id)) ) )),
+    % rules, with head/body interned to ids
+    nb_setval(mm_rid, 0),
+    forall(mm_space(GS, [grule, L, K, B, H]),
+           ( nb_getval(mm_rid, N), N1 is N + 1, nb_setval(mm_rid, N1),
+             mm_intern(H, HId), maplist(mm_intern, B, BIds),
+             assertz(mm_rd(N1, L, K, BIds, HId)),
+             assertz(mm_rfh(HId, N1)),
+             forall(member(BId, BIds), assertz(mm_rfb(BId, N1))) )),
+    forall(mm_space(TS, [sup, W, L]), assertz(mm_sup_i(W, L))).
+
+mm_space(Space, [Rel|Args]) :- G =.. [Space, Rel | Args], catch(call(G), _, fail).
+
+mm_compl_of(Id, CId) :- ( mm_compl(Id, CId0) -> CId = CId0 ; CId = 0 ). % 0 = absent
+
+mm_def_kind(fact). mm_def_kind(strict).
+mm_sd_kind(fact). mm_sd_kind(strict). mm_sd_kind(defeasible).
+
+% --- status (all integer-keyed) ------------------------------------------
+mm_defp(Id)     :- mm_d(Id, true).
+mm_d_known(Id)  :- mm_d(Id, _).
+mm_set_d(Id, V) :- ( mm_d(Id, _) -> true ; assertz(mm_d(Id, V)) ).
+
+mm_dft(Id, V)    :- ( mm_dd(Id, V0) -> V = V0 ; V = unknown ).
+mm_dd_known(Id)  :- mm_dd(Id, _).
+mm_set_dd(Id, V) :- ( mm_dd(Id, _) -> true ; assertz(mm_dd(Id, V)) ).
+
+mm_rule_head(Id, Rid, L, K, B) :- mm_rfh(Id, Rid), mm_rd(Rid, L, K, B, Id).
+mm_applicable(Rid) :- mm_pend(Rid, 0), \+ mm_disc(Rid).
+
+% =====================================================================
+% Phase 1: definite provability (strict rules)
+% =====================================================================
+mm_phase1 :-
+    retractall(mm_pend(_,_)), retractall(mm_disc(_)), retractall(mm_wlq(_)),
+    forall(( mm_rd(Rid, _, strict, B, _), length(B, N) ), assertz(mm_pend(Rid, N))),
+    forall(( mm_rd(_, _, fact, _, H) ), mm_d1_set(H, true)),
+    forall(( mm_ulitid(Q), \+ mm_d_known(Q),
+             \+ mm_rule_head(Q, _, _, strict, _),
+             \+ mm_rule_head(Q, _, _, fact, _) ),
+           mm_d1_set(Q, false)),
+    mm_d1_drain.
+
+mm_d1_set(Q, V) :- ( \+ mm_ulitid(Q) -> true ; mm_d_known(Q) -> true
+                   ; mm_set_d(Q, V), assertz(mm_wlq(Q-V)) ).
+
+mm_d1_drain :-
+    ( retract(mm_wlq(Q-Proved))
+    -> forall(( mm_rfb(Q, Rid), mm_rd(Rid, _, strict, _, _) ), mm_d1_update(Rid, Proved)),
+       mm_d1_drain
+    ;  true ).
+
+mm_d1_update(Rid, true) :-
+    ( mm_disc(Rid) -> true
+    ; retract(mm_pend(Rid, N)), N1 is N - 1, assertz(mm_pend(Rid, N1)),
+      ( N1 =:= 0 -> mm_rd(Rid, _, _, _, H), mm_d1_set(H, true) ; true ) ).
+mm_d1_update(Rid, false) :-
+    ( mm_disc(Rid) -> true ; assertz(mm_disc(Rid)) ),
+    mm_rd(Rid, _, _, _, H),
+    ( mm_d_known(H) -> true
+    ; ( \+ ( mm_rule_head(H, R2, _, strict, _), \+ mm_disc(R2) ) -> mm_d1_set(H, false) ; true ) ).
+
+% =====================================================================
+% Phase 2: defeasible provability (all rules)
+% =====================================================================
+mm_phase2 :-
+    retractall(mm_pend(_,_)), retractall(mm_disc(_)), retractall(mm_wlq(_)),
+    forall(( mm_rd(Rid, _, _, B, _), length(B, N) ), assertz(mm_pend(Rid, N))),
+    forall(( mm_ulitid(Q), mm_defp(Q) ),
+           ( mm_compl_of(Q, NQ),
+             ( mm_defp(NQ) -> mm_d2_set(Q, false) ; mm_d2_set(Q, true) ) )),
+    forall(( mm_ulitid(Q), \+ mm_dd_known(Q), mm_d(Q, false), \+ mm_has_sd(Q) ),
+           mm_d2_set(Q, false)),
+    forall(( mm_rd(_, _, K, [], H), mm_sd_kind(K) ), mm_try_pd(H)),
+    mm_d2_drain.
+
+mm_has_sd(Q) :- mm_rule_head(Q, _, _, K, _), mm_sd_kind(K), !.
+
+mm_d2_set(Q, V) :- ( \+ mm_ulitid(Q) -> true ; mm_dd_known(Q) -> true
+                   ; mm_set_dd(Q, V), assertz(mm_wlq(Q-V)) ).
+
+mm_d2_drain :-
+    ( retract(mm_wlq(Q-Proved)) -> mm_d2_propagate(Q, Proved), mm_d2_drain ; true ).
+
+mm_d2_propagate(Q, Proved) :-
+    forall(mm_rfb(Q, Rid), mm_d2_count(Rid, Proved)),
+    ( Proved == true -> mm_d2_on_pos(Q) ; mm_d2_on_neg(Q) ).
+
+mm_d2_count(Rid, true) :-
+    ( mm_disc(Rid) -> true ; retract(mm_pend(Rid, N)), N1 is N - 1, assertz(mm_pend(Rid, N1)) ).
+mm_d2_count(Rid, false) :-
+    ( mm_disc(Rid) -> true ; assertz(mm_disc(Rid)) ).
+
+mm_d2_on_pos(Q) :-
+    forall(( mm_rfb(Q, Rid), mm_applicable(Rid), mm_rd(Rid, _, K, _, H) ),
+           ( mm_compl_of(H, NH),
+             ( mm_sd_kind(K) -> mm_try_pd(H), mm_try_pd(NH), mm_try_nd(NH)
+             ;                  mm_try_pd(NH), mm_try_nd(NH) ) )),
+    mm_compl_of(Q, NQ), mm_try_nd(NQ).
+
+mm_d2_on_neg(Q) :-
+    forall(( mm_rfb(Q, Rid), mm_rd(Rid, _, _, _, H) ),
+           ( mm_try_nd(H), mm_compl_of(H, NH), mm_try_pd(NH) )),
+    mm_compl_of(Q, NQ), mm_try_pd(NQ).
+
+% --- try-prove a literal defeasibly ---
+mm_try_pd(Q) :-
+    ( \+ mm_ulitid(Q) -> true
+    ; mm_dd_known(Q) -> true
+    ; \+ mm_pd_has_applicable(Q) -> true
+    ; mm_compl_of(Q, NQ), mm_defp(NQ) -> true        % (2): ~q must NOT be +D
+    ; mm_pd_attacks_clear(Q) -> mm_d2_set(Q, true)
+    ; true ).
+
+mm_pd_has_applicable(Q) :- mm_rule_head(Q, Rid, _, K, _), mm_sd_kind(K), mm_applicable(Rid), !.
+
+% (3): every attacker in R[~q] is discarded, or applicable+nonstrict+beaten.
+% Undecided attacker (neither) fails the forall ⇒ wait; re-triggered when it
+% resolves (its head's complement is q).
+mm_pd_attacks_clear(Q) :-
+    mm_compl_of(Q, NQ),
+    forall( mm_rule_head(NQ, Rid, Ls, Ks, _),
+            ( mm_disc(Rid)
+            ; mm_applicable(Rid), Ks \== strict, mm_beaten(Q, Ls) )).
+
+mm_beaten(Q, Ls) :-
+    mm_rule_head(Q, Rid, Lt, K, _), mm_sd_kind(K), mm_applicable(Rid), mm_sup_i(Lt, Ls), !.
+
+% --- try-disprove a literal defeasibly ---
+mm_try_nd(Q) :-
+    ( \+ mm_ulitid(Q) -> true
+    ; mm_dd_known(Q) -> true
+    ; mm_defp(Q) -> true
+    ; mm_compl_of(Q, NQ), mm_defp(NQ) -> mm_d2_set(Q, false)
+    ; mm_nd_all_discarded(Q) -> mm_d2_set(Q, false)
+    ; mm_nd_unbeatable(Q) -> mm_d2_set(Q, false)
+    ; true ).
+
+mm_nd_all_discarded(Q) :-
+    \+ ( mm_rule_head(Q, Rid, _, K, _), mm_sd_kind(K), \+ mm_disc(Rid) ).
+
+mm_nd_unbeatable(Q) :-
+    mm_compl_of(Q, NQ),
+    mm_rule_head(NQ, Rid, Ls, Ks, _), mm_applicable(Rid),
+    ( Ks == strict -> true
+    ; \+ mm_nd_defender_undecided(Q, Ls), mm_nd_defenders_fail(Q, Ls) ), !.
+
+mm_nd_defender_undecided(Q, Ls) :-
+    mm_rule_head(Q, Rid, Lt, K, _), mm_sd_kind(K),
+    \+ mm_disc(Rid), \+ mm_applicable(Rid), mm_sup_i(Lt, Ls), !.
+
+mm_nd_defenders_fail(Q, Ls) :-
+    \+ ( mm_rule_head(Q, Rid, Lt, K, _), mm_sd_kind(K), \+ mm_disc(Rid), mm_sup_i(Lt, Ls) ).
+
+% =====================================================================
+% Phase 3: closed-world negatives
+% =====================================================================
+mm_phase3 :-
+    forall(( mm_ulitid(Q), \+ mm_d_known(Q) ), mm_set_d(Q, false)),
+    forall(( mm_ulitid(Q), \+ mm_dd_known(Q) ), mm_set_dd(Q, false)).
+
+% =====================================================================
+% export status to &st (recover literals from ids)
+% =====================================================================
+mm_reason_export(SS) :-
+    forall(( mm_d(Id, true), mm_idlit(Id, Lit) ),
+           ( G =.. [SS, defp, Lit], ( catch(call(G), _, fail) -> true ; assertz(G) ) )),
+    forall(( mm_dd(Id, V), mm_idlit(Id, Lit) ),
+           ( D =.. [SS, dft, Lit, V], ( catch(call(D), _, fail) -> true ; assertz(D) ) )).
+
+% Fast conclusion enumeration straight from the interned (integer-indexed)
+% status — O(universe) + sort, vs a MeTTa collapse over the &st space. The
+% interned tables persist until the next mm_reason, so this is valid right
+% after reasoning. Returns sorted [Tag, Lit] tuples (pD/nD/pd/nd).
+mm_conclusions(Cs) :-
+    findall([T, Lit], ( mm_ulitid(Id), mm_idlit(Id, Lit), mm_concl_tag(Id, T) ), Cs0),
+    sort(Cs0, Cs).
+
+mm_concl_tag(Id, 'pD') :- mm_d(Id, true).
+mm_concl_tag(Id, 'nD') :- mm_d(Id, false).
+mm_concl_tag(Id, 'pd') :- mm_dd(Id, true).
+mm_concl_tag(Id, 'nd') :- mm_dd(Id, false).

--- a/src/deontic/query.metta
+++ b/src/deontic/query.metta
@@ -1,0 +1,144 @@
+; Non-monotonic query operators over a defeasible theory. Because adding premises
+; can RETRACT conclusions, these are not classical-entailment queries: what-if,
+; why-not, abduce, requires.
+;
+; All operators work over the engine state after (dl-run ...); operators that
+; need a MODIFIED theory (what-if, requires verification) reload the file and
+; inject hypothesis facts via the platform kernel (a clone-and-add-fact step).
+
+; --- positive-status helpers over the current state (pos? lives in types) ---
+(= (positive-lits)
+   (collapse (let $q (ulit-gen)
+     (if (== (pos? $q) True) $q (empty)))))
+
+; goal status in the current state: provable | refuted | unknown
+(= (goal-status $goal)
+   (if (== (pos? $goal) True)
+       provable
+       (if (== (pos? (lit-neg $goal)) True)
+           refuted
+           unknown)))
+
+; =====================================================================
+; what-if: assume facts, re-reason, diff against baseline
+;   -> (whatif <status> (new <lits...>) (assumed <lits...>))
+; =====================================================================
+(= (inject-facts $lits)
+   (let $_ (map-atom $lits $l (mm_add_fact $l &theory &ground &herb &st)) ()))
+
+(= (dl-what-if $path $hyps $goal)
+   (let* (($_b (dl-run $path))
+          ($pos0 (positive-lits))
+          ($_l (dl-load $path))
+          ($_i (inject-facts $hyps))
+          ($_r (dl-reason!))
+          ($status (goal-status $goal))
+          ($new (subtraction-atom (positive-lits) $pos0)))
+     (whatif $status (new (sort-atom $new)) (assumed $hyps))))
+
+; =====================================================================
+; abduce: one backward step over supporting ground rules
+;   -> (abduction <goal> (solutions ((facts...) ...)))
+;      empty fact-set as first solution means "already provable"
+; =====================================================================
+; body literals not already in the proven set (order-preserving)
+(= (missing-of $b $pos)
+   (filter-atom $b $h (not (== (is-member $h $pos) True))))
+
+(= (abduce-candidates $goal $pos)
+   (collapse
+     (match &ground (grule $l $k $b $goal)
+       (if (== $k defeater)
+           (empty)
+           (let $miss (missing-of $b $pos)
+             (if (== $miss ()) (empty) (sort-atom $miss)))))))
+
+(= (dl-abduce $goal)
+   (if (== (pos? $goal) True)
+       (abduction $goal (solutions (())))
+       (let* (($pos (positive-lits))
+              ($cands (unique-atom (abduce-candidates $goal $pos))))
+         (if (== $cands ())
+             (abduction $goal (solutions (($goal))))
+             (abduction $goal (solutions (sort-by-size $cands)))))))
+
+; smallest-first ordering (fewest assumed facts first)
+(= (sort-by-size $xs)
+   (map-atom (sort-atom (map-atom $xs $x ((size-atom $x) $x))) $p
+             (index-atom $p 1)))
+
+; =====================================================================
+; requires: verify candidates by injection + re-reasoning
+;   -> (requires <goal> already-provable)
+;    | (requires <goal> (verified <facts...>))
+;    | (requires <goal> none)
+; =====================================================================
+(= (verify-candidate $path $goal $facts)
+   (let* (($_l (dl-load $path))
+          ($_i (inject-facts $facts))
+          ($_r (dl-reason!)))
+     (pos? $goal)))
+
+(= (first-verified $path $goal $cands)
+   (if (== $cands ())
+       none
+       (if (== (verify-candidate $path $goal (car-atom $cands)) True)
+           (verified (car-atom $cands))
+           (first-verified $path $goal (cdr-atom $cands)))))
+
+(= (dl-requires $path $goal)
+   (let* (($_ (dl-run $path))
+          ($abd (dl-abduce $goal)))
+     (let (abduction $g (solutions $sols)) $abd
+       (if (== (car-atom $sols) ())
+           (requires $goal already-provable)
+           (requires $goal (first-verified $path $goal $sols))))))
+
+; =====================================================================
+; why-not: blockers per supporting rule
+;   -> (whynot <goal> (would <label>|()) (blockers (...)))
+;      blocker: (missing <rule> (<lits>)) | (defeated <rule> <by>)
+;             | (contradicted <rule> <by>) | (ambiguity <rule>)
+;             | (complement-proven)
+; =====================================================================
+(= (dl-why-not $goal)
+   (if (== (pos? $goal) True)
+       (whynot $goal provable)
+       (let* (($pos (positive-lits))
+              ($supps (collapse (match &ground (grule $l $k $b $goal)
+                        (if (== $k defeater) (empty) ($l $b)))))
+              ($would (if (== $supps ()) () (car-atom (car-atom $supps))))
+              ($blockers (wn-blockers $supps $goal $pos)))
+         (if (== $supps ())
+             (whynot $goal (would ())
+                     (blockers (if (== (is-member (lit-neg $goal) $pos) True)
+                                   ((complement-proven))
+                                   ())))
+             (whynot $goal (would $would) (blockers $blockers))))))
+
+(= (wn-blockers $supps $goal $pos)
+   (if (== $supps ()) ()
+       (let* ((($l $b) (car-atom $supps))
+              ($rest (wn-blockers (cdr-atom $supps) $goal $pos))
+              ($miss (missing-of $b $pos)))
+         (if (not (== $miss ()))
+             (cons-atom (missing $l $miss) $rest)
+             (let $atts (wn-attackers $l $goal $pos)
+               (if (== $atts ())
+                   (cons-atom (ambiguity $l) $rest)
+                   (union-atom $atts $rest)))))))
+
+; attackers of <rule $l> for goal: applicable rules for ~goal
+; (defeaters block unless the rule is superior; defeasible attackers block
+;  unless the rule is strictly superior)
+(= (wn-attackers $l $goal $pos)
+   (let $nq (lit-neg $goal)
+     (collapse
+       (match &ground (grule $ls $ks $bs $nq)
+         (if (== (missing-of $bs $pos) ())
+             (if (== $ks defeater)
+                 (if (== (sup? $l $ls) True) (empty) (defeated $l $ls))
+                 (if (and (== (sup? $l $ls) True) (== (sup? $ls $l) False))
+                     (empty)
+                     (contradicted $l $ls)))
+             (empty))))))

--- a/src/deontic/reason.metta
+++ b/src/deontic/reason.metta
@@ -1,0 +1,199 @@
+; Defeasible Logic inference — the DL(d) proof theory (Nute; Antoniou et al.).
+; Computed here as naive fixpoint sweeps over the ground theory; the same monotone
+; conditions are realised by the fast worklist engine in platform/reason.pl.
+;
+; Phase 1  (+Δ): definite provability — facts + strict forward chaining.
+; Phase 2  (+∂/-∂): defeasible provability — seeded, then swept with the standard
+;          try-prove / try-disprove conditions, including:
+;            - strict attackers can never be defeated by superiority;
+;            - a defeasible attacker with an undecided body IS countered
+;              if an applicable supporter is superior to it.
+; Phase 3  closed-world emission: -Δ = not(+Δ), -∂ = not(+∂) at fixpoint.
+
+; =====================================================================
+; Phase 1: definite provability (+Δ)
+; =====================================================================
+
+(= (try-pD $q)
+   (if (== (defp? $q) True)
+       0
+       (if (== () (collapse
+             (match &ground (grule $l $k $b $q)
+               (if (and (== (def-kind? $k) True) (== (body-all-defp $b) True))
+                   yes
+                   (empty)))))
+           0
+           (set-defp $q))))
+
+(= (pass-pD)
+   (foldall + (let $q (ulit-gen) (try-pD $q)) 0))
+
+(= (phase1!) (if (> (pass-pD) 0) (phase1!) ()))
+
+; =====================================================================
+; Phase 2: defeasible provability (+∂/-∂)
+; =====================================================================
+
+; --- seeds (initialise +∂/-∂ before the sweep) ---
+(= (seed-dft $q)
+   (if (not (== (dft-of $q) unknown))
+       0
+       (if (== (defp? $q) True)
+           (if (== (defp? (lit-neg $q)) True)
+               (set-dft $q false)     ; +D q and +D ~q: condition (2) fails
+               (set-dft $q true))     ; +D q and -D ~q: subsumption
+           (if (== (has-sd-rule $q) True)
+               0
+               (set-dft $q false)))))  ; no Rsd support at all
+
+(= (has-sd-rule $q)
+   (case (once (match &ground (grule $l $k $b $q)
+           (if (== (sd-kind? $k) True) yes (empty))))
+     ((yes True) (Empty False))))
+
+(= (seeds!)
+   (let $_ (collapse (let $q (ulit-gen) (seed-dft $q))) ()))
+
+; --- condition (1): ∃ applicable supporter in Rsd[q] ---
+(= (has-applicable-sd $q)
+   (case (once (match &ground (grule $l $k $b $q)
+           (if (and (== (sd-kind? $k) True) (== (body-all-pd $b) True))
+               yes
+               (empty))))
+     ((yes True) (Empty False))))
+
+; --- ∃ applicable supporter t ∈ Rsd[q] with t > s (template labels) ---
+(= (beaten? $q $ls)
+   (case (once (match &ground (grule $lt $kt $bt $q)
+           (if (and (== (sd-kind? $kt) True)
+                    (and (== (body-all-pd $bt) True) (== (sup? $lt $ls) True)))
+               yes
+               (empty))))
+     ((yes True) (Empty False))))
+
+; --- try-prove a literal defeasibly (+∂): a supporter fires and all attackers clear ---
+(= (try-pd $q)
+   (if (not (== (dft-of $q) unknown))
+       0
+       (if (== (has-applicable-sd $q) False)
+           0
+           (if (== (defp? (lit-neg $q)) True)
+               0
+               (if (== (attack-clear $q) True)
+                   (set-dft $q true)
+                   0)))))
+
+; condition (3): walk every attacker s ∈ R[~q] (all rule kinds).
+(= (attack-clear $q)
+   (let $nq (lit-neg $q)
+     (att-walk $q (collapse
+       (match &ground (grule $ls $ks $bs $nq) ($ls $ks $bs))))))
+
+(= (att-walk $q $as)
+   (if (== $as ())
+       True
+       (let ($ls $ks $bs) (car-atom $as)
+         (if (== (body-some-nd $bs) True)
+             (att-walk $q (cdr-atom $as))                 ; discarded attacker
+             (if (== $ks strict)
+                 False                                     ; strict always blocks
+                 (if (== (beaten? $q $ls) True)
+                     (att-walk $q (cdr-atom $as))          ; countered by superior
+                     False))))))                           ; undefeated/undecided
+
+; --- try-disprove a literal defeasibly (-∂): no supporter survives its attackers ---
+(= (try-nd $q)
+   (if (not (== (dft-of $q) unknown))
+       0
+       (if (== (defp? $q) True)
+           0
+           (if (== (defp? (lit-neg $q)) True)
+               (set-dft $q false)                          ; disjunct (2)
+               (if (== (all-sd-discarded $q) True)
+                   (set-dft $q false)                      ; disjunct (1)
+                   (if (== (unbeatable-attacker? $q) True)
+                       (set-dft $q false)                  ; disjunct (3)
+                       0))))))
+
+(= (all-sd-discarded $q)
+   (case (once (match &ground (grule $l $k $b $q)
+           (if (and (== (sd-kind? $k) True) (== (body-some-nd $b) False))
+               alive
+               (empty))))
+     ((alive False) (Empty True))))
+
+(= (unbeatable-attacker? $q)
+   (let $nq (lit-neg $q)
+     (datt-walk $q (collapse
+       (match &ground (grule $ls $ks $bs $nq) ($ls $ks $bs))))))
+
+(= (datt-walk $q $as)
+   (if (== $as ())
+       False
+       (let ($ls $ks $bs) (car-atom $as)
+         (if (not (== (body-all-pd $bs) True))
+             (datt-walk $q (cdr-atom $as))                 ; attacker not applicable
+             (if (== $ks strict)
+                 True                                      ; strict attacker: -d now
+                 (if (== (any-defender-undecided $q $ls) True)
+                     (datt-walk $q (cdr-atom $as))         ; wait for that defender
+                     (if (== (all-defenders-fail $q $ls) True)
+                         True
+                         (datt-walk $q (cdr-atom $as)))))))))
+
+; ∃t ∈ Rsd[q]: not discarded, body undecided, and t > s
+(= (any-defender-undecided $q $ls)
+   (case (once (match &ground (grule $lt $kt $bt $q)
+           (if (and (== (sd-kind? $kt) True)
+                    (and (== (body-some-nd $bt) False)
+                         (and (not (== (body-all-pd $bt) True))
+                              (== (sup? $lt $ls) True))))
+               yes
+               (empty))))
+     ((yes True) (Empty False))))
+
+; ∀t ∈ Rsd[q]: discarded OR not(t > s)
+(= (all-defenders-fail $q $ls)
+   (case (once (match &ground (grule $lt $kt $bt $q)
+           (if (and (== (sd-kind? $kt) True)
+                    (and (== (body-some-nd $bt) False) (== (sup? $lt $ls) True)))
+               survivor
+               (empty))))
+     ((survivor False) (Empty True))))
+
+; --- fixpoint sweep ---
+(= (pass-dft)
+   (foldall + (let $q (ulit-gen) (+ (try-pd $q) (try-nd $q))) 0))
+
+(= (phase2!)
+   (let $_ (seeds!)
+     (phase2-loop!)))
+(= (phase2-loop!) (if (> (pass-dft) 0) (phase2-loop!) ()))
+
+; =====================================================================
+; Phase 3: closed-world negatives (-Δ/-∂ at fixpoint)
+; =====================================================================
+
+(= (finalize-lit $q)
+   (if (== (dft-of $q) unknown) (set-dft $q false) 0))
+
+(= (phase3!)
+   (let $_ (collapse (let $q (ulit-gen) (finalize-lit $q))) ()))
+
+; =====================================================================
+; Driver + conclusions
+; =====================================================================
+
+(= (reason!)
+   (let* (($_1 (phase1!))
+          ($_2 (phase2!))
+          ($_3 (phase3!)))
+     ()))
+
+; Per-literal conclusion pair: (+D|-D) and (+d|-d), as tag tuples.
+(= (concl-of $q)
+   (superpose ((if (== (defp? $q) True) (pD $q) (nD $q))
+               (if (== (dft-of $q) true) (pd $q) (nd $q)))))
+
+(= (conclusions)
+   (collapse (let $q (ulit-gen) (concl-of $q))))

--- a/src/deontic/trust.metta
+++ b/src/deontic/trust.metta
@@ -1,0 +1,95 @@
+; Trust-weighted defeasible reasoning (weakest link over the proof tree).
+;
+; Trust is the WEAKEST LINK along the derivation:
+; the trust of a conclusion is the minimum trust over its proof tree, where
+;   - a claimed fact leaf has its source's trust  (trusts S V);
+;   - a rule node has the rule's trust, which has no MeTTa surface syntax and so
+;     defaults to 0.0, so any rule-derived literal carries trust 0.00 unless
+;     every step in its derivation is a trusted fact.
+; Source attribution is the union of the claiming sources across the tree.
+;
+; Reuses the proof tree from explain.metta, so trust = a fold over (explain lit).
+
+; --- source / trust lookups (populated by the platform ingester into &st) ---
+(= (source-trust-val $s)
+   (case (once (match &st (trustval $s $v) $v))
+     (($v $v) (Empty 0.0))))          ; source absent from trust map -> default 0.0
+
+(= (lit-sources $l) (sort-atom (collapse (match &st (src $l $s) $s))))
+
+; A fact's trust: best (max) of its claiming sources; an unclaimed fact is
+; taken at face value (1.0 — asserted without provenance).
+(= (fact-trust $l)
+   (let $ss (lit-sources $l)
+     (if (== $ss ()) 1.0
+         (foldl-atom (map-atom $ss $s (source-trust-val $s)) 0.0 $a $x (max $a $x)))))
+
+; Rules carry no trust in MeTTa -> default 0.0 (weakest link of any derivation).
+(= (rule-trust $lbl) 0.0)
+
+; --- weakest-link over the proof tree ---
+(= (trust-of $lit) (proof-trust (explain $lit)))
+
+(= (proof-trust (no-proof $l)) 0.0)
+(= (proof-trust (cycle $l)) 0.0)
+(= (proof-trust (proof $l (fact $lbl))) (fact-trust $l))
+(= (proof-trust (proof $l (rule $lbl $subs)))
+   (foldl-atom (map-atom $subs $s (proof-trust $s))
+               (rule-trust $lbl) $a $x (min $a $x)))
+
+; --- source union over the proof tree ---
+(= (sources-of $lit) (sort-atom (proof-sources (explain $lit))))
+
+(= (proof-sources (no-proof $l)) ())
+(= (proof-sources (cycle $l)) ())
+(= (proof-sources (proof $l (fact $lbl))) (lit-sources $l))
+(= (proof-sources (proof $l (rule $lbl $subs)))
+   (unique-atom (foldl-atom (map-atom $subs $s (proof-sources $s))
+                            () $a $x (union-atom $a $x))))
+
+; --- threshold filtering (a literal passes iff its trust >= threshold) ---
+(= (threshold-val $name)
+   (case (once (match &st (threshval $name $v) $v))
+     (($v $v) (Empty 0.0))))
+
+(= (meets-threshold $lit $name) (>= (trust-of $lit) (threshold-val $name)))
+
+; --- unified justification (a single-call "why does this hold?" view) --------
+; Bundles everything known about why a literal holds: DL status + proof tree +
+; weakest-link trust + claiming sources + a confidence label — proof and trust
+; together rather than through separate queries.
+(= (status-of $lit)
+   (if (== (defp? $lit) True) definitely-provable
+   (if (== (dft-of $lit) true) defeasibly-provable
+       not-provable)))
+
+(= (confidence-label $t)
+   (if (>= $t 0.7) high (if (> $t 0.0) low none)))
+
+(= (justify $lit)
+   (let $t (trust-of $lit)
+     (justification (literal $lit)
+                    (status (status-of $lit))
+                    (trust $t)
+                    (confidence (confidence-label $t))
+                    (sources (sources-of $lit))
+                    (proof (explain $lit)))))
+
+; --- trust-annotated conclusions: (tconcl <tag> <lit> <trust> <sources>) ---
+; Only positive conclusions carry trust/sources (negatives have no derivation).
+(= (trust-concl-of $q)
+   (superpose
+     ((if (== (defp? $q) True)
+          (tconcl pD $q (trust-of $q) (sources-of $q))
+          (tconcl nD $q 0.0 ()))
+      (if (== (dft-of $q) true)
+          (tconcl pd $q (trust-of $q) (sources-of $q))
+          (tconcl nd $q 0.0 ())))))
+
+(= (trust-conclusions)
+   (sort-atom (collapse (let $q (ulit-gen) (trust-concl-of $q)))))
+
+(= (dl-trust-run $path)
+   (let* (($_1 (dl-load $path))
+          ($_2 (dl-reason!)))
+     (trust-conclusions)))

--- a/src/deontic/types.metta
+++ b/src/deontic/types.metta
@@ -1,0 +1,100 @@
+; Core datatypes of a defeasible theory (Nute; Antoniou et al. 2001), reified
+; as atoms in PeTTa spaces so rule instantiation is native unification.
+;
+; Literal:  (lit <sign> <mode> <temporal> <functor> <args>)   — 6-slot functor
+;           sign: pos|neg   mode: none|O|P|F   temporal: none|(iv <s> <e>)
+;           Carrying mode+temporal in the functor makes temporal/modal atom
+;           identity automatic: two lits differing in any slot are distinct
+;           atoms in the space, and grounding endpoint-binding falls out of
+;           native unification.
+; Rule:     (rule <label> <kind> <body> <head>)     in &theory (may hold vars)
+;           (grule <label> <kind> <body> <head>)    in &ground (ground, logic-only body)
+;           kind: fact | strict | defeasible | defeater
+; Body item: (lit ...) | (acmp <op> <ax> <ax>) | (tcmp <op> <tp> <tp>) | (abind <var> <ax>)
+; Superiority: (sup <winner> <loser>)               in &theory
+; Statuses (in &st): (ulit <lit>) (defp <lit>) (dft <lit> true|false)
+
+; Classical complement: ~p flips the sign slot,
+; preserving mode and temporal slots.
+(= (lit-neg (lit pos $m $t $f $a)) (lit neg $m $t $f $a))
+(= (lit-neg (lit neg $m $t $f $a)) (lit pos $m $t $f $a))
+
+; Rule-kind groups: which kinds license definite vs defeasible derivation.
+(= (def-kind? fact) True)
+(= (def-kind? strict) True)
+(= (def-kind? defeasible) False)
+(= (def-kind? defeater) False)
+
+(= (sd-kind? fact) True)
+(= (sd-kind? strict) True)
+(= (sd-kind? defeasible) True)
+(= (sd-kind? defeater) False)
+
+; --- status accessors (absence = unknown / not proven) ---
+(= (defp? $l)
+   (case (once (match &st (defp $l) yes))
+     ((yes True) (Empty False))))
+
+(= (dft-of $l)
+   (case (once (match &st (dft $l $v) $v))
+     (($v $v) (Empty unknown))))
+
+(= (set-dft $l $v)
+   (let $_ (add-atom &st (dft $l $v)) 1))
+
+(= (set-defp $l)
+   (let $_ (add-atom &st (defp $l)) 1))
+
+; Positive (provable at either level) — foundational status predicate used by
+; explain/query/trust.
+(= (pos? $l)
+   (or (== (defp? $l) True) (== (dft-of $l) true)))
+
+; --- body satisfaction (rule applicability, recomputed declaratively) ---
+; Phase 1 level: all body literals definitely proven.
+(= (body-all-defp $b)
+   (if (== $b ()) True
+       (if (== (defp? (car-atom $b)) True)
+           (body-all-defp (cdr-atom $b))
+           False)))
+
+; Phase 2 level: applicable = every body literal +d (remaining == 0).
+(= (body-all-pd $b)
+   (if (== $b ()) True
+       (if (== (dft-of (car-atom $b)) true)
+           (body-all-pd (cdr-atom $b))
+           False)))
+
+; Phase 2 level: discarded = some body literal -d.
+(= (body-some-nd $b)
+   (if (== $b ()) False
+       (if (== (dft-of (car-atom $b)) false)
+           True
+           (body-some-nd (cdr-atom $b)))))
+
+; --- superiority (is one rule label ranked above another) ---
+(= (sup? $w $l)
+   (case (once (match &theory (sup $w $l) yes))
+     ((yes True) (Empty False))))
+
+; Generator over the reporting universe (every literal occurring in the
+; ground theory; complements only if they occur themselves).
+(= (ulit-gen) (match &st (ulit $l) $l))
+
+(= (ulit-add $l)
+   (if (== () (collapse (match &st (ulit $l) yes)))
+       (let $_ (add-atom &st (ulit $l)) ())
+       ()))
+(= (ulits-add $ls)
+   (if (== $ls ()) ()
+       (let* (($_1 (ulit-add (car-atom $ls)))
+              ($_2 (ulits-add (cdr-atom $ls))))
+         ())))
+
+; --- inf-aware time-point order (shared by temporal-deontic + Event Calculus) ---
+; `inf` is the open/persistent end; mm_tp_le (io.pl) compares finite points.
+(= (tp<= $a $b) (if (== $b inf) True (== (mm_tp_le $a $b) true)))
+(= (tp<  $a $b)
+   (if (== $b inf) (not (== $a inf))
+       (if (== $a inf) False
+           (and (== (mm_tp_le $a $b) true) (== (mm_tp_le $b $a) false)))))

--- a/src/directive/cli.metta
+++ b/src/directive/cli.metta
@@ -1,0 +1,109 @@
+; CLI — argv dispatch over the engine + task-coordination layers. Command
+; surface (invoked as `dl <command> ...`):
+;   dl reason <file>                       conclusion set
+;   dl explain <lit> <file>                proof tree
+;   dl why-not <lit> <file>                blockers
+;   dl requires <lit> <file>               verified fact-set
+;   dl what-if <file> <fact> <goal>        hypothetical reasoning
+;   dl status <file>                       task status groups
+;   dl next <file>                         next actions
+;   dl claim|unclaim|block|unblock|complete <task> <file> <agent>
+;   dl assert <file> <agent> <plan-text>
+;
+; The launcher passes: argv 0 = entry file, argv 1 = --silent, argv 2.. = ours.
+
+(= (cli-arg $n) (argv (+ $n 2)))
+
+; CLI literal syntax handled by the platform kernel (mm_parse_lit):
+;   name | ~name | -name | (f a b) | ~(f a b)
+(= (parse-cli-lit $a) (mm_parse_lit $a))
+
+(= (print-concls $cs)
+   (if (== $cs ()) ()
+       (let* (($_ (mm_print (mm_concl_str (car-atom $cs))))
+              ($__ (print-concls (cdr-atom $cs))))
+         ())))
+
+(= (print-tconcls $cs)
+   (if (== $cs ()) ()
+       (let* (($_ (mm_print (mm_trust_str (car-atom $cs))))
+              ($__ (print-tconcls (cdr-atom $cs))))
+         ())))
+
+(= (cli-main)
+   (let $cmd (cli-arg 0)
+     (case $cmd
+       ((reason
+          (let* (($cs (dl-run (cli-arg 1)))
+                 ($_ (mm_print "Conclusions:")))
+            (mm_print_concls $cs)))
+        (reason-at
+          (let* (($cs (dl-run-at (cli-arg 2) (cli-arg 1)))
+                 ($_ (mm_print "Conclusions:")))
+            (mm_print_concls $cs)))
+        (trust
+          (let* (($cs (dl-trust-run (cli-arg 1)))
+                 ($_ (mm_print "Conclusions:")))
+            (mm_print_tconcls $cs)))
+        (explain
+          (let* (($_ (dl-run (cli-arg 2))))
+            (println! (explain (parse-cli-lit (cli-arg 1))))))
+        (justify
+          (let* (($_ (dl-run (cli-arg 2))))
+            (println! (justify (parse-cli-lit (cli-arg 1))))))
+        (why-not
+          (let* (($_ (dl-run (cli-arg 2))))
+            (println! (dl-why-not (parse-cli-lit (cli-arg 1))))))
+        (requires
+          (println! (dl-requires (cli-arg 2) (parse-cli-lit (cli-arg 1)))))
+        (what-if
+          (println! (dl-what-if (cli-arg 1)
+                                     ((parse-cli-lit (cli-arg 2)))
+                                     (parse-cli-lit (cli-arg 3)))))
+        (status   (println! (directive-status (cli-arg 1))))
+        (next     (println! (directive-next (cli-arg 1))))
+        (board    (println! (directive-board (cli-arg 1))))
+        (summary  (println! (directive-summary (cli-arg 1))))
+        (info     (println! (directive-info (cli-arg 1))))
+        (claim    (println! (directive-claim (cli-arg 2) (cli-arg 1) (cli-arg 3) False)))
+        (unclaim  (println! (directive-unclaim (cli-arg 2) (cli-arg 1) (cli-arg 3))))
+        (block    (println! (directive-block (cli-arg 2) (cli-arg 1) (cli-arg 3))))
+        (unblock  (println! (directive-unblock (cli-arg 2) (cli-arg 1) (cli-arg 3))))
+        (complete (println! (directive-complete (cli-arg 2) (cli-arg 1) (cli-arg 3))))
+        (assert   (println! (directive-assert (cli-arg 1) (cli-arg 2) (cli-arg 3))))
+        ; process mining (`learn` namespace): args are argv-parsed (file
+        ; list + --format/--min-support/--min-confidence/--against flags)
+        (learn-extract-log (learn-extract-log))
+        (learn-rules       (learn-rules))
+        (learn-validate    (learn-validate))
+        ; plan inspection
+        (trace    (directive-trace (cli-arg 1)))
+        (validate (directive-validate (cli-arg 1) (== (mm_argn_or 2 "") "--strict")))
+        (analyze  (directive-analyze (cli-arg 1)))
+        (compliance (deontic-compliance (cli-arg 1)))
+        (dilemmas (deontic-dilemmas (cli-arg 1)))
+        (deadlines (deontic-deadlines (cli-arg 1) (cli-arg 2)))
+        (timeline (ec-timeline (cli-arg 1) (cli-arg 2)))
+        (assign   (directive-assign (cli-arg 1) (mm_argn_or 2 "")))
+        ; commands needing external services (LLM / OS / network / crypto / TTY)
+        (translate (directive-stub translate "an LLM to translate natural language to MeTTa plans"))
+        (review    (directive-stub review "an LLM to review the plan"))
+        (llm       (directive-stub llm "an LLM provider"))
+        (decompose (directive-stub decompose "an LLM to decompose a task into subtasks"))
+        (spawn     (directive-stub spawn "OS process spawning of agents"))
+        (watch     (directive-stub watch "filesystem/process watching"))
+        (serve     (directive-stub serve "a network server"))
+        (remote    (directive-stub remote "remote plan networking"))
+        (forget    (directive-stub forget "remote plan networking"))
+        (session   (directive-stub session "on-disk session state"))
+        (repl      (directive-stub repl "an interactive terminal"))
+        (completions (directive-stub completions "shell completion generation"))
+        (whoami    (directive-stub whoami "an Ed25519 cryptographic identity"))
+        (init      (directive-stub init "plan scaffolding on disk"))
+        (journal   (directive-stub journal "on-disk plan journal storage"))
+        (findings  (directive-stub findings "on-disk findings storage"))
+        ($other
+          (let* (($_ (println! (unknown-command $other)))
+                 ($__ (println! "usage: dl reason|reason-at|trust|explain|justify|why-not|requires|what-if|trace|validate ..."))
+                 ($___ (println! "       status|next|board|summary|info|analyze|assign|claim|unclaim|block|unblock|complete|assert|learn-extract-log|learn-rules|learn-validate ...")))
+            ()))))))

--- a/src/directive/directive.metta
+++ b/src/directive/directive.metta
@@ -1,0 +1,241 @@
+; Task-coordination core: extraction, next-actions, status/board/summary, and
+; the claim/unclaim/block/unblock/complete lifecycle. Commands return structured
+; result tuples; the CLI layer formats them. Plan mutations are append-only
+; blocks of claims (facts + defeasible rules); a later re-reason resolves them,
+; so state transitions are monotone appends with non-monotonic effect (the block
+; generators live in the task-coordination kernel, platform/directive.pl).
+
+; --- positive plain (no mode/temporal) 0-arity literal names from the state ---
+(= (directive-pos-names)
+   (collapse (let $q (ulit-gen)
+     (let (lit $s $m $t $f $a) $q
+       (if (and (== (pos? $q) True)
+                (and (== $s pos) (and (== $m none) (== $t none))))
+           $f (empty))))))
+
+; --- prefix extraction (strip a known prefix off a literal name) ---
+(= (tasks-with $prefix $names)
+   (filter-atom (map-atom $names $n (dir_prefix_task $n $prefix)) $t (not (== $t nil))))
+
+(= (directive-tasks $names)     (unique-atom (tasks-with task $names)))
+(= (directive-ready $names)     (unique-atom (tasks-with ready $names)))
+(= (directive-completed $names) (unique-atom (tasks-with completed $names)))
+(= (directive-claimed $names)   (unique-atom (tasks-with claimed $names)))
+(= (directive-blocked $names)   (unique-atom (tasks-with blocked $names)))
+(= (directive-upstream $names)  (unique-atom (tasks-with upstream-blocked $names)))
+(= (directive-decomposed $names) (unique-atom (tasks-with decomposed $names)))
+
+; --- assignments (extract + parse assignTo-/assign-to- literal names) ---
+; $names are pre-filtered to parseable assignment names by directive-assignments
+(= (assignments-of $names $known)
+   (map-atom $names $n
+     (let ($t $a) (dir_parse_assignment $n $known) (assign $t $a $n))))
+
+(= (directive-assignments $names)
+   (assignments-of (filter-atom $names $n (== (is-assign-name $n) True))
+                   (directive-tasks $names)))
+
+(= (is-assign-name $n)
+   (not (== (dir_parse_assignment $n ()) nil)))
+
+; --- next actions ---
+; An assignment is actionable iff its task's computed state is `ready` (the
+; state-precedence classifier already excludes completed/blocked/upstream/
+; decomposed/in-progress), so this reuses directive-task-state instead of
+; repeating the five exclusion checks. If nothing is ready, fall back to all
+; assignments.
+(= (directive-next-actions $names)
+   (let $assigns (directive-assignments $names)
+     (if (== (directive-ready $names) ())
+         $assigns
+         (filter-atom $assigns $a
+           (let (assign $t $ag $l) $a (== (directive-task-state $t $names) ready))))))
+
+(= (directive-next $path)
+   (let* (($_ (dl-run $path))
+          ($names (directive-pos-names)))
+     (next-actions (sort-atom (directive-next-actions $names)))))
+
+; --- status / board (tasks grouped by lifecycle state) ---
+(= (directive-status $path)
+   (let* (($_ (dl-run $path))
+          ($names (directive-pos-names)))
+     (status (tasks (sort-atom (directive-tasks $names)))
+             (ready (sort-atom (directive-ready $names)))
+             (claimed (sort-atom (directive-claimed $names)))
+             (blocked (sort-atom (directive-blocked $names)))
+             (upstream-blocked (sort-atom (directive-upstream $names)))
+             (completed (sort-atom (directive-completed $names))))))
+
+; --- task state classification (state precedence) ---
+;   done > blocked > upstream-blocked > decomposed > in-progress > ready > backlog
+(= (directive-task-state $t $names)
+   (if (== (is-member $t (directive-completed $names)) True) done
+   (if (== (is-member $t (directive-blocked $names)) True) blocked
+   (if (== (is-member $t (directive-upstream $names)) True) upstream-blocked
+   (if (== (is-member $t (directive-decomposed $names)) True) decomposed
+   (if (== (is-member $t (directive-claimed $names)) True) in-progress
+   (if (== (is-member $t (directive-ready $names)) True) ready
+       backlog)))))))
+
+(= (tasks-in-state $tasks $names $state)
+   (sort-atom (filter-atom $tasks $t (== (directive-task-state $t $names) $state))))
+
+; --- board (tasks grouped by state) ---
+(= (directive-board $path)
+   (let* (($_ (dl-run $path))
+          ($names (directive-pos-names))
+          ($tasks (directive-tasks $names)))
+     (board (backlog (tasks-in-state $tasks $names backlog))
+            (ready (tasks-in-state $tasks $names ready))
+            (in-progress (tasks-in-state $tasks $names in-progress))
+            (blocked (union-atom (tasks-in-state $tasks $names blocked)
+                                 (tasks-in-state $tasks $names upstream-blocked)))
+            (done (tasks-in-state $tasks $names done)))))
+
+; --- summary (per-state counts + progress %) ---
+(= (directive-summary $path)
+   (let* (($_ (dl-run $path))
+          ($names (directive-pos-names))
+          ($tasks (directive-tasks $names))
+          ($total (size-atom $tasks))
+          ($done (size-atom (tasks-in-state $tasks $names done))))
+     (summary (total $total)
+              (backlog (size-atom (tasks-in-state $tasks $names backlog)))
+              (ready (size-atom (tasks-in-state $tasks $names ready)))
+              (in-progress (size-atom (tasks-in-state $tasks $names in-progress)))
+              (blocked (+ (size-atom (tasks-in-state $tasks $names blocked))
+                          (size-atom (tasks-in-state $tasks $names upstream-blocked))))
+              (done $done)
+              (progress-pct (mm_pct $done $total)))))
+
+; --- info (extract (meta plan ...) properties) ---
+(= (meta-get $kvs $key)
+   (case (collapse (let ($k $v) (superpose $kvs) (if (== $k $key) $v (empty))))
+     ((($v) $v) (() none))))
+
+(= (plan-meta-kvs)
+   (case (once (match &theory (metainfo plan $kvs) $kvs))
+     (($kvs $kvs) (Empty ()))))
+
+(= (directive-info $path)
+   (let* (($_ (dl-run $path))
+          ($kvs (plan-meta-kvs)))
+     (if (== $kvs ())
+         (info none)
+         (info $kvs))))
+
+; --- describe (rule/fact/literal definitions + metadata) ---
+(= (describe-one $label)
+   (case (once (match &theory (rule $label $kind $body $head) (rule $label $kind $body $head)))
+     (((rule $l $k $b $h)
+       (described $l (kind $k) (body $b) (head $h) (meta (meta-get-rule $l))))
+      (Empty
+       (case (once (match &theory (metainfo $label $kvs) $kvs))
+         (($kvs (described $label (meta $kvs)))
+          (Empty (described $label not-found))))))))
+
+(= (meta-get-rule $label)
+   (case (once (match &theory (metainfo $label $kvs) $kvs))
+     (($kvs $kvs) (Empty ()))))
+
+(= (directive-describe $path $labels)
+   (let $_ (dl-run $path)
+     (described-all (map-atom $labels $l (describe-one $l)))))
+
+; --- lifecycle mutations (claim/unclaim/block/unblock/complete/assert) ---
+
+(= (directive-claim $path $task-raw $agent $force)
+   (let* (($_ (dl-run $path))
+          ($task (dir_strip_task $task-raw))
+          ($names (directive-pos-names)))
+     (if (== (is-member (dir_lit task $task) $names) False)
+         (err task-not-found $task (available (sort-atom (directive-tasks $names))))
+         (if (and (== $force False)
+                  (== (is-member (dir_lit ready $task) $names) False))
+             (err not-ready $task)
+             (let ($maxv $last $ma $mc) (dir_find_versions $names claim unclaim $task)
+               (if (== $last action)
+                   (already-claimed $task $maxv)
+                   (let* (($nv (+ $maxv 1))
+                          ($prevc (if (> $mc 0) $mc -1))
+                          ($ts (mm_now_iso))
+                          ($block (dir_action_block $agent $ts $task $nv $prevc
+                                               claim claimed unclaimed unclaim))
+                          ($prop (dir_propagation_block &theory $task $nv))
+                          ($_1 (mm_append_file $path $block))
+                          ($_2 (if (== $prop "") ()
+                                   (let $__ (mm_append_file $path $prop) ()))))
+                     (claimed $task $nv))))))))
+
+(= (directive-unclaim $path $task-raw $agent)
+   (let* (($_ (dl-run $path))
+          ($task (dir_strip_task $task-raw))
+          ($names (directive-pos-names)))
+     (let ($maxv $last $ma $mc) (dir_find_versions $names claim unclaim $task)
+       (if (not (== $last action))
+           (err not-claimed $task)
+           (let* (($nv (+ $maxv 1))
+                  ($preva (if (> $ma 0) $ma -1))
+                  ($ts (mm_now_iso))
+                  ($block (dir_counter_block $agent $ts $task $nv $preva
+                                        unclaim unclaimed claimed claimed claim))
+                  ($_1 (mm_append_file $path $block)))
+             (unclaimed $task $nv))))))
+
+(= (directive-block $path $task-raw $agent)
+   (let* (($_ (dl-run $path))
+          ($task (dir_strip_task $task-raw))
+          ($names (directive-pos-names)))
+     (if (== (is-member (dir_lit completed $task) $names) True)
+         (err already-completed $task)
+         (let ($maxv $last $ma $mc) (dir_find_versions $names block unblock $task)
+           (if (== $last action)
+               (already-blocked $task $maxv)
+               (let* (($nv (+ $maxv 1))
+                      ($prevc (if (> $mc 0) $mc -1))
+                      ($ts (mm_now_iso))
+                      ($block (dir_action_block $agent $ts $task $nv $prevc
+                                           block blocked unblocked unblock))
+                      ($_1 (mm_append_file $path $block)))
+                 (blocked $task $nv)))))))
+
+(= (directive-unblock $path $task-raw $agent)
+   (let* (($_ (dl-run $path))
+          ($task (dir_strip_task $task-raw))
+          ($names (directive-pos-names)))
+     (let ($maxv $last $ma $mc) (dir_find_versions $names block unblock $task)
+       (if (not (== $last action))
+           (err not-blocked $task)
+           (let* (($nv (+ $maxv 1))
+                  ($preva (if (> $ma 0) $ma -1))
+                  ($ts (mm_now_iso))
+                  ($block (dir_counter_block $agent $ts $task $nv $preva
+                                        unblock unblocked blocked blocked block))
+                  ($_1 (mm_append_file $path $block)))
+             (unblocked $task $nv))))))
+
+(= (directive-complete $path $task-raw $agent)
+   (let* (($_ (dl-run $path))
+          ($task (dir_strip_task $task-raw))
+          ($names (directive-pos-names)))
+     (if (== (is-member (dir_lit task $task) $names) False)
+         (err task-not-found $task (available (sort-atom (directive-tasks $names))))
+         (if (== (is-member (dir_lit completed $task) $names) True)
+             (already-completed $task)
+             (let* (($ts (mm_now_iso))
+                    ($block (dir_complete_block $agent $ts $task))
+                    ($_1 (mm_append_file $path $block))
+                    ($_2 (dl-run $path))
+                    ($names2 (directive-pos-names))
+                    ($all (directive-tasks $names2))
+                    ($done (directive-completed $names2)))
+               (if (== (subtraction-atom $all $done) ())
+                   (completed $task plan-complete)
+                   (completed $task)))))))
+
+(= (directive-assert $path $agent $form-text)
+   (let* (($ts (mm_now_iso))
+          ($block (dir_assert_block $agent $ts $form-text))
+          ($_1 (mm_append_file $path $block)))
+     (asserted $form-text)))

--- a/src/directive/inspect.metta
+++ b/src/directive/inspect.metta
@@ -1,0 +1,109 @@
+; Plan-inspection commands beyond the core surface:
+;   trace     full reasoning trace (facts/rules/superiorities/conclusions)
+;   validate  plan structure validation (undefined/unreachable/consistency)
+;   assign    agent assignment listing
+;
+; The renderers live in the plan-inspection kernel (platform/inspect.pl) and emit
+; a deterministic, stable-sorted output. Commands that need an LLM, OS process
+; control, networking, a crypto identity, or an interactive terminal are out of
+; scope for a pure-logic engine; the stub reports that honestly so every command
+; name has a defined response.
+
+; --- trace ---
+(= (directive-trace $path)
+   (let $cs (dl-run $path)
+     (mm_print_trace &theory $cs)))
+
+; --- validate (default non-strict) ---
+(= (directive-validate $path $strict)
+   (let* (($cs (dl-run $path))
+          ($fmt (mm_plan_fmt $path)))
+     (mm_print_plan_validate &theory $cs $fmt $strict)))
+
+; --- analyze: dependency cycles (deadlocks) + self-inconsistency -------------
+; The cycle ALGORITHM is native MeTTa (support-graph transitive closure +
+; mutual-reachability SCCs); Prolog only renders the report and supplies the
+; consistency lines (mn_consistency, the same lines `validate` emits).
+
+; support edges (From To): each body literal of a non-defeater grule -> its head
+; (defeaters block rather than support, so they add no dependency).
+(= (dep-edges)
+   (unique-atom (collapse
+     (match &ground (grule $l $k $body $to)
+       (if (== (sd-kind? $k) True)
+           (let $from (superpose $body) ($from $to))
+           (empty))))))
+
+; transitive closure of the edge relation by naive fixpoint (small plan graphs):
+; rel := rel ∪ {(a,d) | (a,b)∈rel, (b,d)∈edges} until it stops growing.
+(= (tc-step $es $rel)
+   (unique-atom (union-atom $rel
+     (collapse (let* ((($a $b) (superpose $rel)) (($c $d) (superpose $es)))
+                 (if (== $b $c) ($a $d) (empty)))))))
+(= (tc-fix $es $rel)
+   (let $next (tc-step $es $rel)
+     (if (== (size-atom $next) (size-atom $rel)) $rel (tc-fix $es $next))))
+(= (reach-rel) (let $es (dep-edges) (tc-fix $es $es)))
+
+; a literal is cyclic iff it reaches itself; group cyclic literals into SCCs by
+; mutual reachability (each group is a deadlock set).
+(= (cyclic-nodes)
+   (let $rel (reach-rel)
+     (unique-atom (collapse (let ($a $b) (superpose $rel)
+                              (if (== $a $b) $a (empty)))))))
+(= (scc-of $a $cyc $rel)
+   (sort-atom (filter-atom $cyc $b
+     (and (== (is-member ($a $b) $rel) True) (== (is-member ($b $a) $rel) True)))))
+(= (plan-cycle-groups)
+   (let* (($rel (reach-rel)) ($cyc (cyclic-nodes)))
+     (sort-atom (unique-atom (map-atom $cyc $a (scc-of $a $cyc $rel))))))
+
+; --- self-consistency: no circular superiority, no contradictory +D pair ------
+; (the report LINES come from Prolog mn_consistency so `validate` and `analyze`
+;  share one renderer; this is the queryable boolean.)
+(= (sup-pairs) (collapse (match &theory (sup $a $b) ($a $b))))
+(= (circular-sup?)
+   (let $ps (sup-pairs)
+     (not (== () (collapse (let ($a $b) (superpose $ps)
+       (if (and (== (is-member ($b $a) $ps) True) (not (== $a $b))) found (empty))))))))
+
+; functor names that are definite (+D) with the given sign
+(= (def-funcs $sgn $cs)
+   (collapse (case (superpose $cs)
+     (((pD (lit $sgn $m $t $f $a)) $f) ($_ (empty))))))
+(= (contradiction? $cs)
+   (let* (($poss (def-funcs pos $cs)) ($negs (def-funcs neg $cs)))
+     (not (== () (collapse (let $f (superpose $poss)
+       (if (== (is-member $f $negs) True) found (empty))))))))
+
+(= (plan-consistent-cs? $cs)
+   (and (not (== (circular-sup?) True)) (not (== (contradiction? $cs) True))))
+
+; --- public queries + report --------------------------------------------------
+(= (directive-analyze $path)
+   (let* (($cs (dl-run $path)) ($groups (plan-cycle-groups)))
+     (mm_print_analyze2 $groups &theory $cs)))
+(= (plan-cycles $path) (let $_ (dl-run $path) (plan-cycle-groups)))
+(= (plan-consistent? $path) (let $cs (dl-run $path) (plan-consistent-cs? $cs)))
+
+; --- assign (optionally filtered by agent) ---
+(= (assigns-active $names)
+   (filter-atom (directive-assignments $names) $a
+     (let (assign $t $ag $l) $a
+       (== (is-member $t (directive-completed $names)) False))))
+
+(= (assign-names $names $agent)
+   (let $active (if (== $agent "")
+                    (assigns-active $names)
+                    (filter-atom (assigns-active $names) $a
+                      (let (assign $t $ag $l) $a (== $ag $agent))))
+     (sort-atom (map-atom $active $a (let (assign $t $ag $l) $a $l)))))
+
+(= (directive-assign $path $agent)
+   (let* (($_ (dl-run $path))
+          ($names (directive-pos-names))
+          ($ns (assign-names $names $agent)))
+     (mm_print_assign $agent $ns)))
+
+; --- honest stub for commands needing external services ---
+(= (directive-stub $cmd $needs) (mm_print_stub $cmd $needs))

--- a/src/directive/mining.metta
+++ b/src/directive/mining.metta
@@ -1,0 +1,47 @@
+; Process mining — the `learn` namespace (extract-log / rules / validate-rules).
+;
+; The engine lives in the process-mining kernel (platform/mining.pl): event-log
+; extraction from MeTTa `(claims ... (given F) ...)` blocks, the Alpha footprint +
+; directly-follows relations, trace-level support/confidence, and XOR/mutex
+; conflict detection. These wrappers expose structured results to MeTTa and drive
+; the CLI renderers.
+;
+; Rules and r_mined_N labels are emitted as a SET in a stable sorted order, so
+; the output is deterministic across runs.
+
+; --- structured results (queries / tests) ---
+;   (mining-event-log (f1 f2 ...))        -> ((CaseId ((TS Act Actor) ...)) ...)
+;   (mining-rules files minSup minConf)   -> ((Body Head Support "C.CC") ...) sorted
+(= (mining-event-log $files) (mm_event_log $files))
+(= (mining-rules $files $min-support $min-confidence)
+   (mm_mine_rules $files $min-support $min-confidence))
+
+; --- renderers (write the report / DFL / JSON output) ---
+(= (mining-extract-print $files $format)
+   (if (== $format summary)
+       (mm_print_extract_summary $files)
+       (mm_print_extract_json $files)))
+
+(= (mining-rules-print $files $format $min-support $min-confidence)
+   (if (== $format summary)
+       (mm_print_mine_summary $files $min-support $min-confidence)
+       (mm_print_mine_dfl $files $min-support $min-confidence)))
+
+; validate: load the `against` plan, count its non-fact rules, mine the traces.
+(= (mining-validate-print $traces $against)
+   (let* (($_ (dl-load $against))
+          ($n (mm_count_nonfact &theory)))
+     (mm_print_validate $traces $n)))
+
+; --- CLI entry points (argv-driven; `learn <cmd>` defaults) ---
+(= (learn-extract-log)
+   (mining-extract-print (mm_learn_files) (mm_learn_format json)))
+
+(= (learn-rules)
+   (mining-rules-print (mm_learn_files)
+                       (mm_learn_format dfl)
+                       (mm_learn_minsup 1)
+                       (mm_learn_minconf 0.5)))
+
+(= (learn-validate)
+   (mining-validate-print (mm_learn_files) (mm_learn_against "")))

--- a/tests/deontic/fixtures/allen_intervals.metta
+++ b/tests/deontic/fixtures/allen_intervals.metta
@@ -1,0 +1,193 @@
+; Test: All 13 Allen interval relations
+; Coverage: before, after, meets, met-by, overlaps, overlapped-by,
+;           starts, started-by, within, contains, finishes, finished-by, equals
+;
+; Each relation is tested with a pair of temporal facts and a rule
+; with the corresponding Allen constraint. Negative tests verify
+; non-matching relations do NOT fire.
+
+; =========================================================================
+; 1. BEFORE — A ends before B starts (gap between)
+;    A: [100,200]  B: [300,400]
+; =========================================================================
+(given (during (ev-bf-a) 100 200))
+(given (during (ev-bf-b) 300 400))
+(normally r-before
+    (and (during (ev-bf-a) ?T) (during (ev-bf-b) ?S) (before ?T ?S))
+    (result-before))
+
+; EXPECT: +d result-before
+
+; Negative: A is NOT after B
+(normally r-before-neg
+    (and (during (ev-bf-a) ?T) (during (ev-bf-b) ?S) (after ?T ?S))
+    (neg-before))
+; EXPECT-NOT: +d neg-before
+
+; =========================================================================
+; 2. AFTER — A starts after B ends (inverse of before)
+;    A: [300,400]  B: [100,200]
+; =========================================================================
+(given (during (ev-af-a) 300 400))
+(given (during (ev-af-b) 100 200))
+(normally r-after
+    (and (during (ev-af-a) ?T) (during (ev-af-b) ?S) (after ?T ?S))
+    (result-after))
+
+; EXPECT: +d result-after
+
+; =========================================================================
+; 3. MEETS — A ends exactly when B starts
+;    A: [100,200]  B: [200,300]
+; =========================================================================
+(given (during (ev-mt-a) 100 200))
+(given (during (ev-mt-b) 200 300))
+(normally r-meets
+    (and (during (ev-mt-a) ?T) (during (ev-mt-b) ?S) (meets ?T ?S))
+    (result-meets))
+
+; EXPECT: +d result-meets
+
+; Negative: meets requires exact endpoint equality; before should fail
+(normally r-meets-neg
+    (and (during (ev-mt-a) ?T) (during (ev-mt-b) ?S) (before ?T ?S))
+    (neg-meets))
+; EXPECT-NOT: +d neg-meets
+
+; =========================================================================
+; 4. MET-BY — A starts exactly when B ends (inverse of meets)
+;    A: [200,300]  B: [100,200]
+; =========================================================================
+(given (during (ev-mb-a) 200 300))
+(given (during (ev-mb-b) 100 200))
+(normally r-met-by
+    (and (during (ev-mb-a) ?T) (during (ev-mb-b) ?S) (met-by ?T ?S))
+    (result-met-by))
+
+; EXPECT: +d result-met-by
+
+; =========================================================================
+; 5. OVERLAPS — A starts before B, A ends during B
+;    A: [100,300]  B: [200,400]
+; =========================================================================
+(given (during (ev-ov-a) 100 300))
+(given (during (ev-ov-b) 200 400))
+(normally r-overlaps
+    (and (during (ev-ov-a) ?T) (during (ev-ov-b) ?S) (overlaps ?T ?S))
+    (result-overlaps))
+
+; EXPECT: +d result-overlaps
+
+; Negative: A does NOT start B (different start times)
+(normally r-overlaps-neg
+    (and (during (ev-ov-a) ?T) (during (ev-ov-b) ?S) (starts ?T ?S))
+    (neg-overlaps))
+; EXPECT-NOT: +d neg-overlaps
+
+; =========================================================================
+; 6. OVERLAPPED-BY — B starts before A, B ends during A (inverse of overlaps)
+;    A: [200,400]  B: [100,300]
+; =========================================================================
+(given (during (ev-ob-a) 200 400))
+(given (during (ev-ob-b) 100 300))
+(normally r-overlapped-by
+    (and (during (ev-ob-a) ?T) (during (ev-ob-b) ?S) (overlapped-by ?T ?S))
+    (result-overlapped-by))
+
+; EXPECT: +d result-overlapped-by
+
+; =========================================================================
+; 7. STARTS — A and B start together, A ends before B
+;    A: [100,200]  B: [100,400]
+; =========================================================================
+(given (during (ev-st-a) 100 200))
+(given (during (ev-st-b) 100 400))
+(normally r-starts
+    (and (during (ev-st-a) ?T) (during (ev-st-b) ?S) (starts ?T ?S))
+    (result-starts))
+
+; EXPECT: +d result-starts
+
+; =========================================================================
+; 8. STARTED-BY — A and B start together, B ends before A (inverse of starts)
+;    A: [100,400]  B: [100,200]
+; =========================================================================
+(given (during (ev-sb-a) 100 400))
+(given (during (ev-sb-b) 100 200))
+(normally r-started-by
+    (and (during (ev-sb-a) ?T) (during (ev-sb-b) ?S) (started-by ?T ?S))
+    (result-started-by))
+
+; EXPECT: +d result-started-by
+
+; =========================================================================
+; 9. WITHIN (during) — A is strictly contained within B
+;    A: [200,300]  B: [100,400]
+; =========================================================================
+(given (during (ev-wi-a) 200 300))
+(given (during (ev-wi-b) 100 400))
+(normally r-within
+    (and (during (ev-wi-a) ?T) (during (ev-wi-b) ?S) (within ?T ?S))
+    (result-within))
+
+; EXPECT: +d result-within
+
+; Negative: A is NOT equal to B (different bounds)
+(normally r-within-neg
+    (and (during (ev-wi-a) ?T) (during (ev-wi-b) ?S) (equals ?T ?S))
+    (neg-within))
+; EXPECT-NOT: +d neg-within
+
+; =========================================================================
+; 10. CONTAINS — A strictly contains B (inverse of within)
+;     A: [100,400]  B: [200,300]
+; =========================================================================
+(given (during (ev-cn-a) 100 400))
+(given (during (ev-cn-b) 200 300))
+(normally r-contains
+    (and (during (ev-cn-a) ?T) (during (ev-cn-b) ?S) (contains ?T ?S))
+    (result-contains))
+
+; EXPECT: +d result-contains
+
+; =========================================================================
+; 11. FINISHES — A starts after B, both end together
+;     A: [300,400]  B: [100,400]
+; =========================================================================
+(given (during (ev-fn-a) 300 400))
+(given (during (ev-fn-b) 100 400))
+(normally r-finishes
+    (and (during (ev-fn-a) ?T) (during (ev-fn-b) ?S) (finishes ?T ?S))
+    (result-finishes))
+
+; EXPECT: +d result-finishes
+
+; =========================================================================
+; 12. FINISHED-BY — B starts after A, both end together (inverse of finishes)
+;     A: [100,400]  B: [300,400]
+; =========================================================================
+(given (during (ev-fb-a) 100 400))
+(given (during (ev-fb-b) 300 400))
+(normally r-finished-by
+    (and (during (ev-fb-a) ?T) (during (ev-fb-b) ?S) (finished-by ?T ?S))
+    (result-finished-by))
+
+; EXPECT: +d result-finished-by
+
+; =========================================================================
+; 13. EQUALS — A and B have identical start and end times
+;     A: [100,400]  B: [100,400]
+; =========================================================================
+(given (during (ev-eq-a) 100 400))
+(given (during (ev-eq-b) 100 400))
+(normally r-equals
+    (and (during (ev-eq-a) ?T) (during (ev-eq-b) ?S) (equals ?T ?S))
+    (result-equals))
+
+; EXPECT: +d result-equals
+
+; Negative: equal intervals do NOT satisfy before
+(normally r-equals-neg
+    (and (during (ev-eq-a) ?T) (during (ev-eq-b) ?S) (before ?T ?S))
+    (neg-equals))
+; EXPECT-NOT: +d neg-equals

--- a/tests/deontic/fixtures/allen_seq.metta
+++ b/tests/deontic/fixtures/allen_seq.metta
@@ -1,0 +1,3 @@
+(given (during (ev a) 10 20))
+(given (during (ev b) 25 35))
+(normally r1 (and (during (ev a) ?T) (during (ev b) ?S) (before ?T ?S)) seq-ab)

--- a/tests/deontic/fixtures/ambiguity.metta
+++ b/tests/deontic/fixtures/ambiguity.metta
@@ -1,0 +1,3 @@
+(given a)
+(normally r1 a q)
+(normally r2 a (not q))

--- a/tests/deontic/fixtures/animals.metta
+++ b/tests/deontic/fixtures/animals.metta
@@ -1,0 +1,4 @@
+(given (bird tweety))
+(given (bird polly))
+(given (fish nemo))
+(given (mammal rex))

--- a/tests/deontic/fixtures/annotated.dfl
+++ b/tests/deontic/fixtures/annotated.dfl
@@ -1,0 +1,38 @@
+# Annotated example demonstrating semantic annotations for explainability
+
+# Facts
+f1: >> task_auth
+f2: >> no_deps_auth
+f3: >> security_sensitive_auth
+f4: >> agent_coder_available
+f5: >> agent_security_available
+
+# Readiness rule with annotation
+---
+description: "Auth task is ready when it has no dependencies"
+dc:source: "policy/task-scheduling.md"
+---
+r10: task_auth, no_deps_auth => ready_auth
+
+# Default assignment
+---
+description: "Coder agent handles tasks by default"
+confidence: 0.7
+---
+r20: ready_auth, agent_coder_available => assignTo_auth_coder
+
+# Security assignment override
+---
+@id: :security-assignment
+description: "Security-sensitive tasks require security agent"
+dc:source: "policy/security-guidelines.md"
+confidence: 0.95
+justification: "Per security policy section 3.2"
+---
+r21: ready_auth, security_sensitive_auth, agent_security_available => assignTo_auth_security
+
+# Superiority with justification
+---
+justification: "Security expertise required for sensitive data handling"
+---
+r21 > r20

--- a/tests/deontic/fixtures/api-project.dfl
+++ b/tests/deontic/fixtures/api-project.dfl
@@ -1,0 +1,90 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# PLAN: Build a secure REST API with database
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# This plan uses propositional logic with positive facts only.
+# Tasks become ready when their dependencies are complete.
+
+# ───────────────────────────────────────────────────────────────────────────
+# FACTS: Context
+# ───────────────────────────────────────────────────────────────────────────
+
+f1: >> goal_buildSecureAPI
+f2: >> requires_security
+
+# ───────────────────────────────────────────────────────────────────────────
+# FACTS: Agent availability
+# ───────────────────────────────────────────────────────────────────────────
+
+f10: >> agent_architect_available
+f11: >> agent_coder_available
+f12: >> agent_security_available
+
+# ───────────────────────────────────────────────────────────────────────────
+# FACTS: Task definitions
+# ───────────────────────────────────────────────────────────────────────────
+
+f20: >> task_models
+f21: >> task_auth
+f22: >> task_crud
+f23: >> task_tests
+f24: >> task_review
+
+# Task properties
+f30: >> security_related_auth
+f31: >> security_related_review
+
+# Tasks with no dependencies (ready from the start)
+f50: >> no_deps_models
+f51: >> no_deps_auth
+
+# ═══════════════════════════════════════════════════════════════════════════
+# STRICT RULES: Invariants
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Complex goals need decomposition
+r1: goal_buildSecureAPI, requires_security -> needs_decomposition
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DEFEASIBLE RULES: Task readiness (only when deps complete)
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Tasks with no dependencies are ready
+r40: task_models, no_deps_models => ready_models
+r41: task_auth, no_deps_auth => ready_auth
+
+# Tasks with dependencies become ready when deps complete
+r42: task_crud, completed_models => ready_crud
+r43: task_tests, completed_crud, completed_auth => ready_tests
+r44: task_review, completed_tests => ready_review
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DEFEASIBLE RULES: Assignments
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Coder handles general tasks by default
+r10: ready_models, agent_coder_available => assignTo_models_coder
+r11: ready_auth, agent_coder_available => assignTo_auth_coder
+r12: ready_crud, agent_coder_available => assignTo_crud_coder
+r13: ready_tests, agent_coder_available => assignTo_tests_coder
+r14: ready_review, agent_coder_available => assignTo_review_coder
+
+# Security agent handles security-related tasks
+r20: ready_auth, security_related_auth, agent_security_available => assignTo_auth_security
+r21: ready_review, security_related_review, agent_security_available => assignTo_review_security
+
+# Architect handles decomposition
+r30: needs_decomposition, agent_architect_available => assignTo_decompose_architect
+
+# ═══════════════════════════════════════════════════════════════════════════
+# SUPERIORITY: Conflict resolution
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Security beats coder for security-related tasks
+r20 > r11
+r21 > r14
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DYNAMIC FACTS: Added as work progresses
+# Completion facts mark a task as done
+# ═══════════════════════════════════════════════════════════════════════════

--- a/tests/deontic/fixtures/arith.metta
+++ b/tests/deontic/fixtures/arith.metta
@@ -1,0 +1,4 @@
+(given (salary alice 120000))
+(given (salary bob 85000))
+(normally r1 (and (salary ?e ?s) (> ?s 100000)) (high-earner ?e))
+(normally r2 (and (salary ?e ?s) (bind ?d (* ?s 2))) (double-pay ?e ?d))

--- a/tests/deontic/fixtures/arith_div.metta
+++ b/tests/deontic/fixtures/arith_div.metta
@@ -1,0 +1,3 @@
+(given (pair a 10 3))
+(normally r1 (and (pair ?n ?x ?y) (bind ?q (div ?x ?y))) (quot ?n ?q))
+(normally r2 (and (pair ?n ?x ?y) (bind ?r (rem ?x ?y))) (rema ?n ?r))

--- a/tests/deontic/fixtures/arith_divzero.metta
+++ b/tests/deontic/fixtures/arith_divzero.metta
@@ -1,0 +1,2 @@
+(given (pair a 10 0))
+(normally r1 (and (pair ?n ?x ?y) (bind ?q (/ ?x ?y))) (quot ?n ?q))

--- a/tests/deontic/fixtures/basic-tasks.metta
+++ b/tests/deontic/fixtures/basic-tasks.metta
@@ -1,0 +1,58 @@
+;; Basic task coordination test plan
+(meta plan
+  (id "TEST-001")
+  (title "Basic Task Test")
+  (version "1.0.0")
+  (status "active")
+  (created "2026-02-14")
+  (author "agent:tester"))
+
+;; Agents
+(given agent-coder-available)
+(given agent-reviewer-available)
+
+;; Tasks
+(given task-auth)
+(given task-models)
+(given task-crud)
+(given task-tests)
+
+;; Dependencies
+(given no-deps-models)
+(given no-deps-auth)
+
+;; Task Readiness Rules
+(normally r-models (and task-models no-deps-models) ready-models)
+(normally r-auth (and task-auth no-deps-auth) ready-auth)
+(normally r-crud completed-models ready-crud)
+(normally r-tests (and completed-crud completed-auth) ready-tests)
+
+;; Assignment Rules
+(normally assign-models (and ready-models agent-coder-available) assign-to-models-coder)
+(normally assign-auth (and ready-auth agent-coder-available) assign-to-auth-coder)
+(normally assign-crud (and ready-crud agent-coder-available) assign-to-crud-coder)
+(normally assign-tests (and ready-tests agent-coder-available) assign-to-tests-coder)
+
+;; Assignment with superiority
+(normally assign-auth-reviewer (and ready-auth agent-reviewer-available) assign-to-auth-reviewer)
+(prefer assign-auth-reviewer assign-auth)
+
+;; Blocking defeater
+(except block-deploy tests-failing (not ready-deploy))
+
+;; Supervisor lifecycle claims (REQ-006.1: supervisor: prefix for spawn claims)
+(claims supervisor:claude
+  :at "2026-02-22T08:10:43Z"
+  (given claim-v1-auth-by-claude)
+  (normally r-cl-state-v1-auth-by-claude claim-v1-auth-by-claude state-claimed-v1-auth-by-claude)
+  (normally r-cl-chain-v1-auth-by-claude state-claimed-v1-auth-by-claude claimed-auth)
+)
+
+(claims supervisor:claude
+  :at "2026-02-22T08:10:43Z"
+  (given unclaimed-auth)
+  (normally r-ucl-defeat-v1-auth-by-claude unclaimed-auth (not state-claimed-v1-auth-by-claude))
+  (prefer r-ucl-defeat-v1-auth-by-claude r-cl-state-v1-auth-by-claude)
+  (normally r-ucl-unchain-v1-auth-by-claude unclaimed-auth (not claimed-auth))
+  (prefer r-ucl-unchain-v1-auth-by-claude r-cl-chain-v1-auth-by-claude)
+)

--- a/tests/deontic/fixtures/conflict_facts.metta
+++ b/tests/deontic/fixtures/conflict_facts.metta
@@ -1,0 +1,2 @@
+(given p)
+(given (not p))

--- a/tests/deontic/fixtures/ctd_cascade.metta
+++ b/tests/deontic/fixtures/ctd_cascade.metta
@@ -1,0 +1,5 @@
+;; Primary AND first reparation violated -> cascade to O apologize.
+(given person)
+(given litter)
+(given (not pay_fine))
+(normally r1 person (otherwise (forbidden litter) (must pay_fine) (must apologize)))

--- a/tests/deontic/fixtures/ctd_clean.metta
+++ b/tests/deontic/fixtures/ctd_clean.metta
@@ -1,0 +1,3 @@
+;; No violation -> only the primary prohibition holds, no reparation.
+(given person)
+(normally r1 person (otherwise (forbidden litter) (must pay_fine) (must apologize)))

--- a/tests/deontic/fixtures/ctd_violated.metta
+++ b/tests/deontic/fixtures/ctd_violated.metta
@@ -1,0 +1,5 @@
+;; CTD: O(¬litter ⊗ pay_fine ⊗ apologize). Person littered (primary violated)
+;; -> reparation O pay_fine activates. Fine unpaid -> apologize not yet due.
+(given person)
+(given litter)
+(normally r1 person (otherwise (forbidden litter) (must pay_fine) (must apologize)))

--- a/tests/deontic/fixtures/cycle.metta
+++ b/tests/deontic/fixtures/cycle.metta
@@ -1,0 +1,4 @@
+(given seed)
+(always s1 a b)
+(always s2 b a)
+(normally r1 seed a)

--- a/tests/deontic/fixtures/deadline_clean.metta
+++ b/tests/deontic/fixtures/deadline_clean.metta
@@ -1,0 +1,2 @@
+;; Maintenance window passed with no breach -> fulfilled.
+(deadline (forbidden trespass) maintain 0 50 penalty)

--- a/tests/deontic/fixtures/deadline_demo.metta
+++ b/tests/deontic/fixtures/deadline_demo.metta
@@ -1,0 +1,5 @@
+;; Temporal-deontic deadlines (Governatori et al. 2007), a temporal-deontic extension.
+;; Achievement: pay by 30 (sanction: fine). Maintenance: no trespass in [0,100].
+(deadline (must pay) achieve 0 30 fine)
+(deadline (forbidden trespass) maintain 0 100 penalty)
+(given (during pay 25 25))

--- a/tests/deontic/fixtures/deadline_missed.metta
+++ b/tests/deontic/fixtures/deadline_missed.metta
@@ -1,0 +1,4 @@
+;; Pay never done; trespass breach at t=20 within window [0,50].
+(deadline (must pay) achieve 0 30 fine)
+(deadline (forbidden trespass) maintain 0 50 penalty)
+(given (during trespass 20 20))

--- a/tests/deontic/fixtures/defeater.metta
+++ b/tests/deontic/fixtures/defeater.metta
@@ -1,0 +1,4 @@
+(given bird)
+(given injured)
+(normally r1 bird flies)
+(except d1 injured (not flies))

--- a/tests/deontic/fixtures/defeater_sup.metta
+++ b/tests/deontic/fixtures/defeater_sup.metta
@@ -1,0 +1,4 @@
+(given base)
+(normally r1 base p)
+(except d1 base (not p))
+(prefer d1 r1)

--- a/tests/deontic/fixtures/deontic_conflict.metta
+++ b/tests/deontic/fixtures/deontic_conflict.metta
@@ -1,0 +1,6 @@
+;; Deontic conflict resolved by superiority (deontic defeasible interaction).
+;; r1 (obligation) is preferred over r2 (prohibition) of the same proposition.
+(given a)
+(normally r1 a (must p))
+(normally r2 a (forbidden p))
+(prefer r1 r2)

--- a/tests/deontic/fixtures/deontic_dilemma.metta
+++ b/tests/deontic/fixtures/deontic_dilemma.metta
@@ -1,0 +1,4 @@
+;; Deontic dilemma: obligation vs prohibition of p, no superiority to resolve.
+(given a)
+(normally r1 a (must p))
+(normally r2 a (forbidden p))

--- a/tests/deontic/fixtures/dfl_mixed.dfl
+++ b/tests/deontic/fixtures/dfl_mixed.dfl
@@ -1,0 +1,5 @@
+# strict + defeater + negation
+>> bird
+>> injured
+r1: bird => flies
+d1: injured ~> -flies

--- a/tests/deontic/fixtures/dfl_mixed_sexpr.metta
+++ b/tests/deontic/fixtures/dfl_mixed_sexpr.metta
@@ -1,0 +1,4 @@
+(given bird)
+(given injured)
+(normally r1 bird flies)
+(except d1 injured (not flies))

--- a/tests/deontic/fixtures/eventcalc_demo.metta
+++ b/tests/deontic/fixtures/eventcalc_demo.metta
@@ -1,0 +1,6 @@
+;; Event-Calculus obligation lifecycle (oPIEC/RTEC-style), a temporal extension.
+;; Invoice at t=5 initiates "must pay"; pay at t=25 terminates it.
+(happens invoice 5)
+(happens pay 25)
+(initiates invoice (must pay))
+(terminates pay (must pay))

--- a/tests/deontic/fixtures/eventcalc_open.metta
+++ b/tests/deontic/fixtures/eventcalc_open.metta
@@ -1,0 +1,4 @@
+;; Obligation never discharged: invoice at 5, no payment -> in force [5, inf).
+(happens invoice 5)
+(initiates invoice (must pay))
+(terminates pay (must pay))

--- a/tests/deontic/fixtures/incr_base.metta
+++ b/tests/deontic/fixtures/incr_base.metta
@@ -1,0 +1,4 @@
+;; Incremental-grounding base: transitive readiness over a dep chain.
+(normally r1 (and (dep ?a ?b) (ready ?b)) (ready ?a))
+(given (ready base0))
+(given (dep n1 base0))

--- a/tests/deontic/fixtures/incr_base1.metta
+++ b/tests/deontic/fixtures/incr_base1.metta
@@ -1,0 +1,6 @@
+;; Incremental-grounding base: transitive readiness over a dep chain.
+(normally r1 (and (dep ?a ?b) (ready ?b)) (ready ?a))
+(given (ready base0))
+(given (dep n1 base0))
+;; delta 1: extend the chain (propagates ready through existing rule r1)
+(given (dep n2 n1))

--- a/tests/deontic/fixtures/incr_combined.metta
+++ b/tests/deontic/fixtures/incr_combined.metta
@@ -1,0 +1,9 @@
+;; Incremental-grounding base: transitive readiness over a dep chain.
+(normally r1 (and (dep ?a ?b) (ready ?b)) (ready ?a))
+(given (ready base0))
+(given (dep n1 base0))
+;; delta 1: extend the chain (propagates ready through existing rule r1)
+(given (dep n2 n1))
+;; delta 2: extend chain further + introduce a brand-new rule r2
+(given (dep n3 n2))
+(normally r2 (ready ?x) (done ?x))

--- a/tests/deontic/fixtures/incr_delta1.metta
+++ b/tests/deontic/fixtures/incr_delta1.metta
@@ -1,0 +1,2 @@
+;; delta 1: extend the chain (propagates ready through existing rule r1)
+(given (dep n2 n1))

--- a/tests/deontic/fixtures/incr_delta2.metta
+++ b/tests/deontic/fixtures/incr_delta2.metta
@@ -1,0 +1,3 @@
+;; delta 2: extend chain further + introduce a brand-new rule r2
+(given (dep n3 n2))
+(normally r2 (ready ?x) (done ?x))

--- a/tests/deontic/fixtures/mining_branchA.metta
+++ b/tests/deontic/fixtures/mining_branchA.metta
@@ -1,0 +1,4 @@
+;; XOR branch (case A): start -> pick_b -> join
+(claims agent:a :at "2026-01-01T01:00:00Z" (given start))
+(claims agent:a :at "2026-01-01T02:00:00Z" (given pick_b))
+(claims agent:a :at "2026-01-01T03:00:00Z" (given join))

--- a/tests/deontic/fixtures/mining_branchB.metta
+++ b/tests/deontic/fixtures/mining_branchB.metta
@@ -1,0 +1,4 @@
+;; XOR branch (case B): start -> pick_c -> join
+(claims agent:a :at "2026-01-01T01:00:00Z" (given start))
+(claims agent:a :at "2026-01-01T02:00:00Z" (given pick_c))
+(claims agent:a :at "2026-01-01T03:00:00Z" (given join))

--- a/tests/deontic/fixtures/mining_seq.metta
+++ b/tests/deontic/fixtures/mining_seq.metta
@@ -1,0 +1,4 @@
+;; Linear trace for process-mining tests: step1 -> step2 -> step3
+(claims agent:a :at "2026-01-01T01:00:00Z" (given step1))
+(claims agent:a :at "2026-01-01T02:00:00Z" (given step2))
+(claims agent:a :at "2026-01-01T03:00:00Z" (given step3))

--- a/tests/deontic/fixtures/missing_premise.metta
+++ b/tests/deontic/fixtures/missing_premise.metta
@@ -1,0 +1,2 @@
+(given code-written)
+(normally r1 (and code-written tests-pass) ready-review)

--- a/tests/deontic/fixtures/modal.metta
+++ b/tests/deontic/fixtures/modal.metta
@@ -1,0 +1,3 @@
+(given (must pay))
+(given (may relax))
+(given (forbidden steal))

--- a/tests/deontic/fixtures/modal_neg.metta
+++ b/tests/deontic/fixtures/modal_neg.metta
@@ -1,0 +1,6 @@
+;; Negated deontic conclusions (obligation to NOT do something), with superiority.
+;; Exercises [O]~p rendering and modal sign-complement defeat.
+(given a)
+(normally r1 a (must (not p)))
+(normally r2 a (must p))
+(prefer r1 r2)

--- a/tests/deontic/fixtures/neg_facts.metta
+++ b/tests/deontic/fixtures/neg_facts.metta
@@ -1,0 +1,2 @@
+(given (not raining))
+(normally r1 (not raining) dry)

--- a/tests/deontic/fixtures/numeric_xtype.metta
+++ b/tests/deontic/fixtures/numeric_xtype.metta
@@ -1,0 +1,3 @@
+(given (val a 2))
+(given (threshold 2.0))
+(normally r1 (and (val ?x ?v) (threshold ?t) (>= ?v ?t)) (passes ?x))

--- a/tests/deontic/fixtures/penguin.dfl
+++ b/tests/deontic/fixtures/penguin.dfl
@@ -1,0 +1,6 @@
+# Classic penguin example in DFL
+>> bird
+>> penguin
+r1: bird => flies
+r2: penguin => -flies
+r2 > r1

--- a/tests/deontic/fixtures/penguin.metta
+++ b/tests/deontic/fixtures/penguin.metta
@@ -1,0 +1,11 @@
+; Classic Tweety/Penguin example
+; Penguins are birds that don't fly
+
+(given bird)
+(given penguin)
+
+(normally r1 bird flies)
+(normally r2 penguin (not flies))
+
+; Penguins are more specific than birds
+(prefer r2 r1)

--- a/tests/deontic/fixtures/perm_defeats.metta
+++ b/tests/deontic/fixtures/perm_defeats.metta
@@ -1,0 +1,6 @@
+;; Strong permission overrides a defeasible prohibition (Governatori).
+;; Plain reasoning: F p and P p simply coexist as facts. Deontic mode: the
+;; explicit permission defeats the prohibition.
+(given a)
+(normally r1 a (forbidden p))
+(given (may p))

--- a/tests/deontic/fixtures/plan_cycle.metta
+++ b/tests/deontic/fixtures/plan_cycle.metta
@@ -1,0 +1,5 @@
+;; Deadlock: ready-a waits on ready-b, ready-b waits on ready-a (circular).
+(given start)
+(normally rA ready-b ready-a)
+(normally rB ready-a ready-b)
+(normally r0 start ready-c)

--- a/tests/deontic/fixtures/plan_incon.metta
+++ b/tests/deontic/fixtures/plan_incon.metta
@@ -1,0 +1,4 @@
+;; Self-inconsistent: strict rules derive both p and ¬p.
+(given a)
+(always r1 a p)
+(always r2 a (not p))

--- a/tests/deontic/fixtures/strict_beats_def.metta
+++ b/tests/deontic/fixtures/strict_beats_def.metta
@@ -1,0 +1,5 @@
+(given a)
+(given b)
+(always s1 a (not p))
+(normally r1 b p)
+(prefer r1 s1)

--- a/tests/deontic/fixtures/strict_chain.metta
+++ b/tests/deontic/fixtures/strict_chain.metta
@@ -1,0 +1,5 @@
+(given a)
+(always s1 a b)
+(always s2 b c)
+(normally r1 c d)
+(normally r2 e f)

--- a/tests/deontic/fixtures/sup_chain.metta
+++ b/tests/deontic/fixtures/sup_chain.metta
@@ -1,0 +1,6 @@
+(given base)
+(normally r1 base p)
+(normally r2 base (not p))
+(normally r3 base p)
+(prefer r3 r2)
+(prefer r2 r1)

--- a/tests/deontic/fixtures/superiority.metta
+++ b/tests/deontic/fixtures/superiority.metta
@@ -1,0 +1,5 @@
+(given a)
+(normally r1 a p)
+(normally r2 a (not p))
+(normally r3 a p)
+(prefer r3 r2)

--- a/tests/deontic/fixtures/team_defeat.metta
+++ b/tests/deontic/fixtures/team_defeat.metta
@@ -1,0 +1,6 @@
+(given base)
+(normally r1 base p)
+(normally a1 base (not p))
+(normally a2 base (not p))
+(normally d1 base p)
+(prefer d1 a1)

--- a/tests/deontic/fixtures/temporal-plan.metta
+++ b/tests/deontic/fixtures/temporal-plan.metta
@@ -1,0 +1,85 @@
+;; =============================================================================
+;; TEMPORAL TEST PLAN (MeTTa format)
+;; =============================================================================
+;; Tests temporal reasoning features with timestamped claims.
+;; Rules and facts have temporal annotations for time-based queries.
+
+;; -----------------------------------------------------------------------------
+;; Morning Sprint: Initial task setup (09:00)
+;; -----------------------------------------------------------------------------
+(claims agent:coder
+  :at "2026-01-21T09:00:00Z"
+  :note "Morning sprint planning"
+
+  ;; Sprint tasks
+  (given task_feature_a)
+  (given task_feature_b)
+  (given task_bugfix)
+
+  ;; Initial dependencies
+  (given no_deps_feature_a)
+  (given no_deps_bugfix)
+
+  ;; Feature B depends on A
+  (normally dep_b completed_feature_a ready_feature_b))
+
+;; -----------------------------------------------------------------------------
+;; Mid-Morning: Feature A completed (10:30)
+;; -----------------------------------------------------------------------------
+(claims agent:coder
+  :at "2026-01-21T10:30:00Z"
+  :note "Feature A completion"
+
+  (given completed_feature_a)
+  (normally r_a_done completed_feature_a feature_a_shipped))
+
+;; -----------------------------------------------------------------------------
+;; Noon: Bugfix completed (12:00)
+;; -----------------------------------------------------------------------------
+(claims agent:coder
+  :at "2026-01-21T12:00:00Z"
+  :note "Bugfix completion"
+
+  (given completed_bugfix)
+  (normally r_bug_done completed_bugfix bugfix_shipped))
+
+;; -----------------------------------------------------------------------------
+;; Afternoon: Feature B completed (14:00)
+;; -----------------------------------------------------------------------------
+(claims agent:coder
+  :at "2026-01-21T14:00:00Z"
+  :note "Feature B completion"
+
+  (given completed_feature_b)
+  (normally r_b_done completed_feature_b feature_b_shipped))
+
+;; -----------------------------------------------------------------------------
+;; Late Afternoon: QA Review (16:00)
+;; -----------------------------------------------------------------------------
+(claims agent:qa
+  :at "2026-01-21T16:00:00Z"
+  :note "QA review session"
+
+  (given qa_reviewed_a)
+  (given qa_reviewed_b)
+  (given qa_reviewed_bugfix)
+
+  (normally qa1 (and qa_reviewed_a feature_a_shipped) qa_approved_a)
+  (normally qa2 (and qa_reviewed_b feature_b_shipped) qa_approved_b)
+  (normally qa3 (and qa_reviewed_bugfix bugfix_shipped) qa_approved_bugfix))
+
+;; -----------------------------------------------------------------------------
+;; End of Day: Release decision (17:00)
+;; -----------------------------------------------------------------------------
+(claims system:policy
+  :at "2026-01-21T17:00:00Z"
+  :note "Release gate check"
+
+  (normally rel1 (and qa_approved_a qa_approved_b qa_approved_bugfix) sprint_complete)
+  (normally rel2 sprint_complete ready_release))
+
+;; -----------------------------------------------------------------------------
+;; Task Readiness Rules (always active)
+;; -----------------------------------------------------------------------------
+(normally r_ready_a (and task_feature_a no_deps_feature_a) ready_feature_a)
+(normally r_ready_bug (and task_bugfix no_deps_bugfix) ready_bugfix)

--- a/tests/deontic/fixtures/temporal_at.metta
+++ b/tests/deontic/fixtures/temporal_at.metta
@@ -1,0 +1,2 @@
+(given (during p 100 200))
+(given q)

--- a/tests/deontic/fixtures/temporal_fact.metta
+++ b/tests/deontic/fixtures/temporal_fact.metta
@@ -1,0 +1,2 @@
+(given (during meeting 10 20))
+(normally r1 (during meeting ?T) busy)

--- a/tests/deontic/fixtures/trust-claims.metta
+++ b/tests/deontic/fixtures/trust-claims.metta
@@ -1,0 +1,86 @@
+;; =============================================================================
+;; TRUST CLAIMS TEST PLAN (MeTTa format)
+;; =============================================================================
+;; Tests trust-weighted reasoning with claims from multiple agents.
+;; Each agent contributes facts and rules with source attribution.
+
+;; -----------------------------------------------------------------------------
+;; Security Agent Claims: Reports security findings
+;; -----------------------------------------------------------------------------
+(claims agent:security
+  :at "2026-01-21T09:00:00Z"
+  :note "Security scan results"
+
+  ;; Security findings
+  (given scan_complete)
+  (given no_critical_vulns)
+
+  ;; Rules for security approval
+  (normally sec1 scan_complete scanned)
+  (normally sec2 no_critical_vulns security_clear)
+  (normally sec3 (and scanned security_clear) security_approved))
+
+;; -----------------------------------------------------------------------------
+;; Coder Agent Claims: Reports test and build status
+;; -----------------------------------------------------------------------------
+(claims agent:coder
+  :at "2026-01-21T09:30:00Z"
+  :note "CI/CD pipeline results"
+
+  ;; Build and test facts
+  (given build_passed)
+  (given tests_passed)
+  (given coverage_met)
+
+  ;; Rules for code readiness
+  (normally dev1 build_passed builds_ok)
+  (normally dev2 tests_passed tests_ok)
+  (normally dev3 coverage_met coverage_ok)
+  (normally dev4 (and builds_ok tests_ok) code_quality_ok))
+
+;; -----------------------------------------------------------------------------
+;; QA Agent Claims: Reports manual testing
+;; -----------------------------------------------------------------------------
+(claims agent:qa
+  :at "2026-01-21T10:00:00Z"
+  :note "QA sign-off"
+
+  ;; QA findings
+  (given staging_tested)
+  (given uat_approved)
+
+  ;; Rules for QA approval
+  (normally qa1 staging_tested staging_ok)
+  (normally qa2 uat_approved uat_ok)
+  (normally qa3 (and staging_ok uat_ok) qa_approved))
+
+;; -----------------------------------------------------------------------------
+;; Architect Agent Claims: Reviews design
+;; -----------------------------------------------------------------------------
+(claims agent:architect
+  :at "2026-01-21T10:30:00Z"
+  :note "Architecture review"
+
+  ;; Architecture review findings
+  (given design_reviewed)
+  (given backward_compatible)
+
+  ;; Rules for architecture approval
+  (normally arch1 design_reviewed design_ok)
+  (normally arch2 backward_compatible api_stable)
+  (normally arch3 (and design_ok api_stable) arch_approved))
+
+;; -----------------------------------------------------------------------------
+;; System Policy: Combines signals into deployment decision
+;; -----------------------------------------------------------------------------
+(claims system:policy
+  ;; Approval chain rules
+  (normally pol1 (and code_quality_ok qa_approved) dev_approved)
+  (normally pol2 (and dev_approved arch_approved) reviewed)
+  (normally pol3 (and reviewed security_approved) ready_deploy)
+
+  ;; Security blocks deployment (defeater)
+  (except pol4 (not security_approved) (not ready_deploy)))
+
+;; Security override takes precedence
+(prefer pol4 pol3)

--- a/tests/deontic/fixtures/trust-policy.metta
+++ b/tests/deontic/fixtures/trust-policy.metta
@@ -1,0 +1,59 @@
+;; =============================================================================
+;; TRUST POLICY TEST PLAN (MeTTa format)
+;; =============================================================================
+;; Tests trust-weighted reasoning features.
+;; Defines trust values for different agent sources and action thresholds.
+
+;; -----------------------------------------------------------------------------
+;; Trust Values: How much we trust each source (0.0 to 1.0)
+;; -----------------------------------------------------------------------------
+
+;; Security agent has highest trust
+(given (trusts "agent:security" 0.95))
+
+;; System policies are fully trusted
+(given (trusts "system:policy" 1.0))
+
+;; Architect is well-trusted
+(given (trusts "agent:architect" 0.85))
+
+;; QA team has good trust
+(given (trusts "agent:qa" 0.80))
+
+;; Developer trust is moderate
+(given (trusts "agent:coder" 0.70))
+
+;; External sources have lower trust
+(given (trusts "external:api" 0.50))
+
+;; Unknown sources have minimal trust
+(given (trusts "unknown" 0.30))
+
+;; -----------------------------------------------------------------------------
+;; Action Thresholds: Minimum trust required for each action
+;; -----------------------------------------------------------------------------
+
+;; Deployment requires very high confidence (0.90)
+(given (threshold "deploy" 0.90))
+
+;; Merge to main requires high confidence (0.80)
+(given (threshold "merge" 0.80))
+
+;; Code review approval needs moderate confidence (0.70)
+(given (threshold "approve" 0.70))
+
+;; Creating alerts requires minimal confidence (0.50)
+(given (threshold "alert" 0.50))
+
+;; Logging requires lowest confidence (0.30)
+(given (threshold "log" 0.30))
+
+;; -----------------------------------------------------------------------------
+;; Trust Decay (optional): How trust diminishes over time
+;; -----------------------------------------------------------------------------
+
+;; External API trust decays faster (exponential model)
+(given (decays "external:api" "exponential"))
+
+;; Agent trust decays linearly over time
+(given (decays "agent:coder" "linear"))

--- a/tests/deontic/fixtures/trust.metta
+++ b/tests/deontic/fixtures/trust.metta
@@ -1,0 +1,6 @@
+(trusts alice 0.9)
+(trusts bob 0.5)
+(claims alice (given rain))
+(claims bob (given cold))
+(normally r1 (and rain cold) miserable)
+(threshold credible 0.6)

--- a/tests/deontic/fixtures/variables.metta
+++ b/tests/deontic/fixtures/variables.metta
@@ -1,0 +1,4 @@
+(given (parent alice bob))
+(given (parent bob carol))
+(always r1 (parent ?x ?y) (ancestor ?x ?y))
+(normally r2 (and (parent ?x ?y) (ancestor ?y ?z)) (ancestor ?x ?z))

--- a/tests/deontic/run.sh
+++ b/tests/deontic/run.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Deontic-core golden suite. A file passes iff it exits 0 and prints no failures.
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+PETTA_DIR="${PETTA_DIR:-/home/user/Dev/PeTTa}"
+SWIPL_BIN="${SWIPL_BIN:-/home/user/Dev/swipl-9.3.33/build-petta/src/swipl}"
+[ -x "$SWIPL_BIN" ] || SWIPL_BIN=swipl
+FAIL=0; PASS=0
+for f in "$SCRIPT_DIR"/test_*.metta; do
+  [ -f "$f" ] || continue
+  name=$(basename "$f")
+  out=$(timeout -k 5 "${TEST_TIMEOUT:-200}" "$SWIPL_BIN" --stack_limit=8g -q \
+        -s "$PETTA_DIR/src/main.pl" -- "$f" --silent </dev/null 2>&1)
+  code=$?
+  ok=$(printf '%s\n' "$out" | grep -c '✅')
+  bad=$(printf '%s\n' "$out" | grep -c '❌')
+  if [ "$code" -eq 0 ] && [ "$bad" -eq 0 ]; then
+    echo "PASS  $name  ($ok checks)"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  $name  ($ok ok, $bad failed, exit $code)"
+    printf '%s\n' "$out" | grep -E '❌|Error|ERROR' | head -5; FAIL=$((FAIL + 1))
+  fi
+done
+echo "----"; echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && echo "ALL DEONTIC-CORE TESTS PASSED"
+exit $FAIL

--- a/tests/deontic/test_core.metta
+++ b/tests/deontic/test_core.metta
@@ -1,0 +1,126 @@
+!(import! &self (library OmegaClaw-Core lib_deontic))
+; Core defeasible-logic engine tests.
+; Expected values are golden conclusion sets for each fixture.
+; Conclusions are compared as sorted sets of (tag lit) tuples;
+; tags: pD = +D, nD = -D, pd = +d, nd = -d (the DL(d) definite/defeasible
+; proof tags +Δ/−Δ and +∂/−∂).
+
+
+; ---------------------------------------------------------------
+; penguin.metta: superiority resolves the conflict in favour of r2
+; ---------------------------------------------------------------
+!(test (dl-run (dl-path tests/deontic/fixtures/penguin.metta))
+       (sort-atom ((pD (lit pos none none bird ()))
+                   (pD (lit pos none none penguin ()))
+                   (pd (lit pos none none bird ()))
+                   (pd (lit pos none none penguin ()))
+                   (pd (lit neg none none flies ()))
+                   (nD (lit neg none none flies ()))
+                   (nD (lit pos none none flies ()))
+                   (nd (lit pos none none flies ())))))
+
+; ---------------------------------------------------------------
+; conflict_facts.metta: +D both, -d both (condition 2)
+; ---------------------------------------------------------------
+!(test (dl-run (dl-path tests/deontic/fixtures/conflict_facts.metta))
+       (sort-atom ((pD (lit neg none none p ()))
+                   (pD (lit pos none none p ()))
+                   (nd (lit pos none none p ()))
+                   (nd (lit neg none none p ())))))
+
+; ---------------------------------------------------------------
+; ambiguity.metta: unresolved conflict blocks both sides
+; ---------------------------------------------------------------
+!(test (dl-run (dl-path tests/deontic/fixtures/ambiguity.metta))
+       (sort-atom ((pD (lit pos none none a ()))
+                   (pd (lit pos none none a ()))
+                   (nD (lit pos none none q ()))
+                   (nd (lit pos none none q ()))
+                   (nD (lit neg none none q ()))
+                   (nd (lit neg none none q ())))))
+
+; ---------------------------------------------------------------
+; defeater.metta: d1 vetoes flies without proving ~flies
+; ---------------------------------------------------------------
+!(test (dl-run (dl-path tests/deontic/fixtures/defeater.metta))
+       (sort-atom ((pD (lit pos none none bird ()))
+                   (pD (lit pos none none injured ()))
+                   (pd (lit pos none none bird ()))
+                   (pd (lit pos none none injured ()))
+                   (nD (lit neg none none flies ()))
+                   (nd (lit neg none none flies ()))
+                   (nD (lit pos none none flies ()))
+                   (nd (lit pos none none flies ())))))
+
+; ---------------------------------------------------------------
+; strict_chain.metta: a -> b -> c, then c => d; e => f never fires
+; ---------------------------------------------------------------
+!(test (dl-run (dl-path tests/deontic/fixtures/strict_chain.metta))
+       (sort-atom ((pD (lit pos none none a ()))
+                   (pD (lit pos none none b ()))
+                   (pD (lit pos none none c ()))
+                   (pd (lit pos none none a ()))
+                   (pd (lit pos none none b ()))
+                   (pd (lit pos none none c ()))
+                   (pd (lit pos none none d ()))
+                   (nD (lit pos none none d ()))
+                   (nD (lit pos none none e ()))
+                   (nd (lit pos none none e ()))
+                   (nD (lit pos none none f ()))
+                   (nd (lit pos none none f ())))))
+
+; ---------------------------------------------------------------
+; superiority.metta: r3 > r2 lets p through; ~p stays blocked
+; ---------------------------------------------------------------
+!(test (dl-run (dl-path tests/deontic/fixtures/superiority.metta))
+       (sort-atom ((pD (lit pos none none a ()))
+                   (pd (lit pos none none a ()))
+                   (pd (lit pos none none p ()))
+                   (nD (lit pos none none p ()))
+                   (nD (lit neg none none p ()))
+                   (nd (lit neg none none p ())))))
+
+; ---------------------------------------------------------------
+; strict_beats_def.metta: strict attacker ignores superiority
+; ---------------------------------------------------------------
+!(test (dl-run (dl-path tests/deontic/fixtures/strict_beats_def.metta))
+       (sort-atom ((pD (lit pos none none a ()))
+                   (pD (lit pos none none b ()))
+                   (pD (lit neg none none p ()))
+                   (pd (lit pos none none a ()))
+                   (pd (lit pos none none b ()))
+                   (pd (lit neg none none p ()))
+                   (nD (lit pos none none p ()))
+                   (nd (lit pos none none p ())))))
+
+; ---------------------------------------------------------------
+; variables.metta: Datalog grounding with transitive ancestor
+; ---------------------------------------------------------------
+!(test (dl-run (dl-path tests/deontic/fixtures/variables.metta))
+       (sort-atom ((pD (lit pos none none parent (alice bob)))
+                   (pD (lit pos none none parent (bob carol)))
+                   (pD (lit pos none none ancestor (alice bob)))
+                   (pD (lit pos none none ancestor (bob carol)))
+                   (pd (lit pos none none parent (alice bob)))
+                   (pd (lit pos none none parent (bob carol)))
+                   (pd (lit pos none none ancestor (alice bob)))
+                   (pd (lit pos none none ancestor (bob carol)))
+                   (pd (lit pos none none ancestor (alice carol)))
+                   (nD (lit pos none none ancestor (alice carol))))))
+
+; ---------------------------------------------------------------
+; arith.metta: guards filter substitutions; bind extends them
+; ---------------------------------------------------------------
+!(test (dl-run (dl-path tests/deontic/fixtures/arith.metta))
+       (sort-atom ((pD (lit pos none none salary (alice 120000)))
+                   (pD (lit pos none none salary (bob 85000)))
+                   (pd (lit pos none none salary (alice 120000)))
+                   (pd (lit pos none none salary (bob 85000)))
+                   (pd (lit pos none none double-pay (alice 240000)))
+                   (pd (lit pos none none double-pay (bob 170000)))
+                   (pd (lit pos none none high-earner (alice)))
+                   (nD (lit pos none none double-pay (alice 240000)))
+                   (nD (lit pos none none double-pay (bob 170000)))
+                   (nD (lit pos none none high-earner (alice))))))
+
+!(println! test-core-done)

--- a/tests/deontic/test_ctd.metta
+++ b/tests/deontic/test_ctd.metta
@@ -1,0 +1,31 @@
+!(import! &self (library OmegaClaw-Core lib_deontic))
+; Contrary-to-duty (CTD) reparation chains — Governatori's ⊗ operator, via the
+; (otherwise D1 D2 ... Dn) rule-head syntax (one of the deontic extensions).
+; O(¬litter ⊗ pay_fine ⊗ apologize): primary "don't litter", reparation
+; "pay the fine" if that's violated, "apologize" if that's also violated.
+
+
+(= (concl? $lit) (is-member $lit (dl-conclusions)))
+
+; --- violation activates the reparation ---
+!(dl-run (dl-path tests/deontic/fixtures/ctd_violated.metta))
+!(test (concl? (pd (lit pos F none litter ()))) True)       ; primary prohibition holds
+!(test (concl? (pd (lit pos O none pay_fine ()))) True)     ; reparation O pay_fine active
+!(test (concl? (pd (lit pos O none apologize ()))) False)   ; 2nd reparation NOT yet (fine pending)
+; compliance: primary violated, reparation pending
+!(test (compliance-of (lit pos F none litter ())) violated)
+!(test (compliance-of (lit pos O none pay_fine ())) pending)
+
+; --- no violation -> no reparation ---
+!(dl-run (dl-path tests/deontic/fixtures/ctd_clean.metta))
+!(test (concl? (pd (lit pos F none litter ()))) True)
+!(test (concl? (pd (lit pos O none pay_fine ()))) False)    ; reparation dormant
+!(test (compliance-of (lit pos F none litter ())) pending)  ; not littered -> not violated
+
+; --- cascade: primary AND first reparation violated -> 2nd reparation fires ---
+!(dl-run (dl-path tests/deontic/fixtures/ctd_cascade.metta))
+!(test (concl? (pd (lit pos O none pay_fine ()))) True)
+!(test (concl? (pd (lit pos O none apologize ()))) True)    ; cascaded
+!(test (compliance-of (lit pos O none pay_fine ())) violated) ; fine unpaid
+
+!(println! test-ctd-done)

--- a/tests/deontic/test_deadline.metta
+++ b/tests/deontic/test_deadline.metta
@@ -1,0 +1,34 @@
+!(import! &self (library OmegaClaw-Core lib_deontic))
+; Temporal-deontic deadline obligations — Governatori, Hulstijn, Riveret & Rotolo
+; (2007), "Characterising Deadlines in Temporal Modal Defeasible Logic", via the
+; (deadline ...) syntax (a temporal-deontic extension). Achievement obligations
+; must be fulfilled by the deadline; maintenance obligations (prohibitions) must
+; hold throughout the window. Compliance is evaluated at a reference time `now`:
+; fulfilled / violated / pending (deolingo's O^f / O^v / O^u), with sanctions
+; triggered on violation.
+
+
+; --- ACHIEVEMENT: pay by 30, actually paid at t=25 ---
+; at now=40 the payment is in the past and in window -> fulfilled
+!(test (deadline-status (dl-path tests/deontic/fixtures/deadline_demo.metta) 40 pay) fulfilled)
+; at now=20 the payment (t=25) hasn't happened yet, deadline not passed -> pending
+!(test (deadline-status (dl-path tests/deontic/fixtures/deadline_demo.metta) 20 pay) pending)
+
+; --- ACHIEVEMENT violated: never paid, deadline 30 passed (now=40) ---
+!(test (deadline-status (dl-path tests/deontic/fixtures/deadline_missed.metta) 40 pay) violated)
+; ...but before the deadline it is only pending
+!(test (deadline-status (dl-path tests/deontic/fixtures/deadline_missed.metta) 10 pay) pending)
+
+; --- MAINTENANCE: no trespass yet -> pending while in window; clean past window ---
+!(test (deadline-status (dl-path tests/deontic/fixtures/deadline_demo.metta) 40 trespass) pending)
+!(test (deadline-status (dl-path tests/deontic/fixtures/deadline_clean.metta) 60 trespass) fulfilled)
+
+; --- MAINTENANCE violated: trespass at t=20 in window [0,50] (a breach by now=40) ---
+!(test (deadline-status (dl-path tests/deontic/fixtures/deadline_missed.metta) 40 trespass) violated)
+; ...but at now=10 the breach (t=20) hasn't occurred yet -> still pending
+!(test (deadline-status (dl-path tests/deontic/fixtures/deadline_missed.metta) 10 trespass) pending)
+
+; --- the renderer runs end-to-end ---
+!(test (deontic-deadlines (dl-path tests/deontic/fixtures/deadline_demo.metta) 40) true)
+
+!(println! test-deadline-done)

--- a/tests/deontic/test_deontic.metta
+++ b/tests/deontic/test_deontic.metta
@@ -1,0 +1,57 @@
+!(import! &self (library OmegaClaw-Core lib_deontic))
+; Standard Deontic Logic layer (opt-in; the base defeasible logic carries modes
+; O/P/F without inferring, and this layer adds the SDL bridges). Canonical
+; relationships:
+;   F p ≡ O ¬p   (forbidden = obligatory-not)
+;   O p → P p    (ought implies may, under deontic consistency)
+; Verified sound on modal.metta; the default reason path leaves plain defeasible
+; reasoning untouched.
+
+
+(= (concl? $lit) (is-member $lit (dl-conclusions)))
+
+; --- deontic closure of (must pay)(may relax)(forbidden steal) ---
+!(dl-run-deontic (dl-path tests/deontic/fixtures/modal.metta))
+
+; O pay  →  P pay     (ought implies may)
+!(test (concl? (pd (lit pos P none pay ()))) True)
+; O pay  →  F ¬pay    (obligatory ≡ forbidden-not)
+!(test (concl? (pd (lit neg F none pay ()))) True)
+; F steal →  O ¬steal (forbidden ≡ obligatory-not)
+!(test (concl? (pd (lit neg O none steal ()))) True)
+; O ¬steal → P ¬steal (chained: ought-not implies may-not)
+!(test (concl? (pd (lit neg P none steal ()))) True)
+; the bare permission stays put (P is a sink — no spurious obligations)
+!(test (concl? (pd (lit pos O none relax ()))) False)
+
+; --- DEFEASIBLE INTERACTION: superiority resolves a deontic conflict ---
+; r1: a => O p   r2: a => F p   (prefer r1 r2).  Since F p ≡ O ¬p and the
+; equivalence carries r2's label, O p (r1) attacks O ¬p (r2) and r1 > r2 wins:
+; obligation holds, permission follows, forbidden is defeated.
+!(dl-run-deontic (dl-path tests/deontic/fixtures/deontic_conflict.metta))
+!(test (concl? (pd (lit pos O none p ()))) True)    ; O p wins
+!(test (concl? (pd (lit pos P none p ()))) True)    ; O p -> P p
+!(test (concl? (pd (lit pos F none p ()))) False)   ; F p defeated
+!(test (concl? (pd (lit neg O none p ()))) False)   ; O ¬p defeated
+
+; --- STRONG PERMISSION defeats a contrary defeasible prohibition ---
+; r1: a => F p   plus an explicit (may p). The permission emits a defeater that
+; blocks the prohibition (in both its F and O¬ forms); only the permission holds.
+!(dl-run-deontic (dl-path tests/deontic/fixtures/perm_defeats.metta))
+!(test (concl? (pd (lit pos P none p ()))) True)    ; permission holds
+!(test (concl? (pd (lit pos F none p ()))) False)   ; prohibition defeated
+!(test (concl? (pd (lit neg O none p ()))) False)   ; ...in its O¬ form too
+
+; --- DILEMMA: O p vs F p with no superiority is flagged as unresolved ---
+!(test (size-atom (deontic-dilemmas (dl-path tests/deontic/fixtures/deontic_dilemma.metta))) 1)
+; ...and a superiority resolves it (no dilemma)
+!(test (size-atom (deontic-dilemmas (dl-path tests/deontic/fixtures/deontic_conflict.metta))) 0)
+
+; --- opt-in: the DEFAULT path derives none of the deontic consequences ---
+!(dl-run (dl-path tests/deontic/fixtures/modal.metta))
+!(test (concl? (pd (lit pos P none pay ()))) False)
+!(test (concl? (pd (lit neg O none steal ()))) False)
+; ...but still has the three modal facts themselves
+!(test (concl? (pd (lit pos O none pay ()))) True)
+
+!(println! test-deontic-done)

--- a/tests/deontic/test_dfl.metta
+++ b/tests/deontic/test_dfl.metta
@@ -1,0 +1,22 @@
+!(import! &self (library OmegaClaw-Core lib_deontic))
+; DFL (arrow format) parser tests. The DFL surface notation is validated by
+; comparing each .dfl theory to its hand-built .metta equivalent: both must produce
+; the same defeasible conclusions, confirming the two front ends compile to the
+; same underlying theory.
+
+; penguin.dfl  ==  penguin.metta  (facts, defeasible rules, superiority, negation)
+!(test (dl-run (dl-path tests/deontic/fixtures/penguin.dfl))
+       (dl-run (dl-path tests/deontic/fixtures/penguin.metta)))
+
+; strict + defeater + negation:  dfl_mixed.dfl == its MeTTa equivalent
+!(test (dl-run (dl-path tests/deontic/fixtures/dfl_mixed.dfl))
+       (dl-run (dl-path tests/deontic/fixtures/dfl_mixed_sexpr.metta)))
+
+; multi-literal bodies, front-matter blocks (skipped), assignments via DFL
+; (annotated.dfl is a representative annotated DFL example)
+!(dl-run (dl-path tests/deontic/fixtures/annotated.dfl))
+(= (is-pd $f) (is-member (pd (lit pos none none $f ())) (dl-conclusions)))
+!(test (map-atom (ready_auth assignTo_auth_coder assignTo_auth_security) $f (is-pd $f))
+       (True True True))
+
+!(println! test-dfl-done)

--- a/tests/deontic/test_eventcalc.metta
+++ b/tests/deontic/test_eventcalc.metta
@@ -1,0 +1,29 @@
+!(import! &self (library OmegaClaw-Core lib_deontic))
+; Event-Calculus obligation lifecycle — obligations as inertial fluents
+; (RTEC/oPIEC, Mantenoglou & Artikis; Governatori init/term templates), via the
+; happens/initiates/terminates syntax (a temporal extension). An obligation is
+; initiated by an event, persists by inertia (the Event Calculus initiates/
+; terminates/holdsAt frame), terminated by another event (its fulfilment).
+; Maximal in-force intervals computed by one-pass amalgamation (O(n log n) in the
+; number of events). A violation = the obligation still holds at its deadline.
+
+
+; invoice@5 initiates O pay; pay@25 terminates it -> in force [5,25)
+!(test (ec-intervals (dl-path tests/deontic/fixtures/eventcalc_demo.metta) (must pay)) ((5 25)))
+!(test (ec-holds-at (dl-path tests/deontic/fixtures/eventcalc_demo.metta) (must pay) 3)  False) ; before init
+!(test (ec-holds-at (dl-path tests/deontic/fixtures/eventcalc_demo.metta) (must pay) 10) True)  ; in force
+!(test (ec-holds-at (dl-path tests/deontic/fixtures/eventcalc_demo.metta) (must pay) 30) False) ; discharged
+
+; violation = obligation still in force at the deadline (not fulfilled in time)
+!(test (ec-violated-at (dl-path tests/deontic/fixtures/eventcalc_demo.metta) (must pay) 20) True)  ; unpaid at 20
+!(test (ec-violated-at (dl-path tests/deontic/fixtures/eventcalc_demo.metta) (must pay) 30) False) ; paid by 25
+
+; never discharged -> open interval [5,inf); always in force / violated afterwards
+!(test (ec-intervals (dl-path tests/deontic/fixtures/eventcalc_open.metta) (must pay)) ((5 inf)))
+!(test (ec-holds-at (dl-path tests/deontic/fixtures/eventcalc_open.metta) (must pay) 1000) True)
+!(test (ec-violated-at (dl-path tests/deontic/fixtures/eventcalc_open.metta) (must pay) 1000) True)
+
+; the timeline renderer runs end-to-end
+!(test (ec-timeline (dl-path tests/deontic/fixtures/eventcalc_demo.metta) 15) true)
+
+!(println! test-eventcalc-done)

--- a/tests/deontic/test_incremental.metta
+++ b/tests/deontic/test_incremental.metta
@@ -1,0 +1,26 @@
+!(import! &self (library OmegaClaw-Core lib_deontic))
+; Incremental (append-only) grounding: a session that loads a base plan then
+; APPENDS delta plans, grounding only the new closure each time (semi-naive,
+; add-only), must yield IDENTICAL conclusions to a from-scratch load of the
+; concatenated plan. This is the correctness contract for the optimization.
+
+
+; incremental session: base, then two appended deltas (the second adds a new rule)
+(= (incr-result)
+   (let* (($_1 (dl-load-incr   (dl-path tests/deontic/fixtures/incr_base.metta)))
+          ($_2 (dl-append-incr! (dl-path tests/deontic/fixtures/incr_delta1.metta)))
+          ($_3 (dl-append-incr! (dl-path tests/deontic/fixtures/incr_delta2.metta))))
+     (dl-reason-incr)))
+
+; the same plan loaded from scratch (base ++ delta1 ++ delta2)
+!(test (incr-result) (dl-run (dl-path tests/deontic/fixtures/incr_combined.metta)))
+
+; incremental delta after only the FIRST append also matches its concatenation
+(= (incr-result-1)
+   (let* (($_1 (dl-load-incr   (dl-path tests/deontic/fixtures/incr_base.metta)))
+          ($_2 (dl-append-incr! (dl-path tests/deontic/fixtures/incr_delta1.metta))))
+     (dl-reason-incr)))
+
+!(test (incr-result-1) (dl-run (dl-path tests/deontic/fixtures/incr_base1.metta)))
+
+!(println! test-incremental-done)

--- a/tests/deontic/test_query.metta
+++ b/tests/deontic/test_query.metta
@@ -1,0 +1,77 @@
+!(import! &self (library OmegaClaw-Core lib_deontic))
+; Query operator tests: why-not / requires / explain / abduce / what-if.
+; Each expected value is the golden result of the query on the named fixture
+; (see comments per test).
+
+
+; ---------------------------------------------------------------
+; why-not on missing_premise.metta
+; would derive via r1; blocked because the premise tests-pass is missing
+; ---------------------------------------------------------------
+!(dl-run (dl-path tests/deontic/fixtures/missing_premise.metta))
+!(test (dl-why-not (lit pos none none ready-review ()))
+       (whynot (lit pos none none ready-review ())
+               (would r1)
+               (blockers ((missing r1 ((lit pos none none tests-pass ())))))))
+
+; abduce on the same state
+; the one missing premise needed is: {tests-pass}
+!(test (dl-abduce (lit pos none none ready-review ()))
+       (abduction (lit pos none none ready-review ())
+                  (solutions (((lit pos none none tests-pass ()))))))
+
+; requires verifies by injection + re-reasoning
+!(test (dl-requires (dl-path tests/deontic/fixtures/missing_premise.metta)
+                         (lit pos none none ready-review ()))
+       (requires (lit pos none none ready-review ())
+                 (verified ((lit pos none none tests-pass ())))))
+
+; ---------------------------------------------------------------
+; why-not flies on penguin.metta
+; would derive via r1; blocked because r2 contradicts it
+; ---------------------------------------------------------------
+!(dl-run (dl-path tests/deontic/fixtures/penguin.metta))
+!(test (dl-why-not (lit pos none none flies ()))
+       (whynot (lit pos none none flies ())
+               (would r1)
+               (blockers ((contradicted r1 r2)))))
+
+; why-not on a provable literal reports provable
+!(test (dl-why-not (lit neg none none flies ()))
+       (whynot (lit neg none none flies ()) provable))
+
+; explain +d ~flies: rule r2 over fact penguin (proof: r2 <- f2)
+!(test (explain (lit neg none none flies ()))
+       (proof (lit neg none none flies ())
+              (rule r2 ((proof (lit pos none none penguin ()) (fact f2))))))
+
+; explain a fact
+!(test (explain (lit pos none none bird ()))
+       (proof (lit pos none none bird ()) (fact f1)))
+
+; ---------------------------------------------------------------
+; why-not flies on defeater.metta: defeated by d1
+; ---------------------------------------------------------------
+!(dl-run (dl-path tests/deontic/fixtures/defeater.metta))
+!(test (dl-why-not (lit pos none none flies ()))
+       (whynot (lit pos none none flies ())
+               (would r1)
+               (blockers ((defeated r1 d1)))))
+
+; ---------------------------------------------------------------
+; what-if on strict_chain.metta: assuming e makes f provable
+; ---------------------------------------------------------------
+!(test (dl-what-if (dl-path tests/deontic/fixtures/strict_chain.metta)
+                        ((lit pos none none e ()))
+                        (lit pos none none f ()))
+       (whatif provable
+               (new (sort-atom ((lit pos none none e ()) (lit pos none none f ()))))
+               (assumed ((lit pos none none e ())))))
+
+; what-if that refutes: assuming penguin-theory hypothetical against ~flies
+!(test (dl-what-if (dl-path tests/deontic/fixtures/penguin.metta)
+                        ()
+                        (lit pos none none flies ()))
+       (whatif refuted (new ()) (assumed ())))
+
+!(println! test-query-done)

--- a/tests/deontic/test_temporal.metta
+++ b/tests/deontic/test_temporal.metta
@@ -1,0 +1,76 @@
+!(import! &self (library OmegaClaw-Core lib_deontic))
+; Temporal + modal tests using the (during LIT ?T) interval-handle syntax, which
+; binds an interval handle ?T, and the 13 Allen interval relations relate two
+; handles. The cases here cover all 13 Allen relations; allen_intervals.metta is a
+; single fixture that exercises each of the 13 relations plus negative controls.
+
+
+; ---------------------------------------------------------------
+; temporal fact + rule matching it via an interval variable
+;   +D/+d meeting[10,20], +d busy, -D busy
+; ---------------------------------------------------------------
+!(test (dl-run (dl-path tests/deontic/fixtures/temporal_fact.metta))
+       (sort-atom ((pD (lit pos none (iv 10 20) meeting ()))
+                   (pd (lit pos none (iv 10 20) meeting ()))
+                   (pd (lit pos none none busy ()))
+                   (nD (lit pos none none busy ())))))
+
+; ---------------------------------------------------------------
+; Allen `before` over interval handles: a=[10,20] before b=[25,35] -> seq-ab
+; ---------------------------------------------------------------
+!(test (dl-run (dl-path tests/deontic/fixtures/allen_seq.metta))
+       (sort-atom ((pD (lit pos none (iv 10 20) ev (a)))
+                   (pD (lit pos none (iv 25 35) ev (b)))
+                   (pd (lit pos none (iv 10 20) ev (a)))
+                   (pd (lit pos none (iv 25 35) ev (b)))
+                   (pd (lit pos none none seq-ab ()))
+                   (nD (lit pos none none seq-ab ())))))
+
+; ---------------------------------------------------------------
+; modal operators as distinct atoms (O/P/F differ in the mode slot)
+; ---------------------------------------------------------------
+!(test (dl-run (dl-path tests/deontic/fixtures/modal.metta))
+       (sort-atom ((pD (lit pos O none pay ()))
+                   (pd (lit pos O none pay ()))
+                   (pD (lit pos P none relax ()))
+                   (pd (lit pos P none relax ()))
+                   (pD (lit pos F none steal ()))
+                   (pd (lit pos F none steal ())))))
+!(test (lit-neg (lit pos O none pay ())) (lit neg O none pay ()))
+
+; ---------------------------------------------------------------
+; all 13 Allen relations (one fixture covering every relation): each result-* fires +d,
+; each negative-test literal never fires (its rule's constraint fails so it
+; isn't even in the universe — not present at any tag).
+; ---------------------------------------------------------------
+(= (concl-has $cs $tag $f)
+   (is-member ($tag (lit pos none none $f ())) $cs))
+
+!(test (let $cs (dl-run (dl-path tests/deontic/fixtures/allen_intervals.metta))
+         (map-atom (result-before result-after result-meets result-met-by
+                    result-overlaps result-overlapped-by result-starts result-started-by
+                    result-within result-contains result-finishes result-finished-by
+                    result-equals)
+                   $r (concl-has $cs pd $r)))
+       (True True True True True True True True True True True True True))
+
+; the five negative-test literals are absent entirely (not +d and not -d)
+!(test (let $cs (dl-run (dl-path tests/deontic/fixtures/allen_intervals.metta))
+         (map-atom (neg-before neg-meets neg-overlaps neg-within neg-equals)
+                   $n (or (concl-has $cs pd $n) (concl-has $cs nd $n))))
+       (False False False False False))
+
+; ---------------------------------------------------------------
+; --at filtering: p[100,200] active at 150, filtered out at 300
+; ---------------------------------------------------------------
+!(test (dl-run-at (dl-path tests/deontic/fixtures/temporal_at.metta) 150)
+       (sort-atom ((pD (lit pos none none q ()))
+                   (pd (lit pos none none q ()))
+                   (pD (lit pos none (iv 100 200) p ()))
+                   (pd (lit pos none (iv 100 200) p ())))))
+
+!(test (dl-run-at (dl-path tests/deontic/fixtures/temporal_at.metta) 300)
+       (sort-atom ((pD (lit pos none none q ()))
+                   (pd (lit pos none none q ())))))
+
+!(println! test-temporal-done)

--- a/tests/deontic/test_trust.metta
+++ b/tests/deontic/test_trust.metta
@@ -1,0 +1,53 @@
+!(import! &self (library OmegaClaw-Core lib_deontic))
+; Trust-weighted reasoning tests.
+; Golden trust-annotated conclusions:
+;   +D rain (trust: 0.90) [alice]   +D cold (trust: 0.50) [bob]
+;   +d miserable (trust: 0.00) [alice, bob]   -D miserable (trust: 0.00)
+; Trust = weakest link over the proof tree; rule nodes default to 0.0 so any
+; rule-derived literal is 0.00 unless every step is a trusted fact.
+
+
+!(dl-run (dl-path tests/deontic/fixtures/trust.metta))
+
+; fact trust = claiming source's trust value, with source attribution
+!(test (trust-of (lit pos none none rain ())) 0.9)
+!(test (sources-of (lit pos none none rain ())) (alice))
+!(test (trust-of (lit pos none none cold ())) 0.5)
+!(test (sources-of (lit pos none none cold ())) (bob))
+
+; derived trust = weakest link (rule default 0.0); sources are the union
+!(test (trust-of (lit pos none none miserable ())) 0.0)
+!(test (sources-of (lit pos none none miserable ())) (alice bob))
+
+; full trust-annotated conclusion set
+!(test (dl-trust-run (dl-path tests/deontic/fixtures/trust.metta))
+       (sort-atom ((tconcl pD (lit pos none none rain ()) 0.9 (alice))
+                   (tconcl pd (lit pos none none rain ()) 0.9 (alice))
+                   (tconcl pD (lit pos none none cold ()) 0.5 (bob))
+                   (tconcl pd (lit pos none none cold ()) 0.5 (bob))
+                   (tconcl pd (lit pos none none miserable ()) 0.0 (alice bob))
+                   (tconcl nD (lit pos none none miserable ()) 0.0 ()))))
+
+; rendering matches the canonical trust line format
+!(test (mm_trust_str (tconcl pD (lit pos none none rain ()) 0.9 (alice)))
+       "+D rain (trust: 0.90) [alice]")
+!(test (mm_trust_str (tconcl nD (lit pos none none miserable ()) 0.0 ()))
+       "-D miserable (trust: 0.00)")
+
+; threshold filtering (a literal passes iff its trust degree >= threshold)
+!(test (meets-threshold (lit pos none none rain ()) credible) True)
+!(test (meets-threshold (lit pos none none miserable ()) credible) False)
+
+; unified justification: status + trust + confidence + sources + proof in one
+!(test (justify (lit pos none none rain ()))
+       (justification (literal (lit pos none none rain ()))
+                      (status definitely-provable)
+                      (trust 0.9)
+                      (confidence high)
+                      (sources (alice))
+                      (proof (proof (lit pos none none rain ()) (fact f1)))))
+; a rule-derived literal: low confidence (weakest link through a rule node = 0.0)
+!(test (status-of (lit pos none none miserable ())) defeasibly-provable)
+!(test (confidence-label (trust-of (lit pos none none miserable ()))) none)
+
+!(println! test-trust-done)

--- a/tests/integration/test_analyze.metta
+++ b/tests/integration/test_analyze.metta
@@ -1,0 +1,23 @@
+; Plan analysis: dependency-cycle (deadlock) detection over the support graph,
+; and self-inconsistency (contradictory definite conclusions). Cyclic
+; dependencies can never be grounded from facts, so a cycle is a deadlock; a
+; well-formed plan has none and is consistent.
+
+!(import! &self (library OmegaClaw-Core lib_directive))
+
+; deadlock plan: ready-a ⇄ ready-b is one cyclic dependency group
+!(test (size-atom (plan-cycles (dl-path tests/deontic/fixtures/plan_cycle.metta))) 1)
+; a well-formed directive plan has no dependency cycles
+!(test (size-atom (plan-cycles (dl-path tests/deontic/fixtures/basic-tasks.metta))) 0)
+; penguin is acyclic too
+!(test (size-atom (plan-cycles (dl-path tests/deontic/fixtures/penguin.metta))) 0)
+
+; self-inconsistent plan (strict p and ¬p) is flagged; well-formed plans are not
+!(test (plan-consistent? (dl-path tests/deontic/fixtures/plan_incon.metta)) False)
+!(test (plan-consistent? (dl-path tests/deontic/fixtures/basic-tasks.metta)) True)
+!(test (plan-consistent? (dl-path tests/deontic/fixtures/penguin.metta)) True)
+
+; the analyze renderer runs end-to-end
+!(test (directive-analyze (dl-path tests/deontic/fixtures/plan_cycle.metta)) true)
+
+!(println! test-analyze-done)

--- a/tests/integration/test_directive.metta
+++ b/tests/integration/test_directive.metta
@@ -1,0 +1,132 @@
+; Task-coordination layer tests: extraction (next / status / board / summary /
+; info), state classification, and the full claim / complete / unclaim / block /
+; unblock lifecycle drilled on a temp plan copy. Goldens are the expected
+; coordination results for each fixture.
+
+!(import! &self (library OmegaClaw-Core lib_directive))
+
+; ---------------------------------------------------------------
+; extraction + next on basic-tasks.metta
+; expected next-actions: models@coder, auth@coder, auth@reviewer
+; ---------------------------------------------------------------
+!(test (directive-next (dl-path tests/deontic/fixtures/basic-tasks.metta))
+       (next-actions ((assign auth coder assign-to-auth-coder)
+                      (assign auth reviewer assign-to-auth-reviewer)
+                      (assign models coder assign-to-models-coder))))
+
+!(test (directive-status (dl-path tests/deontic/fixtures/basic-tasks.metta))
+       (status (tasks (auth crud models tests))
+               (ready (auth models))
+               (claimed ())
+               (blocked ())
+               (upstream-blocked ())
+               (completed ())))
+
+; board groups by state; summary counts; info extracts plan metadata
+!(test (directive-board (dl-path tests/deontic/fixtures/basic-tasks.metta))
+       (board (backlog (crud tests))
+              (ready (auth models))
+              (in-progress ())
+              (blocked ())
+              (done ())))
+
+!(test (directive-summary (dl-path tests/deontic/fixtures/basic-tasks.metta))
+       (summary (total 4) (backlog 2) (ready 2) (in-progress 0)
+                (blocked 0) (done 0) (progress-pct 0)))
+
+; info extracts the (meta plan ...) KVs; query specific values via meta-get
+; (the raw KV list isn't compared directly because keys like `id`/`status`
+; collide with stdlib function names under evaluation).
+!(dl-run (dl-path tests/deontic/fixtures/basic-tasks.metta))
+!(test (meta-get (plan-meta-kvs) title) "Basic Task Test")
+!(test (meta-get (plan-meta-kvs) author) "agent:tester")
+!(test (meta-get (plan-meta-kvs) missing-key) none)
+
+; state classification precedence (a completed task is `done`, not `ready`)
+!(test (let $names (directive-pos-names) (directive-task-state models $names)) ready)
+
+; ---------------------------------------------------------------
+; full lifecycle drill on a temp copy
+; ---------------------------------------------------------------
+!(mm_write_file "/tmp/mm_directive_drill.metta"
+                (mm_read_file (dl-path tests/deontic/fixtures/basic-tasks.metta)))
+
+; claiming an unready task fails
+!(test (directive-claim "/tmp/mm_directive_drill.metta" crud tester False)
+       (err not-ready crud))
+
+; force-claim bypasses readiness; not exercised further here
+; complete models -> crud becomes ready
+!(test (directive-complete "/tmp/mm_directive_drill.metta" models tester)
+       (completed models))
+; NOTE: ready-models REMAINS concluded after completion — readiness rules do
+; not retract; `next` filters completed tasks instead.
+!(test (let (status $t (ready $r) $c $b $u $d)
+            (directive-status "/tmp/mm_directive_drill.metta")
+            $r)
+       (auth crud models))
+
+; claim crud v1
+!(test (directive-claim "/tmp/mm_directive_drill.metta" crud tester False)
+       (claimed crud 1))
+!(test (let (status $t $r (claimed $c) $b $u $d)
+            (directive-status "/tmp/mm_directive_drill.metta")
+            $c)
+       (crud))
+
+; claimed task no longer in next actions
+!(test (let (next-actions $as) (directive-next "/tmp/mm_directive_drill.metta")
+         (filter-atom $as $a (let (assign $t $ag $l) $a (== $t crud))))
+       ())
+
+; double-claim is reported
+!(test (directive-claim "/tmp/mm_directive_drill.metta" crud tester False)
+       (already-claimed crud 1))
+
+; unclaim cancels the chain (defeats state-claimed-v1)
+!(test (directive-unclaim "/tmp/mm_directive_drill.metta" crud tester)
+       (unclaimed crud 2))
+!(test (let (status $t $r (claimed $c) $b $u $d)
+            (directive-status "/tmp/mm_directive_drill.metta")
+            $c)
+       ())
+
+; reclaim v3 beats the v2 unclaim chain
+!(test (directive-claim "/tmp/mm_directive_drill.metta" crud tester False)
+       (claimed crud 3))
+!(test (let (status $t $r (claimed $c) $b $u $d)
+            (directive-status "/tmp/mm_directive_drill.metta")
+            $c)
+       (crud))
+
+; block auth -> blocked state; readiness untouched (plans gate via rules)
+!(test (directive-block "/tmp/mm_directive_drill.metta" auth tester)
+       (blocked auth 1))
+!(test (let (status $t $r $c (blocked $b) $u $d)
+            (directive-status "/tmp/mm_directive_drill.metta")
+            $b)
+       (auth))
+
+; unblock cancels it
+!(test (directive-unblock "/tmp/mm_directive_drill.metta" auth tester)
+       (unblocked auth 2))
+!(test (let (status $t $r $c (blocked $b) $u $d)
+            (directive-status "/tmp/mm_directive_drill.metta")
+            $b)
+       ())
+
+; complete remaining flow: crud done -> tests still needs auth
+!(test (directive-complete "/tmp/mm_directive_drill.metta" crud tester)
+       (completed crud))
+!(test (directive-complete "/tmp/mm_directive_drill.metta" auth tester)
+       (completed auth))
+!(test (let (status $t (ready $r) $c $b $u $d)
+            (directive-status "/tmp/mm_directive_drill.metta")
+            $r)
+       (auth crud models tests))
+
+; finishing the last task reports plan completion
+!(test (directive-complete "/tmp/mm_directive_drill.metta" tests tester)
+       (completed tests plan-complete))
+
+!(println! test-directive-done)

--- a/tests/integration/test_inspect.metta
+++ b/tests/integration/test_inspect.metta
@@ -1,0 +1,26 @@
+; Plan-inspection commands (trace / validate / assign). These assertions pin the
+; structured results (sorted assignment sets, validity verdicts) so regressions
+; in extraction or rendering surface as concrete value mismatches.
+
+!(import! &self (library OmegaClaw-Core lib_directive))
+
+; assign: active (non-completed) assignment literals, sorted, all agents.
+!(test (let* (($_ (dl-run (dl-path tests/deontic/fixtures/basic-tasks.metta)))
+              ($names (directive-pos-names)))
+         (assign-names $names ""))
+       (assign-to-auth-coder assign-to-auth-reviewer assign-to-models-coder))
+
+; assign filtered by a specific agent (reviewer only gets the auth-reviewer slot).
+!(test (let* (($_ (dl-run (dl-path tests/deontic/fixtures/basic-tasks.metta)))
+              ($names (directive-pos-names)))
+         (assign-names $names reviewer))
+       (assign-to-auth-reviewer))
+
+; validate: a well-formed plan is valid (the dangling tests-failing literal only
+; yields warnings, not errors, in non-strict mode).
+!(test (directive-validate (dl-path tests/deontic/fixtures/basic-tasks.metta) False) True)
+
+; penguin.metta is clean -> valid with no warnings.
+!(test (directive-validate (dl-path tests/deontic/fixtures/penguin.metta) False) True)
+
+!(println! test-inspect-done)

--- a/tests/integration/test_mining.metta
+++ b/tests/integration/test_mining.metta
@@ -1,0 +1,36 @@
+; Process-mining tests (rule learning from event logs). These assertions pin the
+; deterministic structured results — learned causal rules with their support and
+; confidence, the per-case event log, and that the renderers run end to end — so
+; regressions surface fast.
+
+!(import! &self (library OmegaClaw-Core lib_directive))
+
+; --- rule learning: linear trace step1 -> step2 -> step3 ---
+; two causal pairs, full support/confidence, sorted by (body,head).
+!(test (mining-rules ((dl-path tests/deontic/fixtures/mining_seq.metta)) 1 0.5)
+       ((step1 step2 1 "1.00") (step2 step3 1 "1.00")))
+
+; --- multi-trace XOR branch: start -> {pick_b | pick_c} -> join ---
+; fractional confidence (start has two outgoing edges across the 2 traces).
+!(test (mining-rules ((dl-path tests/deontic/fixtures/mining_branchA.metta)
+                      (dl-path tests/deontic/fixtures/mining_branchB.metta)) 1 0.5)
+       ((pick_b join 1 "1.00") (pick_c join 1 "1.00")
+        (start pick_b 1 "0.50") (start pick_c 1 "0.50")))
+
+; min-confidence filter drops the 0.50 edges, keeping the certain ones.
+!(test (mining-rules ((dl-path tests/deontic/fixtures/mining_branchA.metta)
+                      (dl-path tests/deontic/fixtures/mining_branchB.metta)) 1 0.7)
+       ((pick_b join 1 "1.00") (pick_c join 1 "1.00")))
+
+; --- event log: one case per file, events in timestamp order ---
+!(test (size-atom (mining-event-log ((dl-path tests/deontic/fixtures/mining_seq.metta)))) 1)
+!(test (let ($id $evs) (car-atom (mining-event-log ((dl-path tests/deontic/fixtures/mining_seq.metta)))) $id)
+       mining_seq)
+
+; --- renderers run and return true (exact output shape exercised here) ---
+!(test (mining-extract-print ((dl-path tests/deontic/fixtures/mining_seq.metta)) json) true)
+!(test (mining-rules-print ((dl-path tests/deontic/fixtures/mining_seq.metta)) dfl 1 0.5) true)
+!(test (mining-rules-print ((dl-path tests/deontic/fixtures/mining_branchA.metta)
+                            (dl-path tests/deontic/fixtures/mining_branchB.metta)) summary 1 0.0) true)
+
+!(println! test-mining-done)


### PR DESCRIPTION
Stacked on #180.

This adds lib_directive, a task orchestrator built on lib_deontic. The idea behind it is that coordinating work is really a defeasible reasoning problem. A plan lists tasks and the rules for when each one becomes ready, and those readiness rules are just defeasible rules over the deontic engine. Working out what can be done right now is then nothing more than running the engine over the plan and reading off the tasks whose dependencies are satisfied. Priority, conditional blocking and reversible claims all fall out of the underlying logic instead of needing special-case code.

The lifecycle of claiming, completing and blocking works by appending blocks to the plan file itself. Each block is versioned and outranks the one before it, so the most recent action wins and remains reversible. That makes the plan file its own durable and auditable state, with nothing kept outside it. Blocking also propagates down the dependency graph, so when a task is blocked everything downstream is marked blocked as well and the work can be rerouted.

There is also a small process-mining layer that recovers an event log from those appended blocks and learns directly-follows rules from it. Tests are under tests/integration and the API is documented in docs/reference-lib-directive.md.
