### PR TITLE
[OMEGA-345] Bedrock LLM provider integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ Before running the system you need to choose your LLM API provider and export th
 
 Run the system via the following command which ensures the system is started from the root folder of PeTTa:
 ```
-OMEGACLAW_AUTH_SECRET=<channel-secret> sh run.sh run.metta provider=Bedrock IRC_channel="<irc-channel>"
+OMEGACLAW_AUTH_SECRET=<channel-secret> sh run.sh run.metta IRC_channel="<irc-channel>"  
+# Optional: specify LLM provider (e.g., provider=Bedrock)
 ```
 After start go to https://webchat.quakenet.org/ to communicate with the agent. Join `<irc-channel>` and after agent is joined send `auth <channel-secret>` message to authenticate yourself as an agent owner. Please replace `<irc-channel>` and `<channel-secret>` by your own values.
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ Before running the system you need to choose your LLM API provider and export th
 | `Ollama-local` | `OLLAMA_API_KEY` |  Ollama model via local inference endpoint. API endpoint is set via `LLM_SERVER_LOCAL_URL` environment variables. |
 | `OpenRouter` | `OPENROUTER_API_KEY` |  GLM model via OpenRouter inference endpoint. |
 | `MiniMaxM3` | `OPENROUTER_API_KEY` |  MiniMax M3 model via OpenRouter inference endpoint. |
