### PR TITLE
[OMEGA-102] WebSocket channel autotests

### DIFF
--- a/Autotests/mock_websocket/README.md
+++ b/Autotests/mock_websocket/README.md
@@ -1,0 +1,195 @@
+# WebSocket autotests — setup and run
+
+This suite exercises the WebSocket communication channel (`channels/wschat.py`)
+with the deterministic LLM mock (`provider=Test`). The agent is a WebSocket
+**client**; a local mock WebSocket **server** (`WsMockDriver`) stands in for the
+ASI Create chat, so no external service participates and the whole flow is local
+and deterministic (CI-eligible).
+
+For the LLM-mock harness shared with this suite see `Autotests/mock/README.md`.
+
+## 1. Prerequisites
+
+- Docker engine on the host.
+- Repository checked out, working from its root.
+- Python virtual environment under `Autotests/venv` with `pytest` and
+  `websockets` installed (`pip install pytest websockets`).
+
+## 2. Build the local image
+
+```
+docker build -t omegaclaw:mock .
+```
+
+## 3. Start the container on the websocket channel with the Test provider
+
+The container connects back to the host on TCP port 9765 to reach the mock LLM
+controller (`TEST_SERVER_IP`) and to `WS_URL` for the chat transport. Under the
+default Docker bridge the host is `172.17.0.1`. The mock WS server listens on
+`WS_MOCK_PORT` (default `8770`); `WS_URL` must point at it and `WS_TOKEN` must
+match the bearer token the mock server checks (`test-token`).
+
+```
+env WS_URL=ws://172.17.0.1:8770 WS_TOKEN=test-token TEST_SERVER_IP=172.17.0.1 \
+  ./scripts/omegaclaw start -s 0000 -p Test -t websocket -d omegaclaw:mock
+```
+
+Notes:
+
+- `-t websocket` selects the WebSocket channel; `WS_URL`/`WS_TOKEN` are passed to
+  the container.
+- `-p Test` selects the mock LLM dispatcher; `TEST_SERVER_IP` is the host's
+  docker-bridge address used to reach the mock LLM controller.
+- The container is created with the name `omegaclaw` (the script default).
+
+The agent reconnects with backoff until the mock server is up, so the container
+can be started before or after the pytest session. Wait until the agent loop is
+running:
+
+```
+until docker logs omegaclaw 2>&1 | grep -qE "CHARS_SENT: [0-9]+"; do sleep 2; done
+```
+
+## 4. Configure the test environment
+
+```
+export OMEGACLAW_CONTAINER=omegaclaw
+export WS_MOCK_PORT=8770        # must match the WS_URL port used in step 3
+export WS_TOKEN=test-token      # must match step 3
+```
+
+| Variable | Required | Description |
+|---|---|---|
+| `OMEGACLAW_CONTAINER` | Yes | Container name passed to `docker exec`. |
+| `WS_MOCK_PORT` | No | Port the mock WS server binds (default `8770`). Must match the `WS_URL` port. |
+| `WS_TOKEN` | No | Bearer token the mock server requires (default `test-token`). Must match the container's `WS_TOKEN`. |
+
+## 5. Run the suite
+
+This directory has two tiers:
+
+- `test_wschat_unit.py` — in-process unit tests of `channels/wschat.py`. No
+  container, no `-t websocket`, no `websockets` library needed (wschat imports it
+  lazily). Runs in the same CI job as `mock/test_comm.py` / `test_llm.py` /
+  `test_rpc.py`; registered in `Autotests/run_mandatory`.
+- `test_*_ws_mock.py` — end-to-end integration tests that drive a `-t websocket`
+  container through `WsMockDriver`. They need the container started as in step 3
+  and the `websockets` library on the host. Not in `run_mandatory` (a single CI
+  container runs one commchannel; these need `-t websocket`, not the `-t test`
+  used by `run_mandatory`).
+
+Unit tests (no container required):
+
+```
+cd Autotests
+pytest -s -v mock_websocket/test_wschat_unit.py       # expect: 6 passed
+```
+
+Integration tests (against the `-t websocket` container from step 3):
+
+```
+cd Autotests
+source venv/bin/activate
+pytest -s -v mock_websocket/test_*_ws_mock.py         # expect: 7 passed
+```
+
+The `LlmMockController` (tcp:9765) and `WsMockDriver` (tcp:`WS_MOCK_PORT`) are
+provided by session-scoped fixtures in `mock_websocket/conftest.py`, started once
+per session.
+
+## 6. Tear down
+
+```
+./scripts/omegaclaw clean
+```
+
+# Tests description
+
+## Unit — `test_wschat_unit.py` (registered in `Autotests/run_mandatory`)
+
+In-process tests of `channels/wschat.py`, driving its pure functions directly:
+no container, no `websockets` library. This is the CI regression entry — it runs
+on every PR in the same job as `test_comm` / `test_llm` / `test_rpc`.
+
+- `test_enqueue_join_and_last_seen` — three `user_message` frames drain as
+  `A | B | C`; `last_seen_seq` advances to 3; a second drain is empty.
+- `test_dedup_by_last_seen_seq` — frames with `seq <= last_seen_seq` are dropped.
+- `test_dedup_by_inbox_order` — a frame with `seq <= inbox[-1]` is dropped.
+- `test_frame_robustness` — non-JSON / non-dict / non-int seq / non-str text /
+  unknown / ack / error frames are dropped without raising; a following valid
+  frame is enqueued.
+- `test_outbox_buffers_while_disconnected_and_flushes` — `send_message` while
+  disconnected buffers an `agent_message` (uuid `client_seq`); `_drain_outbox`
+  flushes it with the same `client_seq`.
+- `test_resume_frame_reflects_last_seen` — `_build_resume_frame` carries the
+  current `last_seen_seq`.
+
+## Integration — `test_*_ws_mock.py` (needs a `-t websocket` container)
+
+End-to-end tests through `WsMockDriver`. They prove the full wiring
+(`channels.metta` websocket dispatch, `send` skill → `agent_message`, real drain
+→ LLM) that the unit tests cannot reach. Not in `run_mandatory` (they need a
+`-t websocket` container, unlike the `-t test` container `run_mandatory` runs
+against); run them on the stand or a dedicated CI stage.
+
+### 1. test_ws_delivery_ws_mock.py
+
+Delivery round-trip. A `user_message` reaches the agent; the agent replies with
+`(send "WS-PONG-<run_id>")`; the mock receives an `agent_message` and acks it.
+
+- Checks: an `agent_message` carrying the token arrives; its `client_seq` is a
+  valid uuid hex; the mock acked that `client_seq`.
+
+### 2. test_ws_queue_merge_ws_mock.py
+
+Queue merge. Three `user_message` frames (contiguous seq) are injected
+back-to-back before the agent drains, so they join as `A | B | C` in one LLM
+input (the merged prompt is the registered answer key).
+
+- Checks: a single merged `agent_message` (`WS-MERGED-<run_id>`) arrives; after a
+  forced reconnect the `resume` frame carries `last_seen_seq` equal to the last
+  of the three seqs.
+
+### 3. test_ws_resume_dedup_ws_mock.py
+
+Resume + dedup. After one delivered/answered prompt the connection is dropped;
+the agent reconnects and sends `resume` with the advanced `last_seen_seq`; the
+mock replays the already-seen frame.
+
+- Checks: the `resume` frame carries the advanced `last_seen_seq`; the replayed
+  frame (`seq <= last_seen_seq`) is deduped by the agent — no second answer.
+
+### 4. test_ws_outbox_flush_ws_mock.py
+
+Outbox flush. A prompt is delivered while connected; the connection is dropped
+and reconnects refused for a short window, so the agent produces its reply while
+disconnected and buffers it in the outbox; on reconnect the outbox is flushed
+before any new inbound traffic.
+
+- Checks: the buffered `agent_message` (`WS-BUFFERED-<run_id>`) is delivered after
+  reconnect and not duplicated.
+
+### 5. test_ws_frame_robustness_ws_mock.py
+
+Frame robustness. Non-JSON, a malformed `user_message` (non-int `seq`), an
+unknown frame type, an `error` frame, and a non-object payload are all sent to
+the agent.
+
+- Checks: the channel drops them without crashing (connection stays open); a
+  following valid prompt (`WS-ALIVE-<run_id>`) is answered normally.
+
+## Skill smoke (prove skills work over this transport)
+
+Two mirrors of the `mock/` suite with delivery swapped to `ws_send_prompt` — not
+in `run_mandatory` (skills are already covered there over the comm channel).
+
+### 6. test_create_file_ws_mock.py
+
+Creates `/tmp/testcat/hello.txt` containing exactly `Hello`, delivered over
+WebSocket. Same assertions as `mock/test_create_file_mock.py`.
+
+### 7. test_memory_chromadb_ws_mock.py
+
+Requests the agent to remember a fact tagged `CI-SMOKE-<run_id>`, delivered over
+WebSocket; the `remember` skill runs for real and grows the ChromaDB vector
+store. Same assertions as `mock/test_memory_chromadb_mock.py`.

