### PR TITLE
[OMEGA-290] [FIX] telegram: don't abort remaining chunks when one chunk fails; greppable send-status log lines

### DIFF
--- a/Autotests/run_mandatory
+++ b/Autotests/run_mandatory
@@ -36,3 +36,4 @@ mock/test_workflow_plugin_mock.py
 mock_websocket/test_wschat_unit.py
 test_websearch_smoke.py
 unit/test_fileio_verified_writes.py
+unit/test_telegram_send_chunking.py

--- a/Autotests/unit/test_telegram_send_chunking.py
+++ b/Autotests/unit/test_telegram_send_chunking.py
@@ -1,0 +1,132 @@
+"""In-process unit tests for channels/telegram.py send_message chunking +
+delivery-status logging.
+
+No container, no network, no token — same pattern as
+mock_websocket/test_wschat_unit.py: the module is loaded by file path and its
+`_api_call` layer is stubbed. That makes these CI-eligible alongside
+test_comm / test_llm / test_rpc.
+
+Covers the send-hardening behavior:
+  - a failed chunk does NOT abort the remaining chunks of a multi-chunk message
+  - a failed chunk pauses 1s before the remaining chunks (rate-limit relief)
+  - per-chunk [SEND_FAIL] lines and a [SEND_OK]/[SEND_PARTIAL]/[SEND_FAIL]
+    summary line make delivery status greppable in the log
+  - unbound/disconnected sends log [SEND_SKIP] instead of dropping silently
+"""
+import importlib.util
+import logging
+import os
+import sys
+import types
+
+import pytest
+
+_REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_CHANNELS_DIR = os.path.join(_REPO_ROOT, "channels")
+_TELEGRAM_PATH = os.path.join(_CHANNELS_DIR, "telegram.py")
+
+# telegram.py does `import auth` (a channels/ sibling) and
+# `from src.logger import get_logger` (repo-root package) at import time.
+for _p in (_REPO_ROOT, _CHANNELS_DIR):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def _load_telegram():
+    spec = importlib.util.spec_from_file_location("telegram_under_test", _TELEGRAM_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def tg():
+    module = _load_telegram()
+    module._connected = True
+    module._chat_id = "12345"
+    return module
+
+
+def _capture_sends(module):
+    sent = []
+    module._api_call = (
+        lambda method, params=None, timeout=30, use_post=False: sent.append(params["text"])
+    )
+    return sent
+
+
+def _capture_sleeps(module):
+    sleeps = []
+    module.time = types.SimpleNamespace(sleep=sleeps.append)
+    return sleeps
+
+
+def test_single_chunk_ok_logs_send_ok(tg, caplog):
+    caplog.set_level(logging.INFO)
+    sent = _capture_sends(tg)
+
+    tg.send_message("hello")
+
+    assert sent == ["hello"]
+    assert "[SEND_OK] chunks=1 chars=5" in caplog.text
+    assert "[SEND_FAIL]" not in caplog.text
+
+
+def test_long_text_is_chunked(tg, caplog):
+    caplog.set_level(logging.INFO)
+    sent = _capture_sends(tg)
+
+    tg.send_message("a" * 3900 + "b" * 3900 + "c" * 10)
+
+    assert [len(c) for c in sent] == [3900, 3900, 10]
+    assert "[SEND_OK] chunks=3 chars=7810" in caplog.text
+
+
+def test_failed_chunk_does_not_abort_remaining_chunks(tg, caplog):
+    caplog.set_level(logging.INFO)
+    sent = []
+
+    def flaky(method, params=None, timeout=30, use_post=False):
+        sent.append(params["text"])
+        if len(sent) == 2:
+            raise RuntimeError("boom")
+
+    tg._api_call = flaky
+    sleeps = _capture_sleeps(tg)
+
+    tg.send_message("a" * 3900 + "b" * 3900 + "c" * 3900)
+
+    assert len(sent) == 3, "chunk 3 must still be attempted after chunk 2 fails"
+    assert sleeps == [1], "one rate-limit pause after the mid-message failure"
+    assert "[SEND_FAIL] chunk=2/3" in caplog.text
+    assert "[SEND_PARTIAL] ok=2 fail=1" in caplog.text
+
+
+def test_all_chunks_failing_logs_send_fail_summary(tg, caplog):
+    caplog.set_level(logging.INFO)
+
+    def broken(method, params=None, timeout=30, use_post=False):
+        raise RuntimeError("boom")
+
+    tg._api_call = broken
+    sleeps = _capture_sleeps(tg)
+
+    tg.send_message("a" * 3900 + "b" * 3900)
+
+    assert sleeps == [1], "no pause after the final chunk"
+    assert "[SEND_FAIL] chunk=1/2" in caplog.text
+    assert "[SEND_FAIL] chunk=2/2" in caplog.text
+    assert "[SEND_FAIL] ok=0 fail=2" in caplog.text
+    assert "[SEND_PARTIAL]" not in caplog.text
+
+
+def test_unbound_or_disconnected_skips_with_log(tg, caplog):
+    caplog.set_level(logging.INFO)
+    sent = _capture_sends(tg)
+    tg._connected = False
+
+    tg.send_message("hello")
+
+    assert sent == []
+    assert "[SEND_SKIP] connected=False bound=True chars=5" in caplog.text
+    assert "[SEND_OK]" not in caplog.text and "[SEND_FAIL]" not in caplog.text

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -240,9 +240,14 @@ def send_message(text):
         target_chat = _chat_id
 
     if not _connected or not target_chat:
+        logger.warning(
+            f"[SEND_SKIP] connected={_connected} bound={bool(target_chat)} chars={len(text)}"
+        )
         return
 
     max_len = 3900
+    total = (len(text) + max_len - 1) // max_len
+    ok = fails = 0
     for i in range(0, len(text), max_len):
         chunk = text[i:i + max_len]
         if not chunk:
@@ -254,9 +259,23 @@ def send_message(text):
                 timeout=15,
                 use_post=True,
             )