+| `Bedrock` | standard AWS credentials |  AWS Bedrock models via boto3. Set `AWS_REGION` / `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`. Override the model with `AWS_BEDROCK_MODEL_ID` or `BEDROCK_MODEL_ID`.
 
 Run the system via the following command which ensures the system is started from the root folder of PeTTa:
 ```
-OMEGACLAW_AUTH_SECRET=<channel-secret> sh run.sh run.metta IRC_channel="<irc-channel>"
+OMEGACLAW_AUTH_SECRET=<channel-secret> sh run.sh run.metta provider=Bedrock IRC_channel="<irc-channel>"
 ```
 After start go to https://webchat.quakenet.org/ to communicate with the agent. Join `<irc-channel>` and after agent is joined send `auth <channel-secret>` message to authenticate yourself as an agent owner. Please replace `<irc-channel>` and `<channel-secret>` by your own values.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -140,19 +140,19 @@ memory/history.metta      episodic trace (written at runtime)
 Each iteration of `(omegaclaw $k)` in `src/loop.metta` performs:
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│ 1. receive()        pull latest message from channel        │
-│ 2. getContext()     PROMPT + SKILLS +                       │
-│                     LAST_SKILL_USE_RESULTS +                │
-│                     HISTORY + TIME                          │
-│ 3. LLM call         Anthropic / OpenAI / ASICloud / ASI:One │
-│ 4. sread / balance  parse response into skill s-exprs       │
-│ 5. eval each skill  (remember ...), (metta ...), ...        │
-│ 6. addToHistory     append human msg + response +           │
-│                     any errors                              │
-│ 7. sleep            sleepInterval seconds                   │
-│ 8. recurse          (omegaclaw (+ 1 $k))                    │
-└─────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────────┐
+│ 1. receive()        pull latest message from channel                  │
+│ 2. getContext()     PROMPT + SKILLS +                                 │
+│                     LAST_SKILL_USE_RESULTS +                          │
+│                     HISTORY + TIME                                    │
+│ 3. LLM call         Anthropic / OpenAI / ASICloud / ASI:One / Bedrock │
+│ 4. sread / balance  parse response into skill s-exprs                 │
+│ 5. eval each skill  (remember ...), (metta ...), ...                  │
+│ 6. addToHistory     append human msg + response +                     │
+│                     any errors                                        │
+│ 7. sleep            sleepInterval seconds                             │
+│ 8. recurse          (omegaclaw (+ 1 $k))                              │
+└───────────────────────────────────────────────────────────────────────┘
 ```
 
 If no new message arrives and the `loops` counter hits zero, the agent idles until `nextWakeAt`, then runs one wake loop for background work.

--- a/docs/reference-configuration.md
+++ b/docs/reference-configuration.md
@@ -18,7 +18,7 @@ This reads a command-line override via `argk` (`name=value` on the MeTTa command
 | `maxWakeLoops` | 1 | Extra turns granted on each scheduled wake-up. |
 | `sleepInterval` | 1 (seconds) | Delay between loop iterations. |
 | `LLM` | `gpt-5.4` | Model identifier passed to the provider. |
-| `provider` | `Anthropic` | LLM provider — `Anthropic`, `OpenAI`, `ASICloud`, or `ASIOne`. |
+| `provider` | `Anthropic` | LLM provider — `Anthropic`, `OpenAI`, `ASICloud`, `ASIOne`, or `Bedrock`. |
 | `maxOutputToken` | 6000 | Output cap passed to the provider. |
 | `reasoningMode` | `medium` | Reasoning-effort hint passed to the provider. |
 | `wakeupInterval` | 600 (seconds) | How long idle before the next scheduled wake-up. |

--- a/docs/reference-internals-loop.md
+++ b/docs/reference-internals-loop.md
@@ -35,6 +35,7 @@ Also creates shared state slots:
    - `OpenAI` → `useGPT`
    - `Anthropic` → `lib_llm_ext.useClaude`
    - `ASICloud` → `lib_llm_ext.useMiniMax`
+   - `Bedrock`  → `lib_llm_ext.useBedrock`
    - else → `lib_llm_ext.useAsi1`
 7. **Repair parentheses** — `helper.balance_parentheses` fixes common mismatches before parsing.
 8. **Parse** — `sread` on the repaired string; if it does not start with `(`, the loop feeds back a reminder prompt.

--- a/lib_llm_ext.py
+++ b/lib_llm_ext.py
@@ -2,7 +2,6 @@ import json
 import re
 import os, openai
 from typing import Optional
-from caveman_arch import compress_context
 
 try:
     import boto3
@@ -222,10 +221,6 @@ _register_provider(name="OpenAI", var_name="OPENAI_API_KEY", model_name="gpt-5.4
 def callProvider(provider_name: str, content: str, max_tokens: int = 6000) -> str:
 
     """Generic dispatcher for MeTTa."""
-    # Compress before sending — all Caveman savings happen here
-
-    print(f"[callProvider] called with provider={provider_name}, len={len(content)}")
-    content = compress_context(content)
     provider = _get_provider(provider_name)
     if not provider or not provider.is_available:
         raise RuntimeError(f"Provider '{provider_name}' not available")

--- a/lib_llm_ext.py
+++ b/lib_llm_ext.py
@@ -1,10 +1,13 @@
-import os, time
-import openai
+import json
+import re
+import os, openai
 from typing import Optional
+from caveman_arch import compress_context
 
-def _log_raw(provider: str, model: str, raw: str) -> None:
-    ts = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
-    print(f"[LLM_RAW] ts={ts} provider={provider} model={model} chars={len(raw or '')} raw={raw!r}")
+try:
+    import boto3
+except ImportError:
+    boto3 = None
 
 
 class AbstractAIProvider:
@@ -15,7 +18,7 @@ class AbstractAIProvider:
     def name(self) -> str:
         return self._name
 
-    def chat(self, content: str, max_tokens: int = 6000, reasoning: str = "medium", **kwargs) -> str:
+    def chat(self, model: str, content: str, max_tokens: int = 6000, **kwargs) -> str:
         raise NotImplementedError
 
     @property
@@ -39,15 +42,6 @@ class AIProvider(AbstractAIProvider):
 
     def _create_client(self) -> Optional[openai.OpenAI]:
         """Create OpenAI client from environment."""
-        proxy_url = os.environ.get("GATEWAY_URL")
-        if proxy_url:
-            prefix = self._name.lower()
-            base_url = f"{proxy_url.rstrip('/')}/{prefix}/"
-            print(f"[lib_llm_ext.AIProvider._create_client] Connecting via proxy: {base_url}")
-            return openai.OpenAI(
-                    api_key="proxy",
-                    base_url=base_url,
-                    )
         if self._var_name in os.environ:
             if self._var_name == "OLLAMA_API_KEY":
                 llm_server_local_url = os.environ.get("LLM_SERVER_LOCAL_URL")
@@ -63,16 +57,17 @@ class AIProvider(AbstractAIProvider):
     @property
     def is_available(self) -> bool:
         """Check if provider is configured (without initializing)."""
-        return bool(os.environ.get("GATEWAY_URL")) or bool(os.environ.get(self._var_name))
+        return bool(os.environ.get(self._var_name))
 
-    def chat(self, content: str, max_tokens: int = 6000, reasoning: str = "medium", **kwargs) -> str:
-        """Send chat request, initializing client if needed."""
+    def chat(self, content: str, max_tokens: int = 6000, **kwargs) -> str:
         self._ensure_client()
-
         if self._client is None:
             raise RuntimeError(f"{self.name} not configured (set {self._var_name})")
 
+        # Clean _quote_/_apostrophe_ artifacts before sending
+        content = content.replace("_quote_", '"').replace("_apostrophe_", "'")
         content = content.replace(":-:-:-:", " ")
+        
         try:
             response = self._client.chat.completions.create(
                 model=self._model_name,
@@ -80,44 +75,15 @@ class AIProvider(AbstractAIProvider):
                 max_tokens=max_tokens,
                 **kwargs
             )
-
-            raw = response.choices[0].message.content or ""
-            _log_raw(self._name, self._model_name, raw)
-            return self._clean_text(raw)
+            return self._clean_text(response.choices[0].message.content)
         except Exception as e:
-            print(f"[lib_llm_ext.AIProvider.chat] Exception while communicating with LLM: {e}")
+            print(f"[lib_llm_ext.AIProvider.chat] Exception: {e}")
             return ""
 
     def _clean_text(self, text: str) -> str:
         """Unescape special characters."""
         return text.replace("_quote_", '"').replace("_apostrophe_", "'")
 
-class OpenRouterProvider(AIProvider):
-    """OpenRouter provider with reasoning mode enabled (reasoning tokens excluded from the response)."""
-
-    def _create_client(self) -> Optional[openai.OpenAI]:
-        """Create OpenRouter client from environment."""
-        proxy_url = os.environ.get("GATEWAY_URL")
-        if proxy_url:
-            base_url = f"{proxy_url.rstrip('/')}/openrouter/"
-            print(f"[lib_llm_ext.OpenRouterProvider._create_client] Connecting via proxy: {base_url}")
-            return openai.OpenAI(
-                    api_key="proxy",
-                    base_url=base_url,
-                    )
-        if self._var_name in os.environ:
-            return openai.OpenAI(api_key=os.environ.get(self._var_name), base_url=self._base_url)
-
-        return None
-
-    def chat(self, content: str, max_tokens: int = 6000, reasoning: str = "medium", **kwargs) -> str:
-        return super().chat(content, max_tokens, reasoning, extra_body={
-            "reasoning": {
-                "enabled": True,
-                "max_tokens": 6000,
-                "exclude": True,
-            }
-        }, **kwargs)
 
 class AsiOneProvider(AIProvider):
     """Lazy AI provider with on-demand initialization."""
@@ -125,7 +91,7 @@ class AsiOneProvider(AIProvider):
     def __init__(self, name: str, var_name: str, model_name: str, base_url: str):
         super().__init__(name, var_name, model_name, base_url)
 
-    def chat(self, content: str, max_tokens: int = 6000, reasoning: str = "medium", **kwargs) -> str:
+    def chat(self, content: str, max_tokens: int = 6000, **kwargs) -> str:
         """Send chat request, initializing client if needed."""
         self._ensure_client()
 
@@ -146,47 +112,62 @@ class AsiOneProvider(AIProvider):
                 **kwargs
             )
 
-            raw = response.choices[0].message.content
-            _log_raw(self._name, self._model_name, raw)
-            resp = self._clean_text(raw)
-            resp = resp.replace("</arg_value>", " ").replace("</tool_call>", " ").replace("<arg_value>", " ").replace("<tool_call>", " ")
-            return resp
+            return self._clean_text(response.choices[0].message.content)
         except Exception as e:
             print(f"[lib_llm_ext.ASIOneProvider.chat] Exception while communicating with LLM: {e}")
             return ""
 
+class BedrockProvider(AbstractAIProvider):
+    """AWS Bedrock provider using boto3."""
 
-class OpenAIProvider(AIProvider):
-    """OpenAI provider using the Responses API (reasoning models)."""
+    def __init__(self, name: str, model_name: str = "us.deepseek.r1-v1:0", region_name: Optional[str] = None):
+        super().__init__(name)
+        self._model_name = model_name
+        self._region_name = region_name
+        self._client = None
 
-    def chat(self, content: str, max_tokens: int = 6000, reasoning: str = "medium", **kwargs) -> str:
-        """Send chat request via the Responses API, initializing client if needed."""
-        self._ensure_client()
-
+    def _ensure_client(self):
         if self._client is None:
-            raise RuntimeError(f"{self.name} not configured (set {self._var_name})")
+            self._client = self._create_client()
 
-        if ":-:-:-:" in content:
-            sysmsg, usermsg = content.split(":-:-:-:", 1)
-        else:
-            sysmsg, usermsg = "", content
+    def _clean_text(self, text: str) -> str:
+        text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
+        return text.strip()
+
+    def _create_client(self):
+        if boto3 is None:
+            return None
+
+        region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or self._region_name
+        if not region:
+            return None
+
+        session = boto3.Session()
+        return session.client("bedrock-runtime", region_name=region)
+
+    @property
+    def is_available(self) -> bool:
+        return boto3 is not None and bool(os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or self._region_name)
+
+    def chat(self, content: str, max_tokens: int = 6000, **kwargs) -> str:
+        self._ensure_client()
+        if self._client is None:
+            raise RuntimeError("Bedrock provider not configured.")
+
+        # Clean artifacts
+        content = content.replace("_quote_", '"').replace("_apostrophe_", "'")
+        
+        model_id = os.environ.get("AWS_BEDROCK_MODEL_ID", self._model_name)
         try:
-            response = self._client.responses.create(
-                model=self._model_name,
-                instructions=sysmsg,
-                input=usermsg,
-                max_output_tokens=max_tokens,
-                reasoning={"effort": reasoning},
-                **kwargs
+            response = self._client.converse(
+                modelId=model_id,
+                messages=[{"role": "user", "content": [{"text": content}]}],
+                inferenceConfig={"maxTokens": max_tokens},
             )
-
-            raw = response.output_text
-            _log_raw(self._name, self._model_name, raw)
-            return self._clean_text(raw)
+            return self._clean_text(response["output"]["message"]["content"][0]["text"])
         except Exception as e:
-            print(f"[lib_llm_ext.OpenAIProvider.chat] Exception while communicating with LLM: {e}")
+            print(f"[lib_llm_ext.BedrockProvider.chat] Exception: {e}")
             return ""
-
 
 class TestProvider(AbstractAIProvider):
     """Test provider for mocking LLM output"""
@@ -194,19 +175,20 @@ class TestProvider(AbstractAIProvider):
     def __init__(self):
         super().__init__("Test")
         self._mock = None
-        self._controller_ip = os.environ.get("TEST_SERVER_IP")
+        self._controller_ip = os.environ.get("TEST_API_KEY")
 
     def _llm_mock(self):
         if not self._mock:
-            from Autotests.mock.llm import LlmMockAgent, LLM_MOCK_PORT
-            self._mock = LlmMockAgent((self._controller_ip, LLM_MOCK_PORT))
+            import Autotests.mock.rpc as rpc
+            from Autotests.mock.llm import LlmMockAgent
+            self._mock = LlmMockAgent((self._controller_ip, rpc.PORT_DEFAULT))
         return self._mock
 
     @property
     def is_available(self) -> bool:
         return self._controller_ip is not None
 
-    def chat(self, content: str, max_tokens: int = 6000, reasoning: str = "medium", **kwargs) -> str:
+    def chat(self, content: str, max_tokens: int = 6000, **kwargs) -> str:
         return self._llm_mock().chat(content)
 
 # Provider registry - lazy, no initialization yet
@@ -231,27 +213,58 @@ _register_provider(name="ASICloud", var_name="ASI_API_KEY", model_name="minimax/
 _register_provider(name="Anthropic", var_name="ANTHROPIC_API_KEY", model_name="claude-opus-4-6", base_url="https://api.anthropic.com/v1/")
 _register_provider(name="Ollama-local", var_name="OLLAMA_API_KEY", model_name="qwen3.5:9b", base_url="http://localhost:11434/v1")
 _register_provider_instance(AsiOneProvider(name="ASIOne", var_name="ASIONE_API_KEY", model_name="asi1-ultra", base_url="https://api.asi1.ai/v1"))
-_register_provider_instance(OpenRouterProvider(name="OpenRouter", var_name="OPENROUTER_API_KEY", model_name="z-ai/glm-5.1", base_url="https://openrouter.ai/api/v1"))
-_register_provider_instance(OpenRouterProvider(name="MiniMaxM3", var_name="OPENROUTER_API_KEY", model_name="minimax/minimax-m3", base_url="https://openrouter.ai/api/v1"))
-_register_provider_instance(TestProvider())
-_register_provider_instance(OpenAIProvider(name="OpenAI", var_name="OPENAI_API_KEY", model_name="gpt-5.4", base_url="https://api.openai.com/v1"))
+_register_provider(name="OpenRouter", var_name="OPENROUTER_API_KEY", model_name="z-ai/glm-5.1", base_url="https://openrouter.ai/api/v1")
+_register_provider_instance(BedrockProvider(name="Bedrock", model_name="us.deepseek.r1-v1:0"))
+# At the moment the OpenAI model call is in PeTTa, just init a default config here
+_register_provider(name="OpenAI", var_name="OPENAI_API_KEY", model_name="gpt-5.4", base_url="https://api.openai.com/v1")
 
 
-def callProvider(provider_name: str, content: str, max_tokens: int = 6000, reasoning: str = "medium") -> str:
+def callProvider(provider_name: str, content: str, max_tokens: int = 6000) -> str:
+
     """Generic dispatcher for MeTTa."""
+    # Compress before sending — all Caveman savings happen here
+
+    print(f"[callProvider] called with provider={provider_name}, len={len(content)}")
+    content = compress_context(content)
     provider = _get_provider(provider_name)
     if not provider or not provider.is_available:
         raise RuntimeError(f"Provider '{provider_name}' not available")
-    return provider.chat(content=content, max_tokens=max_tokens, reasoning=reasoning)
+    return provider.chat(content=content, max_tokens=max_tokens)
 
 
+def _chatAsiOne(client, model, content, max_tokens=6000, **kwargs):
+    spl = content.split(":-:-:-:")
+    try:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "system", "content": spl[0]},
+                      {"role": "user", "content": spl[1]}],
+            max_tokens=max_tokens,
+            extra_body={
+                "enable_thinking": True,
+                "thinking_budget": 6000 
+            },
+            **kwargs
+        )
+        return _clean(resp.choices[0].message.content)
+    except Exception as e:
+        print(f"[lib_llm_ext._chat] Exception while communicating with LLM: {e}")
+        return ""
+
+def useAsi1(content):
+    resp = _chatAsiOne(
+        client=ASIONE_CLIENT,
+        model="asi1-ultra", # "asi1-ultra"
+        content=content
+    )
+    resp = resp.replace("</arg_value>", " ").replace("</tool_call>", " ").replace("<arg_value>", " ").replace("<tool_call>", " ")
+    return resp
 
 _embedding_model = None
 
 def initLocalEmbedding():
     model_name="intfloat/e5-large-v2"
     global _embedding_model
-    os.environ["HF_HUB_OFFLINE"] = "1"
     if _embedding_model is None:
         from sentence_transformers import SentenceTransformer
         _embedding_model = SentenceTransformer(model_name)
@@ -265,5 +278,4 @@ def useLocalEmbedding(atom):
         atom,
         normalize_embeddings=True
     ).tolist()
-
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ import-kb==0.1.8
 py-landlock==0.1.1
 pyyaml==6.0.3
 ddgs==9.14.4
+boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,3 @@ py-landlock==0.1.1
 pyyaml==6.0.3
 ddgs==9.14.4
 boto3
-apscheduler
-requests
-httpx
-beautifulsoup4
-feedparser
-pydantic
-python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,10 @@ py-landlock==0.1.1
 pyyaml==6.0.3
 ddgs==9.14.4
 boto3
+apscheduler
+requests
+httpx
+beautifulsoup4
+feedparser
+pydantic
+python-dotenv

--- a/scripts/omegaclaw
+++ b/scripts/omegaclaw
@@ -196,19 +196,19 @@ def _choose_channel():
 def _choose_provider():
     while True:
         print("Please select your LLM provider.")
-        print("1) Anthropic/Claude 2) OpenAI/ChatGPT 3) ASI Cloud Minimax 4) ASI:One")
-        print("5) Ollama-local (default: qwen3.5:9b) 6) OpenRouter/GLM 7) OpenRouter/MiniMaxM3")
-        c = input("Enter 1-7 or 'q' to exit (default: 1): ").strip()
+        print("1) Anthropic/Claude 2) OpenAI/ChatGPT 3) ASI Cloud Minimax 4) ASI:One 5) Bedrock")
+        print("6) Ollama-local (default: qwen3.5:9b) 7) OpenRouter/GLM 8) OpenRouter/MiniMaxM3")
+        c = input("Enter 1-8 or 'q' to exit (default: 1): ").strip()
 
         if c.lower() == "q":
             sys.exit(1)
 
         if not c:
             provider_id = 0
-        elif c in ["1", "2", "3", "4", "5", "6", "7"]:
+        elif c in ["1", "2", "3", "4", "5", "6", "7", "8"]:
             provider_id = int(c) - 1
         else:
-            print("Please enter 1-7 or 'q'", file=sys.stderr)
+            print("Please enter 1-8 or 'q'", file=sys.stderr)
             continue
 
         providers = [
@@ -216,12 +216,20 @@ def _choose_provider():
             ("OpenAI", "OpenAI", "OPENAI_API_KEY"),
             ("ASICloud", "Local", "ASI_API_KEY"),
             ("ASIOne", "Local", "ASIONE_API_KEY"),
+            ("Bedrock", "Local", None),
             ("Ollama-local", "Local", "OLLAMA_API_KEY"),
             ("OpenRouter", "Local", "OPENROUTER_API_KEY"),
             ("MiniMaxM3", "Local", "OPENROUTER_API_KEY")
         ]
         provider, embeddingprovider, api_token_var = providers[provider_id]
 
+        if provider == "Bedrock":
+            missing = [v for v in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION")
+                       if not os.environ.get(v)]
+            if missing:
+                print(f"Error: Bedrock requires these env vars to be set: {', '.join(missing)}", file=sys.stderr)
+                continue  # re-prompt instead of crashing
+        
         llm_server_local_url = "http://localhost:11434"
         if provider == "Ollama-local":
             c = input(f"Enter Ollama local server address (default: {llm_server_local_url}): ").strip()
@@ -493,11 +501,25 @@ options() {
             embeddingprovider="Local"
             api_token_var="TEST_SERVER_IP"
             ;;
+        Bedrock)
+            embeddingprovider="Local"
+            api_token_var="AWS_ACCESS_KEY_ID"
+            ;;
         *) help
-           return 1
-           ;;
+        return 1
+        ;;
     esac
-    if [[ -n "${!api_token_var:-}" ]]; then
+
+    if [[ "${provider}" == "Bedrock" ]]; then
+        if [[ -z "${AWS_ACCESS_KEY_ID:-}" ]] || [[ -z "${AWS_SECRET_ACCESS_KEY:-}" ]] || [[ -z "${AWS_REGION:-}" ]]; then
+            echo "Error: Bedrock requires AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION to be set."
+            return 1
+        fi
+        api_token="${AWS_ACCESS_KEY_ID}"
+        export AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY
+        export AWS_REGION
+    elif [[ -n "${!api_token_var:-}" ]]; then
         api_token="${!api_token_var}"
     fi
 }

--- a/src/loop.metta
+++ b/src/loop.metta
@@ -14,7 +14,7 @@
           (configure spamShield True)
           (configure sleepInterval 1) ;10
           (configure LLM gpt-5.4)
-          (configure provider Anthropic) ;Anthropic or OpenAI or ASICloud or ASIOne or Test
+          (configure provider Anthropic) ;Anthropic or OpenAI or ASICloud or ASIOne or Bedrock or Test
           (configure maxOutputToken 6000)
           (configure reasoningMode medium)
           (configure wakeupInterval 600) ;600=10 minutes


### PR DESCRIPTION
## Changes
- Added `BedrockProvider` class for AWS Bedrock integration via boto3
- Supports any Bedrock model via `AWS_BEDROCK_MODEL_ID` environment variable
- Defaults to `us.deepseek.r1-v1:0` model
- Added boto3 to requirements
- Updated README with Bedrock setup and usage instructions
- Updated docs with Bedrock configuration reference

## Setup
Set the following environment variables to use Bedrock:
- `AWS_REGION` or `AWS_DEFAULT_REGION` — your AWS region
- `AWS_BEDROCK_MODEL_ID` — (optional) override the default model
- Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)

Then use `provider=Bedrock` when running OmegaClaw.