--- a/Autotests/mock_websocket/conftest.py
+++ b/Autotests/mock_websocket/conftest.py
@@ -1,0 +1,71 @@
+"""Pytest fixtures for the WebSocket test suite.
+
+Transport: the agent's WebSocket channel (`channels/wschat.py`) connects to a
+local mock server (`WsMockDriver`) that stands in for the ASI Create chat, so
+no external service participates. The LLM is the deterministic Test provider,
+shared with the other mock suites via `LlmMockController` on tcp:9765.
+
+There is no message-level `auth <secret>` step: WebSocket auth is the handshake
+bearer token (`Bearer test-token`), checked by the mock server on connect.
+
+Mock-only speedups (as in mock/conftest.py): drop the live Checker teardown's
+IRC cancel + 15s sleep and lower POLL, leaving Autotests/helpers.py untouched
+for live runs.
+"""
+import os
+import sys
+
+import pytest
+
+_MOCK_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "mock"))
+if _MOCK_DIR not in sys.path:
+    sys.path.insert(0, _MOCK_DIR)
+
+_SELF_DIR = os.path.dirname(__file__)
+if _SELF_DIR not in sys.path:
+    sys.path.insert(0, _SELF_DIR)
+
+import helpers  # noqa: E402
+from llm import LlmMockController, LLM_MOCK_PORT  # noqa: E402
+from ws_driver import WsMockDriver  # noqa: E402
+
+
+WS_MOCK_PORT = int(os.environ.get("WS_MOCK_PORT") or 8770)
+WS_TOKEN = os.environ.get("WS_TOKEN") or "test-token"
+
+
+def _mock_checker_exit(self, _exc_type, _exc_val, _exc_tb):
+    self.step("teardown: cleanup test artifacts")
+    for path in self._cleanup_dirs:
+        helpers.cleanup_dir(path)
+        if helpers.dexec("test", "-e", path).returncode == 0:
+            print(f"       [WARN] {path} still exists", flush=True)
+        else:
+            print(f"       removed {path}", flush=True)
+    h_removed = helpers.history_cleanup_by_markers(self._cleanup_markers)
+    print(f"       history: {h_removed} blocks removed", flush=True)
+    c_removed = helpers.chromadb_cleanup_by_markers(self._cleanup_markers)
+    print(f"       chromadb: {c_removed} vectors removed", flush=True)
+    return False
+
+
+helpers.POLL = 0.5
+helpers.Checker.__exit__ = _mock_checker_exit
+
+
+@pytest.fixture(scope="session")
+def llm():
+    controller = LlmMockController(("0.0.0.0", LLM_MOCK_PORT))
+    try:
+        yield controller
+    finally:
+        controller.stop(5)
+
+
+@pytest.fixture(scope="session")
+def ws():
+    driver = WsMockDriver(WS_MOCK_PORT, token=WS_TOKEN)
+    try:
+        yield driver
+    finally:
+        driver.stop(5)

