### PR TITLE
[OMEGA-207] Disable importing knowledge base by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ COPY --chown=www-data:www-data --chmod=0600 ./proxy/* /opt/nginx/
 ENV OMEGACLAW_DIR=/PeTTa/repos/OmegaClaw-Core
 ENV MEMORY_DIR=${OMEGACLAW_DIR}/memory
 # Start defaults for import-kb
-ENV IMPORT_KB_ON_START=1
+ENV IMPORT_KB_ON_START=0
 
 # Bring in only local OmegaClaw source (filtered by .dockerignore).
 COPY . ${OMEGACLAW_DIR}

--- a/scripts/omegaclaw
+++ b/scripts/omegaclaw
@@ -239,13 +239,13 @@ def _choose_provider():
 def _choose_import_kb():
     while True:
         c = input(
-            "Import knowledge base on startup? Will improve results but takes about 30 minutes. [Y/n]: "
+            "Import knowledge base on startup? Will improve results but takes about 30 minutes. [y/N]: "
         ).strip().lower()
 
-        if c in ("", "y", "yes"):
+        if c in ("y", "yes"):
             return "1"
 
-        if c in ("n", "no"):
+        if c in ("", "n", "no"):
             return "0"
 
         if c == "q":

--- a/scripts/omegaclaw
+++ b/scripts/omegaclaw
@@ -521,7 +521,7 @@ start() {
             -e "SL_BOT_TOKEN=${SL_BOT_TOKEN:-}"
             -e OMEGACLAW_AUTH_SECRET="$OMEGACLAW_AUTH_SECRET"
             -e LLM_SERVER_LOCAL_URL="$llm_server_local_url"
-            -e IMPORT_KB_ON_START="${IMPORT_KB_ON_START:-1}"
+            -e IMPORT_KB_ON_START="${IMPORT_KB_ON_START:-0}"
             "$image"
             "commchannel=${commchannel}"
             "provider=${provider}"


### PR DESCRIPTION
Starting OmegaClaw using `scripts/omegaclaw` in non-interactive mode leads to the loading knowledge base by default. The problem is that this loading takes about half of an hour which means user will wait without being able to do something with this. This PR disables loading KB by default.

## Description
Briefly describe the changes and issue fixed

## How Has This Been Tested?
Describe test scenarios which can be used to test the issue and the fix.

## Checklist
- [ ] The code generated by LLM is reviewed by the PR creator
- [ ] Self-review completed
- [ ] Test scenarios above are passed with the version of the code from PR
