### PR TITLE
MAIN SCRIPT: fix pull crash in script if no hub image to pull, just local

### DIFF
--- a/scripts/omegaclaw
+++ b/scripts/omegaclaw
@@ -504,7 +504,7 @@ options() {
 
 start() {
     docker rm -f omegaclaw 2>/dev/null || true
-    docker pull "${image}" || true
+    docker pull "${image}"  >/dev/null 2>&1 || true
 
     docker_cmd=(
         docker run -d -it

--- a/scripts/omegaclaw
+++ b/scripts/omegaclaw
@@ -504,7 +504,7 @@ options() {
 
 start() {
     docker rm -f omegaclaw 2>/dev/null || true
-    docker pull "${image}"  >/dev/null 2>&1 || true
+    docker pull "${image}" 2>/dev/null || true
 
     docker_cmd=(
         docker run -d -it


### PR DESCRIPTION
## Description
The pull command in the omegaclaw script is crashing if there is nothing to pull:  just a local image.

**NEEDED FOR HACKATHON TOMORROW**

## How Has This Been Tested?
I tested both with and without a pull from the docker hub. Both worked for me.

## Checklist
- [N/A ] The code generated by LLM is reviewed by the PR creator
- [ X] Self-review completed
- [ X] Test scenarios above are passed with the version of the code from PR