--- a/Autotests/mock_websocket/test_create_file_ws_mock.py
+++ b/Autotests/mock_websocket/test_create_file_ws_mock.py
@@ -1,0 +1,81 @@
+"""
+WebSocket variant of test_create_file: OmegaClaw creates hello.txt with content
+"Hello" in /tmp/testcat. Skill smoke over the WebSocket transport.
+
+Run:
+    pytest test_create_file_ws_mock.py -s
+"""
+import time
+
+
+from helpers import (
+    Checker, dexec, make_prompt, wait_for_file,
+)
+from ws_helpers import ws_send_prompt
+
+TARGET_DIR = "/tmp/testcat"
+TARGET_FILE = "/tmp/testcat/hello.txt"
+WAIT = 30
+
+
+def test_hello_file_ws_mock(llm, ws):
+    with Checker("create hello.txt", cleanup_dirs=[TARGET_DIR]) as c:
+        print(f"\n=== OmegaClaw smoke test (run-id {c.run_id}) ===", flush=True)
+
+        c.step("wait for agent WebSocket connection")
+        if not ws.wait_for_connection(timeout=60):
+            c.fail("connection", "agent did not connect to the mock WS server")
+        c.ok("connection")
+
+        c.verify_clean()
+
+        start_ts = int(time.time()) - 1
+
+        c.step("send prompt via websocket")
+        prompt = make_prompt(
+            c.run_id,
+            f"Please overwrite {TARGET_FILE} so it contains exactly the single "
+            "word Hello (no quotes, no extra newlines, create the directory if needed).",
+        )
+        llm.set_answer(prompt, f'(shell "mkdir -p /tmp/testcat") (write-file "/tmp/testcat/hello.txt" "Hello")')
+
+        ws_send_prompt(ws, prompt)
+        c.ok("websocket", f"prompt delivered, run-id={c.run_id}")
+
+        c.step(f"wait for {TARGET_FILE} (timeout {WAIT}s)")
+        file_mtime = wait_for_file(TARGET_FILE, start_ts, timeout=WAIT)
+        if file_mtime is None:
+            c.fail("file created", f"{TARGET_FILE} not created within {WAIT}s")
+        c.ok("file created", f"after {file_mtime - start_ts}s")
+
+        c.step("check testcat exists in /tmp")
+        if dexec("test", "-d", TARGET_DIR).returncode != 0:
+            c.fail("dir exists", f"{TARGET_DIR} missing")
+        c.ok("dir exists")
+
+        c.step("check hello.txt exists in testcat")
+        if dexec("test", "-f", TARGET_FILE).returncode != 0:
+            c.fail("file exists", f"{TARGET_FILE} missing")
+        c.ok("file exists")
+
+        c.step("check mtime newer than test start")
+        dir_mtime = int(dexec("stat", "-c", "%Y", TARGET_DIR).stdout.strip())
+        if dir_mtime < start_ts:
+            c.fail("dir mtime", f"{dir_mtime} < {start_ts}")
+        if file_mtime < start_ts:
+            c.fail("file mtime", f"{file_mtime} < {start_ts}")
+        c.ok("mtime", f"start={start_ts} dir={dir_mtime} file={file_mtime}")
+
+        c.step("check file permissions")
+        perms = dexec("stat", "-c", "%A", TARGET_FILE).stdout.strip()
+        if not perms.startswith("-rw"):
+            c.fail("permissions", perms)
+        c.ok("permissions", perms)
+
+        c.step("check file content")
+        content = dexec("cat", TARGET_FILE).stdout
+        if content not in ("Hello", "Hello\n"):
+            c.fail("content", repr(content))
+        c.ok("content", repr(content))
+
+        c.done()

--- a/Autotests/mock_websocket/test_memory_chromadb_ws_mock.py
+++ b/Autotests/mock_websocket/test_memory_chromadb_ws_mock.py
@@ -1,0 +1,95 @@
+"""
+WebSocket variant of test_memory_chromadb: the mocked LLM invokes
+(remember "...") with a unique marker; the remember skill runs for real and
+grows the ChromaDB vector store. Skill smoke over the WebSocket transport.
+
+Run:
+    pytest test_memory_chromadb_ws_mock.py -s
+"""
+import subprocess
+import time
+
+
+from helpers import (
+    CHROMA_SQLITE, CONTAINER, Checker, find_skill_calls,
+    make_prompt, wait_for_skill_call,
+)
+from ws_helpers import ws_send_prompt
+
+
+def chromadb_vector_count():
+    py = (
+        "import sqlite3;"
+        f"c=sqlite3.connect('{CHROMA_SQLITE}');"
+        "print(c.execute('SELECT COUNT(*) FROM embeddings').fetchone()[0])"
+    )
+    res = subprocess.run(
+        ["docker", "exec", CONTAINER, "python3", "-c", py],
+        capture_output=True, text=True,
+    )
+    if res.returncode != 0:
+        return None
+    try:
+        return int(res.stdout.strip())
+    except ValueError:
+        return None
+
+
+def test_memory_chromadb_ws_mock(llm, ws):
+    with Checker("chromadb vector write (ws mock)") as c:
+        print(f"\n=== OmegaClaw: chromadb ws mock (run-id {c.run_id}) ===",
+              flush=True)
+
+        c.step("wait for agent WebSocket connection")
+        if not ws.wait_for_connection(timeout=60):
+            c.fail("connection", "agent did not connect to the mock WS server")
+        c.ok("connection")
+
+        c.step("count chromadb vectors before")
+        count_before = chromadb_vector_count()
+        if count_before is None:
+            c.fail("chromadb", f"cannot query {CHROMA_SQLITE}")
+        c.ok("chromadb before", f"{count_before} vectors")
+
+        c.step("send remember prompt via websocket with mocked response")
+        marker = f"CI-SMOKE-{c.run_id}"
+        c.add_cleanup_marker(marker)
+        prompt = make_prompt(
+            c.run_id,
+            f"Please remember this exact fact using the remember skill: "
+            f"'Unique smoke marker {marker} was emitted by CI.'",
+        )
+        llm.set_answer(
+            prompt,
+            f'(remember "Unique smoke marker {marker} was emitted by CI.")',
+        )
+        ws_send_prompt(ws, prompt)
+        c.ok("websocket", f"run-id={c.run_id}")
+
+        c.step("verify agent invoked (remember ...) with our marker")
+        arg = wait_for_skill_call(
+            c.run_id, "remember", timeout=30, arg_substr=marker,
+        )
+        if arg is None:
+            all_calls = find_skill_calls(c.run_id, "remember") or []
+            c.fail(
+                "remember invoked",
+                f"no (remember ...) with marker {marker}. Got: "
+                f"{[a[:80] for a in all_calls[:3]]}",
+            )
+        c.ok("remember invoked", f"arg contains marker (len={len(arg)})")
+
+        c.step("wait for chromadb vector count to grow")
+        deadline = time.time() + 60
+        count_after = count_before
+        while time.time() < deadline:
+            count_after = chromadb_vector_count()
+            if count_after is not None and count_after > count_before:
+                break
+            time.sleep(2)
+        if count_after is None or count_after <= count_before:
+            c.fail("chromadb grew", f"count stayed {count_before} (is {count_after})")
+        c.ok("chromadb grew",
+             f"{count_before} -> {count_after} (+{count_after - count_before})")
+
+        c.done()