+            ok += 1
         except Exception as exc:
-            logger.exception(f"Send failed: {exc}")
-            return
+            # A failed chunk no longer aborts the remaining chunks: partial
+            # delivery with a diagnosable log beats silently dropping the rest
+            # of a multi-chunk message.
+            fails += 1
+            logger.exception(f"[SEND_FAIL] chunk={i // max_len + 1}/{total} err={exc}")
+            if i + max_len < len(text):
+                # the most likely chunk failure is a rate limit; give the API
+                # a beat before the remaining chunks instead of hammering it
+                time.sleep(1)
+    if fails == 0:
+        logger.info(f"[SEND_OK] chunks={ok} chars={len(text)}")
+    elif ok == 0:
+        logger.error(f"[SEND_FAIL] ok=0 fail={fails} chars={len(text)}")
+    else:
+        logger.warning(f"[SEND_PARTIAL] ok={ok} fail={fails} chars={len(text)}")
 
 class TelegramChannel(channels.CommChannel):
 


### PR DESCRIPTION
## Description
Two small robustness fixes to the Telegram send path, no behavior change on the happy path. Rebased onto current `main`; the new log lines go through the structured logger (`src.logger`) introduced in #226.

**1. A failed chunk no longer aborts the remaining chunks.** `send_message` splits
long messages at 3900 chars, but any chunk failure `return`ed out of the loop, so
the tail of a long multi-chunk message was silently dropped. Now the failed chunk
is logged (`logger.exception`, so the traceback is kept), the sender pauses 1s
(the most likely chunk failure is a rate limit — don't hammer the API), and the
remaining chunks are still attempted — partial delivery with a diagnosable log
beats silently losing the rest. (Related community pain: the long-running
truncated/multi-send-failure reports in the ASI Alliance channel.)

**2. Greppable delivery-status log lines.** Every send now ends with a summary,
and skipped/failed sends leave a trace:

```
... | INFO     | telegram | [SEND_OK] chunks=2 chars=5100
... | ERROR    | telegram | [SEND_FAIL] chunk=1/3 err=<exception>       <- per failed chunk, with traceback
... | WARNING  | telegram | [SEND_PARTIAL] ok=2 fail=1 chars=11700
... | ERROR    | telegram | [SEND_FAIL] ok=0 fail=3 chars=11700         <- every chunk failed
... | WARNING  | telegram | [SEND_SKIP] connected=False bound=True chars=42   <- previously dropped with no trace
```

This makes "did my message actually go out?" answerable from the log — useful
both for operators and for the agent-side self-verification patterns the
community has been building (send-then-verify).

Possible follow-up (not in this PR to keep it minimal): a single retry per failed
chunk (honoring 429 `retry_after`) before counting it as failed — the send-path
analogue of what #18 proposes for LLM-provider 429s.

## How Has This Been Tested?
`Autotests/unit/test_telegram_send_chunking.py` — in-process unit
tests following the `mock_websocket/test_wschat_unit.py` pattern (module loaded
by file path, `_api_call` stubbed, `caplog` assertions; no container, network,
or token needed), wired into `Autotests/run_mandatory` so CI executes them:
- single-chunk success logs `[SEND_OK]`
- 3900-char chunk boundaries preserved
- a mid-message chunk failure still attempts the remaining chunks (after a 1s pause) and logs `[SEND_FAIL]` + `[SEND_PARTIAL]`
- every chunk failing logs a `[SEND_FAIL] ok=0` summary instead of claiming partial delivery
- unbound/disconnected sends nothing and logs `[SEND_SKIP]`

Run: `pytest Autotests/unit/test_telegram_send_chunking.py`

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
