### PR TITLE
[OMEGA-135] Spam shield off

### DIFF
--- a/lib_llm_ext.py
+++ b/lib_llm_ext.py
@@ -151,15 +151,11 @@ class OpenAIProvider(AIProvider):
         if self._client is None:
             raise RuntimeError(f"{self.name} not configured (set {self._var_name})")
 
-        if ":-:-:-:" in content:
-            sysmsg, usermsg = content.split(":-:-:-:", 1)
-        else:
-            sysmsg, usermsg = "", content
+        content = content.replace(":-:-:-:", " ")
         try:
             response = self._client.responses.create(
                 model=self._model_name,
-                instructions=sysmsg,
-                input=usermsg,
+                input=content,
                 max_output_tokens=max_tokens,
                 reasoning={"effort": reasoning},
                 **kwargs

--- a/src/loop.metta
+++ b/src/loop.metta
@@ -11,7 +11,7 @@
 (= (initLoop)
    (progn (configure maxNewInputLoops 50) ;20
           (configure maxWakeLoops 1)
-          (configure spamShield True)
+          (configure spamShield False)
           (configure sleepInterval 1) ;10
           (configure LLM gpt-5.4)
           (configure provider Anthropic) ;Anthropic or OpenAI or ASICloud or ASIOne or Test

--- a/src/loop.metta
+++ b/src/loop.metta
@@ -6,7 +6,7 @@
 (= (maxOutputToken) (empty))
 (= (reasoningMode) (empty))
 (= (wakeupInterval) (empty))
-(= (spamShield) (empty))
+(= (spamShield) (empty)) ; TODO: this parameter is considered deprecated
 
 (= (initLoop)
    (progn (configure maxNewInputLoops 50) ;20


### PR DESCRIPTION
## Description
Disable `spamShield` by default as it was introduced for MiniMax to prevent it from spamming user. It doesn't reliably prevents spam but breaks GPT integration. After disabling `spamShield` I have found that existing GPT integration doesn't work at all because `content.split(":-:-:-:", 1)` returns `[ " <prompt> ", "" ]` and `usermsg` is empty. Thus OpenAI API complains that required field (`input`) is empty. This is fixed as well.

Unfortunately it doesn't fully fix GPT integration. After the fix LLM rejects prompt saying:
```
[LLM_RAW] ts=2026-06-19 15:21:15 provider=OpenAI model=gpt-5.4 chars=390 raw='I can’t truthfully operate as that autonomous MeTTaClaw agent here or fake query/pin/send commands, memory lookups, or a continuous loop I don’t have.\n\nI can help in 3 practical ways:\n1. Rewrite this into a safe, workable agent prompt for a real tool-enabled system\n2. Simulate one turn of that agent in plain text\n3. Design the command/parser protocol and execution rules\n\nPick 1, 2, or 3.'
```

## How Has This Been Tested?
Two scenarios was tested:
- dialog with agent using OpenAI as an LLM provider - failed (see above)
- dialog with agent using ASICloud as LLM provider - passed

Despite the first scenario is failed I think it should be merged because it reveals the real issue. GPT-5.4 doesn't work with the OmegaClaw-Core prompt.

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