--- a/Autotests/mock_websocket/test_ws_delivery_ws_mock.py
+++ b/Autotests/mock_websocket/test_ws_delivery_ws_mock.py
@@ -1,0 +1,69 @@
+"""
+WebSocket delivery round-trip: a user_message reaches the agent, the agent
+replies with a valid agent_message (uuid client_seq), the mock acks it.
+
+Run:
+    pytest test_ws_delivery_ws_mock.py -s
+"""
+import uuid
+
+from helpers import Checker, make_prompt
+from ws_helpers import ws_send_prompt
+
+WAIT = 30
+
+
+def _is_uuid_hex(value):
+    try:
+        uuid.UUID(hex=str(value))
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def _wait_for_reply(ws, needle, timeout):
+    import time
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        client_seq, text = ws.pop_agent_reply(timeout=max(1, int(deadline - time.time())))
+        if text is None:
+            break
+        if needle in text:
+            return client_seq, text
+    return None, None
+
+
+def test_ws_delivery_ws_mock(llm, ws):
+    with Checker("ws delivery round-trip") as c:
+        print(f"\n=== OmegaClaw: ws delivery (run-id {c.run_id}) ===", flush=True)
+
+        c.step("wait for agent WebSocket connection")
+        if not ws.wait_for_connection(timeout=60):
+            c.fail("connection", "agent did not connect to the mock WS server")
+        c.ok("connection")
+        ws.clear()
+
+        c.step("register answer and inject user_message")
+        answer = f"WS-PONG-{c.run_id}"
+        prompt = make_prompt(c.run_id, f"Reply with exactly this token using the send skill: {answer}")
+        llm.set_answer(prompt, f'(send "{answer}")')
+        ws_send_prompt(ws, prompt)
+        c.ok("injected", f"run-id={c.run_id}")
+
+        c.step("wait for agent_message with our token")
+        client_seq, text = _wait_for_reply(ws, answer, WAIT)
+        if text is None:
+            c.fail("agent_message", f"no reply containing {answer!r} within {WAIT}s")
+        c.ok("agent_message", f"text={text!r}")
+
+        c.step("check client_seq is a valid uuid hex")
+        if not _is_uuid_hex(client_seq):
+            c.fail("client_seq", f"not a uuid hex: {client_seq!r}")
+        c.ok("client_seq", client_seq)
+
+        c.step("check mock acked the agent_message")
+        if client_seq not in ws._acks:
+            c.fail("ack", f"{client_seq} not in acked set {ws._acks}")
+        c.ok("ack", f"acked client_seq={client_seq}")
+
+        c.done()

--- a/Autotests/mock_websocket/test_ws_frame_robustness_ws_mock.py
+++ b/Autotests/mock_websocket/test_ws_frame_robustness_ws_mock.py
@@ -1,0 +1,62 @@
+"""
+WebSocket frame robustness: malformed / non-JSON / unknown-type / error frames
+are dropped without crashing the channel; a following valid prompt is answered.
+
+Run:
+    pytest test_ws_frame_robustness_ws_mock.py -s
+"""
+import json
+import time
+
+from helpers import Checker, make_prompt
+
+
+WAIT = 30
+
+
+def _wait_for_reply(ws, needle, timeout):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        client_seq, text = ws.pop_agent_reply(timeout=max(1, int(deadline - time.time())))
+        if text is None:
+            break
+        if needle in text:
+            return client_seq, text
+    return None, None
+
+
+def test_ws_frame_robustness_ws_mock(llm, ws):
+    with Checker("ws frame robustness") as c:
+        print(f"\n=== OmegaClaw: ws frame robustness (run-id {c.run_id}) ===", flush=True)
+
+        c.step("wait for agent WebSocket connection")
+        if not ws.wait_for_connection(timeout=60):
+            c.fail("connection", "agent did not connect to the mock WS server")
+        c.ok("connection")
+        ws.clear()
+
+        c.step("send malformed / non-JSON / unknown / error frames")
+        ws.inject_raw("this is not json <<<{")
+        ws.inject_raw(json.dumps({"type": "user_message", "seq": "not-an-int", "text": 123}))
+        ws.inject_raw(json.dumps({"type": "totally_unknown_type", "foo": 1}))
+        ws.inject_raw(json.dumps({"type": "error", "code": "E_TEST", "message": "boom"}))
+        ws.inject_raw(json.dumps(["not", "a", "dict"]))
+        time.sleep(2)
+        c.ok("bad frames sent", "5 malformed/invalid frames delivered")
+
+        c.step("channel survives: connection still open")
+        if not ws.wait_for_connection(timeout=5):
+            c.fail("survived", "agent connection dropped after bad frames")
+        c.ok("survived", "connection still open")
+
+        c.step("a following valid prompt is answered")
+        answer = f"WS-ALIVE-{c.run_id}"
+        prompt = make_prompt(c.run_id, f"Reply with the send skill: {answer}")
+        llm.set_answer(prompt, f'(send "{answer}")')
+        ws.inject_user_message(prompt)
+        client_seq, text = _wait_for_reply(ws, answer, WAIT)
+        if text is None:
+            c.fail("recovery", f"no reply containing {answer!r} within {WAIT}s after bad frames")
+        c.ok("recovery", f"client_seq={client_seq} text={text!r}")
+
+        c.done()

