### PR TITLE
[OMEGA-343] Add a Codex provider for ChatGPT/Codex-subscription auth

### DIFF
--- a/codex_chat.py
+++ b/codex_chat.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Interactive chat against your ChatGPT/Codex subscription (the provider=Codex backend).
+
+  python3 codex_chat.py [MODEL]      # interactive REPL (default: gpt-5.4)
+  python3 codex_chat.py --selftest   # non-interactive 2-turn memory check
+
+In the REPL:  exit / quit  to leave  ·  /reset  clears history  ·  /model NAME  switches model.
+Replies stream live; conversation history is kept so it's a real multi-turn chat.
+"""
+import sys, json, uuid, urllib.request, urllib.error
+from lib_codex_auth import _access_token, CODEX_RESPONSES_URL, CODEX_DEFAULT_MODEL
+
+SYSTEM = "You are a helpful, concise assistant."
+
+
+def ask(history, model, stream_to=None):
+    token, account_id = _access_token()
+    body = json.dumps({
+        "model": model, "instructions": SYSTEM, "input": history,
+        "reasoning": {"effort": "medium"}, "stream": True, "store": False,
+    }).encode()
+    req = urllib.request.Request(CODEX_RESPONSES_URL, data=body, method="POST", headers={
+        "Authorization": f"Bearer {token}", "chatgpt-account-id": account_id,
+        "openai-beta": "responses=experimental", "originator": "codex_cli_rs",
+        "Content-Type": "application/json", "Accept": "text/event-stream",
+        "User-Agent": "codex_cli_rs/0.139.0", "session_id": str(uuid.uuid4()),
+    })
+    out = []
+    try:
+        with urllib.request.urlopen(req, timeout=180) as r:
+            for raw in r:
+                line = raw.decode("utf-8", "replace").strip()
+                if not line.startswith("data:"):
+                    continue
+                d = line[5:].strip()
+                if d == "[DONE]":
+                    break
+                try:
+                    ev = json.loads(d)
+                except ValueError:
+                    continue
+                if ev.get("type") == "response.output_text.delta":
+                    delta = ev.get("delta", "")
+                    out.append(delta)
+                    if stream_to:
+                        stream_to.write(delta); stream_to.flush()
+    except urllib.error.HTTPError as e:
+        msg = e.read()[:300].decode("utf-8", "replace")
+        if stream_to:
+            stream_to.write(f"[HTTP {e.code}: {msg}]")
+        return f"[HTTP {e.code}: {msg}]"
+    return "".join(out)
+
+
+def umsg(t): return {"type": "message", "role": "user",      "content": [{"type": "input_text",  "text": t}]}
+def amsg(t): return {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": t}]}
+
+
+def selftest(model):
+    h = []
+    h.append(umsg("Remember this number: 42. Reply just 'ok'.")); r1 = ask(h, model); h.append(amsg(r1))
+    h.append(umsg("What number did I ask you to remember? Reply with only the number."))
+    r2 = ask(h, model)
+    print("turn1:", repr(r1)); print("turn2:", repr(r2))
+    print("MULTI-TURN MEMORY:", "PASS" if "42" in r2 else "FAIL")
+
+
+def repl(model):
+    print(f"Codex chat — model={model}.  exit/quit · /reset · /model NAME\n")
+    h = []
+    while True:
+        try:
+            u = input("you> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print(); break
+        if u in ("exit", "quit"):
+            break
+        if not u:
+            continue
+        if u == "/reset":
+            h = []; print("(history cleared)\n"); continue
+        if u.startswith("/model "):
+            model = u.split(None, 1)[1].strip(); print(f"(model -> {model})\n"); continue
+        h.append(umsg(u))
+        sys.stdout.write("gpt> ")
+        r = ask(h, model, stream_to=sys.stdout); print("\n")
+        h.append(amsg(r))
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if "--selftest" in args:
+        rest = [a for a in args if a != "--selftest"]
+        selftest(rest[0] if rest else CODEX_DEFAULT_MODEL)
+    else:
+        repl(args[0] if args else CODEX_DEFAULT_MODEL)

--- a/docs/reference-provider-codex.md
+++ b/docs/reference-provider-codex.md
@@ -1,0 +1,47 @@
+# Reference — `Codex` provider (ChatGPT subscription auth)
+
+Run OmegaClaw's LLM off a **ChatGPT Plus/Pro/Team subscription** instead of a pay-per-token API key, by reusing a logged-in Codex CLI session. No `*_API_KEY` required.
+
+---
+
+## Enable
+
+```bash
+codex login                 # one-time: sign in with your ChatGPT account
+metta run.metta provider=Codex
+```
+
+That's it — the loop calls `callProvider((provider) …)`, so `provider=Codex` routes to the provider with no other change.
+
+---
+
+## How it works
+
+`lib_codex_auth.py` (registered by `lib_llm_ext.py` as provider `Codex`) is self-contained (Python stdlib only, no `openai` SDK):
+
+1. **Token** — reads `~/.codex/auth.json` written by `codex login`: `tokens.access_token` (Bearer), `tokens.account_id`, `tokens.refresh_token`. When the access-token JWT is within 60s of expiry it refreshes via the public Codex OAuth client at `https://auth.openai.com/oauth/token` and writes the file back.
+2. **Inference** — `POST https://chatgpt.com/backend-api/codex/responses` using the **Responses API** schema (`input` is a list; `stream` must be `true`), with headers `Authorization: Bearer …`, `chatgpt-account-id: …` (required), `openai-beta: responses=experimental`, `originator: codex_cli_rs`. The SSE `response.output_text.delta` events are aggregated into the reply.
+
+## Configuration
+
+| Setting | Default | Notes |
+|---|---|---|
+| `provider=Codex` | — | selects this provider |
+| `CODEX_MODEL` (env) | `gpt-5.4` | model slug; subscription slugs drift (e.g. `gpt-5.5`, `gpt-5.4-mini`, `gpt-5-codex`) |
+| `CODEX_AUTH_PATH` (env) | `~/.codex/auth.json` | alternate token location (e.g. copied to a CI runner) |
+
+`reasoningMode` maps to the Responses `reasoning.effort`. `maxOutputToken` is **ignored** — the Codex backend rejects `max_output_tokens`.
+
+## Self-test
+
+```bash
+python3 lib_codex_auth.py     # prints: is_available: True | model: gpt-5.4  /  reply: 'codex-provider-works'
+```
+
+---
+
+## Notes
+
+- The `chatgpt.com/backend-api/codex` endpoint is internal, so model slugs and request details can change over time.
+- Usage counts against your ChatGPT/Codex rate limits (rolling 5-hour + weekly).
+- Treat `~/.codex/auth.json` as a credential — don't commit or share it.

--- a/lib_codex_auth.py
+++ b/lib_codex_auth.py
@@ -1,0 +1,161 @@
+"""ChatGPT / Codex subscription-auth provider for OmegaClaw (opt-in feature).
+
+Reuses the token from a logged-in Codex CLI (``~/.codex/auth.json``) to drive the
+OpenAI **Responses API** on the Codex backend, billed against the ChatGPT
+subscription instead of a pay-per-token API key. No API key needed: run
+``codex login`` once with a ChatGPT account, then start OmegaClaw with
+``provider=Codex``.
+
+Mechanism (verified against the official ``openai/codex`` source):
+  * token: ``~/.codex/auth.json`` -> ``tokens.access_token`` (Bearer),
+    ``tokens.account_id`` (the required ``chatgpt-account-id`` header),
+    ``tokens.refresh_token``; refresh via the public OAuth client at
+    ``auth.openai.com/oauth/token`` when the access-token JWT is near expiry.
+  * inference: ``POST https://chatgpt.com/backend-api/codex/responses`` with a
+    Responses-API body (``input`` is a list, ``stream`` must be true) and the
+    headers ``openai-beta: responses=experimental`` + ``originator: codex_cli_rs``.
+
+This file is intentionally dependency-free (stdlib only) so it can be tested on
+its own and does not rely on the ``openai`` SDK correctly handling the
+undocumented backend.
+
+Note: the backend endpoint is internal, so request details and model slugs may
+change over time. Treat ``~/.codex/auth.json`` as a credential (don't commit or share it).
+"""
+import os, json, time, base64, uuid, urllib.request, urllib.error
+
+CODEX_AUTH_PATH = os.path.expanduser(os.environ.get("CODEX_AUTH_PATH", "~/.codex/auth.json"))
+CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"          # Codex public OAuth client (no secret)
+CODEX_TOKEN_URL = "https://auth.openai.com/oauth/token"
+CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+CODEX_DEFAULT_MODEL = os.environ.get("CODEX_MODEL", "gpt-5.4")
+
+
+def _jwt_exp(token: str) -> int:
+    """Read the `exp` claim from a JWT access token (no signature check)."""
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        return int(json.loads(base64.urlsafe_b64decode(payload)).get("exp", 0))
+    except Exception:
+        return 0
+
+
+def _load_auth() -> dict:
+    with open(CODEX_AUTH_PATH) as f:
+        return json.load(f)
+
+
+def _refresh(auth: dict) -> dict:
+    """Exchange the refresh token for a fresh access token; write auth.json back."""
+    body = json.dumps({
+        "client_id": CODEX_CLIENT_ID,
+        "grant_type": "refresh_token",
+        "refresh_token": auth["tokens"]["refresh_token"],
+    }).encode()
+    req = urllib.request.Request(CODEX_TOKEN_URL, data=body, method="POST",
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        data = json.loads(r.read())
+    auth["tokens"]["access_token"] = data["access_token"]
+    if data.get("refresh_token"):
+        auth["tokens"]["refresh_token"] = data["refresh_token"]
+    auth["last_refresh"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    try:
+        with open(CODEX_AUTH_PATH, "w") as f:
+            json.dump(auth, f)
+    except OSError:
+        pass  # read-only fs: token still usable for this process
+    return auth
+
+
+def _access_token():
+    """Return (access_token, account_id), refreshing if within 60s of expiry."""
+    auth = _load_auth()
+    token = auth["tokens"]["access_token"]
+    if _jwt_exp(token) <= time.time() + 60:
+        auth = _refresh(auth)
+        token = auth["tokens"]["access_token"]
+    return token, auth["tokens"]["account_id"]
+
+
+class CodexProvider:
+    """Duck-typed OmegaClaw AI provider: exposes ``name`` / ``is_available`` / ``chat``."""
+
+    def __init__(self, name: str = "Codex", model_name: str = None):
+        self._name = name
+        self._model_name = model_name or CODEX_DEFAULT_MODEL
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def is_available(self) -> bool:
+        return os.path.exists(CODEX_AUTH_PATH)
+
+    def _clean_text(self, text: str) -> str:
+        return text.replace("_quote_", '"').replace("_apostrophe_", "'")
+
+    def chat(self, content: str, max_tokens: int = 6000, reasoning: str = "medium", **kwargs) -> str:
+        if not self.is_available:
+            raise RuntimeError("Codex not logged in (run `codex login`; expected ~/.codex/auth.json)")
+        # OmegaClaw packs an optional system prompt before the ":-:-:-:" separator.
+        if ":-:-:-:" in content:
+            sysmsg, usermsg = content.split(":-:-:-:", 1)
+        else:
+            sysmsg, usermsg = "", content
+        usermsg = usermsg.replace(":-:-:-:", " ")
+        try:
+            token, account_id = _access_token()
+            payload = json.dumps({
+                "model": self._model_name,
+                "instructions": sysmsg,
+                "input": [{"type": "message", "role": "user",
+                           "content": [{"type": "input_text", "text": usermsg}]}],
+                "reasoning": {"effort": reasoning},
+                "stream": True,          # the Codex backend rejects non-streaming requests
+                "store": False,
+            }).encode()
+            req = urllib.request.Request(
+                CODEX_RESPONSES_URL, data=payload, method="POST",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "chatgpt-account-id": account_id,          # required; drop -> 401/403
+                    "openai-beta": "responses=experimental",
+                    "originator": "codex_cli_rs",
+                    "Content-Type": "application/json",
+                    "Accept": "text/event-stream",
+                    "User-Agent": "codex_cli_rs/0.139.0",
+                    "session_id": str(uuid.uuid4()),
+                })
+            chunks = []
+            with urllib.request.urlopen(req, timeout=180) as resp:
+                for raw in resp:                                # parse the SSE event stream
+                    line = raw.decode("utf-8", "replace").strip()
+                    if not line.startswith("data:"):
+                        continue
+                    data = line[5:].strip()
+                    if data == "[DONE]":
+                        break
+                    try:
+                        event = json.loads(data)
+                    except ValueError:
+                        continue
+                    if event.get("type") == "response.output_text.delta":
+                        chunks.append(event.get("delta", ""))
+            return self._clean_text("".join(chunks))
+        except urllib.error.HTTPError as e:
+            detail = e.read()[:400].decode("utf-8", "replace")
+            print(f"[lib_codex_auth.CodexProvider.chat] HTTP {e.code}: {detail}")
+            return ""
+        except Exception as e:
+            print(f"[lib_codex_auth.CodexProvider.chat] Exception: {e}")
+            return ""
+
+
+if __name__ == "__main__":
+    # Live self-test: `python3 lib_codex_auth.py` (uses your real Codex login).
+    p = CodexProvider()
+    print("is_available:", p.is_available, "| model:", p._model_name)
+    print("reply:", repr(p.chat("Reply with exactly: codex-provider-works")))

--- a/lib_llm_ext.py
+++ b/lib_llm_ext.py
@@ -220,6 +220,17 @@ _register_provider_instance(OpenRouterProvider(name="OpenRouter", var_name="OPEN
 _register_provider_instance(TestProvider())
 _register_provider_instance(OpenAIProvider(name="OpenAI", var_name="OPENAI_API_KEY", model_name="gpt-5.4", base_url="https://api.openai.com/v1"))
 
+# Codex (ChatGPT subscription auth) — opt-in, self-contained (no openai SDK; reuses ~/.codex/auth.json).
+try:
+    import sys as _sys
+    _codex_base = os.path.dirname(os.path.abspath(__file__)) if globals().get("__file__") else os.environ.get("OMEGACLAW_DIR", ".")
+    if _codex_base not in _sys.path:
+        _sys.path.insert(0, _codex_base)
+    from lib_codex_auth import CodexProvider as _CodexProvider
+    _register_provider_instance(_CodexProvider(name="Codex"))
+except Exception as _codex_err:
+    print(f"[lib_llm_ext] Codex provider not registered: {_codex_err}")
+
 
 def callProvider(provider_name: str, content: str, max_tokens: int = 6000, reasoning: str = "medium") -> str:
     """Generic dispatcher for MeTTa."""

--- a/src/loop.metta
+++ b/src/loop.metta
@@ -14,7 +14,7 @@
           (configure spamShield True)
           (configure sleepInterval 1) ;10
           (configure LLM gpt-5.4)
-          (configure provider Anthropic) ;Anthropic or OpenAI or ASICloud or ASIOne or Test
+          (configure provider Anthropic) ;Anthropic or OpenAI or ASICloud or ASIOne or Codex or Test
           (configure maxOutputToken 6000)
           (configure reasoningMode medium)
           (configure wakeupInterval 600) ;600=10 minutes


### PR DESCRIPTION
This adds a Codex provider so OmegaClaw can use a ChatGPT or Codex subscription for its LLM calls instead of a separate API key. Authentication goes through the same OAuth tokens that the Codex CLI uses, read from the local Codex auth file at runtime and refreshed automatically, so nothing is hardcoded.

It registers as a normal provider in the LLM layer, so you select it the same way as any other provider. There is also a small interactive REPL for trying it on its own. It adds lib_codex_auth.py, its registration in lib_llm_ext.py, codex_chat.py and docs/reference-provider-codex.md.