--- a/Autotests/mock_websocket/test_ws_outbox_flush_ws_mock.py
+++ b/Autotests/mock_websocket/test_ws_outbox_flush_ws_mock.py
@@ -1,0 +1,67 @@
+"""
+WebSocket outbox flush: an answer produced while the socket is down is buffered
+and delivered after reconnect, exactly once (single client_seq).
+
+The prompt is delivered while connected; the connection is then dropped and
+reconnects refused for a short window. The agent drains its inbox and produces
+the reply while disconnected, so send_message buffers it in the outbox; on
+reconnect the outbox is flushed before any new inbound traffic.
+
+Run:
+    pytest test_ws_outbox_flush_ws_mock.py -s
+"""
+import time
+
+from helpers import Checker, make_prompt
+
+
+WAIT = 40
+
+
+def test_ws_outbox_flush_ws_mock(llm, ws):
+    with Checker("ws outbox flush after reconnect") as c:
+        print(f"\n=== OmegaClaw: ws outbox flush (run-id {c.run_id}) ===", flush=True)
+
+        c.step("wait for agent WebSocket connection")
+        if not ws.wait_for_connection(timeout=60):
+            c.fail("connection", "agent did not connect to the mock WS server")
+        c.ok("connection")
+        ws.clear()
+
+        c.step("deliver prompt, then drop and refuse reconnects while the agent replies")
+        answer = f"WS-BUFFERED-{c.run_id}"
+        prompt = make_prompt(c.run_id, f"Reply with the send skill: {answer}")
+        llm.set_answer(prompt, f'(send "{answer}")')
+        ws.inject_user_message(prompt)
+        ws.block_connections()
+        c.ok("dropped", "connection dropped, reconnects blocked")
+
+        c.step("hold the outage so the reply is produced while disconnected")
+        time.sleep(6)
+        ws.unblock_connections()
+        c.ok("released", "reconnects allowed again")
+
+        c.step("wait for the buffered agent_message after reconnect")
+        if not ws.wait_for_connection(timeout=30):
+            c.fail("reconnect", "agent did not reconnect after the outage")
+        got = None
+        deadline = time.time() + WAIT
+        while time.time() < deadline:
+            client_seq, text = ws.pop_agent_reply(timeout=max(1, int(deadline - time.time())))
+            if text is None:
+                break
+            if answer in text:
+                got = (client_seq, text)
+                break
+        if got is None:
+            c.fail("buffered reply", f"no reply containing {answer!r} within {WAIT}s after reconnect")
+        c.ok("buffered reply", f"client_seq={got[0]} text={got[1]!r}")
+
+        c.step("no duplicate delivery of the buffered message")
+        extras = ws.drain_agent_replies(max_wait=6)
+        dupes = [(cs, t) for cs, t in extras if t and answer in t]
+        if dupes:
+            c.fail("no duplicate", f"buffered message delivered more than once: {dupes}")
+        c.ok("no duplicate", "buffered message delivered exactly once")
+
+        c.done()

--- a/Autotests/mock_websocket/test_ws_queue_merge_ws_mock.py
+++ b/Autotests/mock_websocket/test_ws_queue_merge_ws_mock.py
@@ -1,0 +1,69 @@
+"""
+WebSocket queue merge: three user_message frames queued before the agent
+drains are joined as "A | B | C" into one LLM input; last_seen_seq ends at 3.
+
+Run:
+    pytest test_ws_queue_merge_ws_mock.py -s
+"""
+import time
+
+from helpers import Checker, make_prompt
+
+
+WAIT = 40
+
+
+def _wait_for_reply(ws, needle, timeout):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        client_seq, text = ws.pop_agent_reply(timeout=max(1, int(deadline - time.time())))
+        if text is None:
+            break
+        if needle in text:
+            return client_seq, text
+    return None, None
+
+
+def test_ws_queue_merge_ws_mock(llm, ws):
+    with Checker("ws queue merge A | B | C") as c:
+        print(f"\n=== OmegaClaw: ws queue merge (run-id {c.run_id}) ===", flush=True)
+
+        c.step("wait for agent WebSocket connection")
+        if not ws.wait_for_connection(timeout=60):
+            c.fail("connection", "agent did not connect to the mock WS server")
+        c.ok("connection")
+        ws.clear()
+
+        c.step("register merged answer and inject three user_messages back-to-back")
+        answer = f"WS-MERGED-{c.run_id}"
+        p1 = make_prompt(c.run_id, "fragment ALPHA")
+        p2 = make_prompt(c.run_id, "fragment BRAVO")
+        p3 = make_prompt(c.run_id, "fragment CHARLIE")
+        joined = " | ".join([p1, p2, p3])
+        llm.set_answer(joined, f'(send "{answer}")')
+        s1 = ws.inject_user_message(p1)
+        s2 = ws.inject_user_message(p2)
+        s3 = ws.inject_user_message(p3)
+        if not (s2 == s1 + 1 and s3 == s2 + 1):
+            c.fail("seq assignment", f"expected contiguous seq, got {s1}/{s2}/{s3}")
+        c.ok("injected", f"seq {s1}/{s2}/{s3}")
+
+        c.step("wait for the single merged agent_message")
+        client_seq, text = _wait_for_reply(ws, answer, WAIT)
+        if text is None:
+            c.fail(
+                "merged reply",
+                f"no reply for the joined 'A | B | C' input within {WAIT}s "
+                "(the three frames were not merged into one LLM input)",
+            )
+        c.ok("merged reply", f"text={text!r}")
+
+        c.step("force reconnect and read resume last_seen_seq")
+        base = ws.resume_count()
+        ws.drop_connection()
+        last_seen = ws.wait_for_resume(min_count=base + 1, timeout=30)
+        if last_seen != s3:
+            c.fail("last_seen_seq", f"expected {s3} (last of the merged batch), resume carried {last_seen!r}")
+        c.ok("last_seen_seq", f"resume carried last_seen_seq={s3}")
+
+        c.done()

--- a/Autotests/mock_websocket/test_ws_resume_dedup_ws_mock.py
+++ b/Autotests/mock_websocket/test_ws_resume_dedup_ws_mock.py
@@ -1,0 +1,79 @@
+"""
+WebSocket resume + dedup: after a forced reconnect the agent sends resume with
+the advanced last_seen_seq; a frame with seq <= last_seen_seq is dropped by the
+agent's dedup. The dedup is isolated from the send-level &lastsend guard by
+replaying a distinct text under an already-seen seq: if the frame were not
+deduped it would produce a new, non-suppressed answer.
+
+Run:
+    pytest test_ws_resume_dedup_ws_mock.py -s
+"""
+import json
+import time
+
+from helpers import Checker, make_prompt
+
+
+WAIT = 30
+
+
+def _wait_for_reply(ws, needle, timeout):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        client_seq, text = ws.pop_agent_reply(timeout=max(1, int(deadline - time.time())))
+        if text is None:
+            break
+        if needle in text:
+            return client_seq, text
+    return None, None
+
+
+def test_ws_resume_dedup_ws_mock(llm, ws):
+    with Checker("ws resume + dedup") as c:
+        print(f"\n=== OmegaClaw: ws resume dedup (run-id {c.run_id}) ===", flush=True)
+
+        c.step("wait for agent WebSocket connection")
+        if not ws.wait_for_connection(timeout=60):
+            c.fail("connection", "agent did not connect to the mock WS server")
+        c.ok("connection")
+        ws.clear()
+
+        c.step("deliver one prompt and get the single reply")
+        answer = f"WS-ONCE-{c.run_id}"
+        prompt = make_prompt(c.run_id, f"Reply once with the send skill: {answer}")
+        llm.set_answer(prompt, f'(send "{answer}")')
+        seq = ws.inject_user_message(prompt)
+        client_seq, text = _wait_for_reply(ws, answer, WAIT)
+        if text is None:
+            c.fail("first reply", f"no reply containing {answer!r} within {WAIT}s")
+        c.ok("first reply", f"seq={seq} client_seq={client_seq}")
+        ws.clear()
+
+        c.step("register a distinct answer for a poisoned replay at the seen seq")
+        poison = f"WS-POISON-{c.run_id}"
+        poison_prompt = make_prompt(c.run_id, f"Poisoned replay must be dropped: {poison}")
+        llm.set_answer(poison_prompt, f'(send "{poison}")')
+        c.ok("poison registered")
+
+        c.step("force reconnect; agent must resume with the advanced last_seen_seq")
+        base = ws.resume_count()
+        ws.drop_connection()
+        last_seen = ws.wait_for_resume(min_count=base + 1, timeout=30)
+        if last_seen != seq:
+            c.fail("resume last_seen_seq", f"expected {seq}, resume carried {last_seen!r}")
+        c.ok("resume last_seen_seq", f"resume carried last_seen_seq={seq}")
+
+        c.step("replay a distinct text under the already-seen seq; dedup must drop it")
+        if not ws.wait_for_connection(timeout=30):
+            c.fail("reconnect", "agent did not reconnect after drop")
+        ws.inject_raw(json.dumps({"type": "user_message", "seq": seq, "text": poison_prompt}))
+        extras = ws.drain_agent_replies(max_wait=WAIT // 3 or 5)
+        leaked = [t for _, t in extras if t and (poison in t or answer in t)]
+        if leaked:
+            c.fail(
+                "dedup",
+                f"agent processed a frame with seq={seq} <= last_seen_seq={seq}: {leaked}",
+            )
+        c.ok("dedup", "replayed / poisoned frame at seen seq was dropped")
+
+        c.done()

--- a/Autotests/mock_websocket/test_wschat_unit.py
+++ b/Autotests/mock_websocket/test_wschat_unit.py
@@ -1,0 +1,121 @@
+"""
+In-process unit tests for the WebSocket channel logic (channels/wschat.py).
+
+These drive the channel's pure functions directly on the host: no container, no
+running agent, no `-t websocket`, and no `websockets` library (wschat imports it
+lazily, only when actually connecting). That makes them CI-eligible in the same
+job as test_comm / test_llm / test_rpc — they catch regressions in the dedup,
+A | B | C merge, outbox and frame-parsing logic on every run.
+
+The end-to-end wiring (channels.metta websocket dispatch, send skill ->
+agent_message, real drain -> LLM) is covered separately by the
+test_*_ws_mock.py integration suite, which needs a `-t websocket` container.
+"""
+import importlib.util
+import json
+import os
+import uuid
+
+import pytest
+
+_WSCHAT_PATH = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "channels", "wschat.py")
+)
+
+
+def _load_wschat():
+    spec = importlib.util.spec_from_file_location("wschat_under_test", _WSCHAT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def wschat():
+    module = _load_wschat()
+    module._inbox.clear()
+    module._outbox.clear()
+    module._last_seen_seq = None
+    module._connected = False
+    module._ws = None
+    module._running = False
+    return module
+
+
+def _user_message(seq, text):
+    return json.dumps({"type": "user_message", "seq": seq, "text": text})
+
+
+def test_enqueue_join_and_last_seen(wschat):
+    wschat._handle_frame(_user_message(1, "A"))
+    wschat._handle_frame(_user_message(2, "B"))
+    wschat._handle_frame(_user_message(3, "C"))
+    assert wschat.getLastMessage() == "A | B | C"
+    assert wschat._last_seen_seq == 3
+    assert wschat.getLastMessage() == ""
+
+
+def test_dedup_by_last_seen_seq(wschat):
+    wschat._handle_frame(_user_message(1, "A"))
+    wschat._handle_frame(_user_message(2, "B"))
+    assert wschat.getLastMessage() == "A | B"
+    assert wschat._last_seen_seq == 2
+
+    wschat._handle_frame(_user_message(2, "replay-2"))
+    wschat._handle_frame(_user_message(1, "replay-1"))
+    assert wschat.getLastMessage() == ""
+
+
+def test_dedup_by_inbox_order(wschat):
+    wschat._handle_frame(_user_message(5, "X"))
+    wschat._handle_frame(_user_message(5, "Y"))
+    wschat._handle_frame(_user_message(4, "Z"))
+    assert wschat.getLastMessage() == "X"
+    assert wschat._last_seen_seq == 5
+
+
+def test_frame_robustness(wschat):
+    wschat._handle_frame("this is not json <<<{")
+    wschat._handle_frame(json.dumps(["not", "a", "dict"]))
+    wschat._handle_frame(json.dumps({"type": "user_message", "seq": "x", "text": "t"}))
+    wschat._handle_frame(json.dumps({"type": "user_message", "seq": 1, "text": 123}))
+    wschat._handle_frame(json.dumps({"type": "totally_unknown"}))
+    wschat._handle_frame(json.dumps({"type": "ack", "seq": 1, "client_seq": "abc"}))
+    wschat._handle_frame(json.dumps({"type": "error", "code": "E", "message": "boom"}))
+    assert len(wschat._inbox) == 0
+
+    wschat._handle_frame(_user_message(1, "OK"))
+    assert wschat.getLastMessage() == "OK"
+
+
+def test_outbox_buffers_while_disconnected_and_flushes(wschat):
+    wschat._connected = False
+    wschat._ws = None
+
+    wschat.send_message("buffered-1")
+    assert len(wschat._outbox) == 1
+    payload = wschat._outbox[0]
+    assert payload["type"] == "agent_message"
+    assert payload["text"] == "buffered-1"
+    uuid.UUID(hex=payload["client_seq"])
+    original_client_seq = payload["client_seq"]
+
+    sent = []
+
+    class _FakeWs:
+        def send(self, message):
+            sent.append(message)
+
+    wschat._drain_outbox(_FakeWs())
+    assert len(wschat._outbox) == 0
+    assert len(sent) == 1
+    flushed = json.loads(sent[0])
+    assert flushed["type"] == "agent_message"
+    assert flushed["text"] == "buffered-1"
+    assert flushed["client_seq"] == original_client_seq
+
+
+def test_resume_frame_reflects_last_seen(wschat):
+    assert wschat._build_resume_frame() == {"type": "resume", "last_seen_seq": None}
+    wschat._last_seen_seq = 7
+    assert wschat._build_resume_frame() == {"type": "resume", "last_seen_seq": 7}

--- a/Autotests/mock_websocket/ws_driver.py
+++ b/Autotests/mock_websocket/ws_driver.py
@@ -1,0 +1,230 @@
+"""Local mock WebSocket server standing in for the ASI Create chat.
+
+The agent's WebSocket channel (`channels/wschat.py`) is a client: it connects
+to a chat server, sends `resume`, receives `user_message`, replies with
+`agent_message`, and expects `ack`. This driver is that server, running on the
+pytest host, so the WS transport can be exercised without ASI Create.
+
+Test-side surface mirrors RealTgDriver / SlackRealDriver:
+
+- inject_user_message(text)  -> send `user_message{seq,text}` (auto seq)
+- pop_agent_reply(timeout=N) -> (client_seq, text) from the agent, or (None, None)
+- drain_agent_replies(...)   -> drain everything pending
+- clear()                    -> empty the reply queue
+- stop(timeout)              -> shut the server down
+- mirror(text)               -> no-op (no separate mirror surface for WS)
+
+Plus WS-specific hooks the channel tests need:
+
+- inject_raw(raw)            -> send an arbitrary frame (malformed / unknown)
+- drop_connection()          -> close the agent's socket to force a reconnect
+- block_connections() / unblock_connections() -> refuse reconnects for a window
+- wait_for_connection(...)   -> block until the agent is connected
+- wait_for_resume(...)       -> block until a `resume` frame arrives; the last
+                                one's `last_seen_seq` is on `.last_resume_seq`
+"""
+import json
+import queue
+import threading
+import time
+
+
+class WsMockDriver:
+    def __init__(self, port, host="0.0.0.0", token="test-token"):
+        self._host = host
+        self._port = int(port)
+        self._token = token or ""
+        self._lock = threading.Lock()
+        self._ws = None
+        self._replies = queue.Queue()
+        self._sent = []
+        self._acks = []
+        self._next_seq = 1
+        self.last_resume_seq = None
+        self._resume_count = 0
+        self._connected = threading.Event()
+        self._resumed = threading.Event()
+        self._accept = threading.Event()
+        self._accept.set()
+        self._server = None
+        self._ready = threading.Event()
+        self._thread = threading.Thread(target=self._serve, daemon=True, name="ws-mock-server")
+        self._thread.start()
+        if not self._ready.wait(timeout=10):
+            raise RuntimeError("WsMockDriver failed to start listening")
+        print(f"[WsMockDriver] listening on {self._host}:{self._port}", flush=True)
+
+    def inject_user_message(self, text, **_):
+        with self._lock:
+            seq = self._next_seq
+            self._next_seq += 1
+            self._sent.append((seq, str(text)))
+        self._send({"type": "user_message", "seq": seq, "text": str(text)})
+        print(f"[WsMockDriver] -> user_message seq={seq}: {text!r}", flush=True)
+        return seq
+
+    def inject_raw(self, raw):
+        with self._lock:
+            ws = self._ws
+        if ws is None:
+            raise RuntimeError("no agent connected")
+        with self._lock:
+            ws.send(raw)
+        print(f"[WsMockDriver] -> raw frame: {raw!r}", flush=True)
+
+    def pop_agent_reply(self, timeout=30):
+        try:
+            client_seq, text, _ts = self._replies.get(timeout=timeout)
+            return client_seq, text
+        except queue.Empty:
+            return None, None
+
+    def drain_agent_replies(self, max_wait=2):
+        out = []
+        deadline = time.time() + max_wait
+        while time.time() < deadline:
+            try:
+                client_seq, text, _ts = self._replies.get(timeout=0.2)
+                out.append((client_seq, text))
+            except queue.Empty:
+                break
+        return out
+
+    def clear(self):
+        while True:
+            try:
+                self._replies.get_nowait()
+            except queue.Empty:
+                return
+
+    def mirror(self, text):
+        return
+
+    _mirror = mirror
+
+    def drop_connection(self):
+        with self._lock:
+            ws = self._ws
+            self._ws = None
+        self._connected.clear()
+        if ws is not None:
+            try:
+                ws.close()
+            except Exception:
+                pass
+            print("[WsMockDriver] dropped agent connection", flush=True)
+
+    def block_connections(self):
+        self._accept.clear()
+        self.drop_connection()
+
+    def unblock_connections(self):
+        self._accept.set()
+
+    def wait_for_connection(self, timeout=30):
+        return self._connected.wait(timeout=timeout)
+
+    def resume_count(self):
+        with self._lock:
+            return self._resume_count
+
+    def wait_for_resume(self, min_count=1, timeout=30):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with self._lock:
+                if self._resume_count >= min_count:
+                    return self.last_resume_seq
+            time.sleep(0.1)
+        return None
+
+    def stop(self, timeout=5):
+        self.drop_connection()
+        if self._server is not None:
+            try:
+                self._server.shutdown()
+            except Exception:
+                pass
+        self._thread.join(timeout=timeout)
+
+    def _serve(self):
+        from websockets.sync.server import serve
+
+        with serve(self._handler, self._host, self._port,
+                   process_request=self._process_request) as server:
+            self._server = server
+            self._ready.set()
+            server.serve_forever()
+
+    def _process_request(self, connection, request):
+        if not self._accept.is_set():
+            print("[WsMockDriver] refusing handshake (blocked)", flush=True)
+            return connection.respond(503, "blocked")
+        return None
+
+    def _handler(self, ws):
+        headers = getattr(ws.request, "headers", {})
+        authorization = headers.get("Authorization", "") if hasattr(headers, "get") else ""
+        if self._token and authorization != f"Bearer {self._token}":
+            print(f"[WsMockDriver] rejecting unauthorized connection: {authorization!r}", flush=True)
+            try:
+                ws.close(1008, "unauthorized")
+            except Exception:
+                pass
+            return
+
+        with self._lock:
+            self._ws = ws
+        self._connected.set()
+        print("[WsMockDriver] agent connected", flush=True)
+        try:
+            for raw in ws:
+                self._on_frame(ws, raw)
+        except Exception:
+            pass
+        finally:
+            with self._lock:
+                if self._ws is ws:
+                    self._ws = None
+                    self._connected.clear()
+
+    def _on_frame(self, ws, raw):
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", errors="ignore")
+        try:
+            frame = json.loads(raw)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(frame, dict):
+            return
+
+        frame_type = frame.get("type")
+        if frame_type == "resume":
+            with self._lock:
+                self.last_resume_seq = frame.get("last_seen_seq")
+                self._resume_count += 1
+                pending = list(self._sent)
+            self._resumed.set()
+            print(f"[WsMockDriver] <- resume last_seen_seq={frame.get('last_seen_seq')}", flush=True)
+            for seq, text in pending:
+                self._send({"type": "user_message", "seq": seq, "text": text}, ws=ws)
+        elif frame_type == "agent_message":
+            client_seq = frame.get("client_seq")
+            text = frame.get("text")
+            self._replies.put((client_seq, text, time.time()))
+            self._acks.append(client_seq)
+            print(f"[WsMockDriver] <- agent_message client_seq={client_seq}: {text!r}", flush=True)
+            self._send({"type": "ack", "seq": None, "client_seq": client_seq}, ws=ws)
+        else:
+            print(f"[WsMockDriver] <- ignoring frame type {frame_type!r}", flush=True)
+
+    def _send(self, payload, ws=None):
+        with self._lock:
+            target = ws if ws is not None else self._ws
+            if target is None:
+                return False
+            try:
+                target.send(json.dumps(payload))
+                return True
+            except Exception as exc:
+                print(f"[WsMockDriver] send failed: {exc}", flush=True)
+                return False

--- a/Autotests/mock_websocket/ws_helpers.py
+++ b/Autotests/mock_websocket/ws_helpers.py
@@ -1,0 +1,43 @@
+"""WebSocket-flavored thin wrappers over the shared IRC test infrastructure.
+
+The shared `Autotests/helpers.py` is built around an IRC `send_prompt`. For the
+WebSocket suite we substitute that with `ws_send_prompt(ws, prompt)`, which has
+the mock WS server deliver a `user_message` frame to the agent.
+
+Everything else — `Checker`, `dexec`, `wait_for_file`, history/skill waiters,
+prompt envelope — is reused unchanged.
+"""
+import os
+import sys
+
+_PARENT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+if _PARENT not in sys.path:
+    sys.path.insert(0, _PARENT)
+
+from helpers import (  # noqa: E402, F401  (re-exported for tests)
+    Checker,
+    dexec,
+    dexec_root,
+    make_prompt,
+    wait_for_file,
+    wait_for_file_mtime_change,
+    wait_for_history_keyword,
+    wait_for_history_block,
+    wait_for_skill_call,
+    wait_for_any_skill_call,
+    wait_for_skill_match,
+    find_skill_calls,
+    read_history,
+    get_mtime,
+    get_size,
+)
+
+
+def ws_send_prompt(ws_driver, prompt):
+    """Deliver `prompt` to the agent over the mock WebSocket transport.
+
+    Mirrors the role of `helpers.send_prompt` in the IRC suite — the mock
+    server sends a `user_message` frame the agent picks up on its next drain.
+    """
+    ws_driver.inject_user_message(prompt)
+    return True

--- a/Autotests/run_mandatory
+++ b/Autotests/run_mandatory
@@ -29,4 +29,5 @@ mock/test_technical_analysis_mock.py
 mock/test_transition_episodes_after_eviction_mock.py
 mock/test_transition_metta_to_remember_mock.py
 mock/test_transition_pin_to_remember_mock.py
+mock_websocket/test_wschat_unit.py
 test_websearch_smoke.py


### PR DESCRIPTION
## What

Regression tests for the WebSocket comm channel (channels/wschat.py). They run
without ASI Create: a local mock WebSocket server plays the chat side.

Unit tests (mock_websocket/test_wschat_unit.py) drive wschat.py in process:
dedup by last_seen_seq and by inbox order, the "A | B | C" merge, the outbox
buffer and flush, and frame parsing (non-JSON, malformed, unknown, error).
They need no container and no websockets dependency, so they run in the
existing CI job and are listed in run_mandatory.

End-to-end tests (test_*_ws_mock.py) drive a real agent on a -t websocket
container through a mock WS server (WsMockDriver) with the Test provider:
delivery and ack, queue merge, resume/dedup, outbox flush after a reconnect,
frame robustness, and two skill smokes (write-file, and remember which adds a
ChromaDB vector). They need a -t websocket container, so they are not in
run_mandatory, which runs one -t test container. See mock_websocket/README.md
for how to run them.

## Testing

Unit: 6 passed (locally and on the stand; they import fine without websockets).
End-to-end: 7 passed against a -t websocket container built from this branch.
