### PR TITLE
[OMEGA-242] Use swrite to log Prolog exceptions without crash

### DIFF
--- a/src/log.metta
+++ b/src/log.metta
@@ -1,7 +1,10 @@
+!(import_prolog_function swrite)
+
 (= (log $type $module $msg)
-   (case $type 
-      ((INFO (py-call (logger.log_info $msg $module)))
-      (DEBUG (py-call (logger.log_debug $msg $module)))
-      (WARNING (py-call (logger.log_warning $msg $module)))
-      (ERROR (py-call (logger.log_error $msg $module)))
-      ($else ERROR-LOGGER-TYPE-UNIDENTIFIED))))
+   (let $str (swrite $msg)
+     (case $type 
+        ((INFO (py-call (logger.log_info $str $module)))
+        (DEBUG (py-call (logger.log_debug $str $module)))
+        (WARNING (py-call (logger.log_warning $str $module)))
+        (ERROR (py-call (logger.log_error $str $module)))
+        ($else ERROR-LOGGER-TYPE-UNIDENTIFIED)))))


### PR DESCRIPTION
## Description
`py-call` is used to implement new logger facility. When code tries to log Prolog exception it crashes the Prolog interpreter. For example it happens when Docker is started using OpenAI as a provider. For some reason the code cannot find `useGPTEmbeddings` function which leads to crash:
```
ERROR: [Thread main] /PeTTa/src/main.pl:23: user:main janus:py_call/3: Domain error: `py_term' expected, found `existence_error(procedure,useGPTEmbedding/2)'
```

Root cause: `py-call` function crashes if it gets Prolog exception on input. For example the following MeTTa code crashes:
```metta
(= (log $msg)  (py-call (print $msg)))
(= (foo $a $b) ())

!(let $sexpr (catch (eval (foo 1)))
  (progn
    (println! $sexpr)
    (log $sexpr)))
```
it outputs:
```
(partial foo (1)) <-- println! result
ERROR: [Thread main] /home/vital/projects/trueagi/PeTTa/src/main.pl:23: user:main janus:py_call/3: Arguments are not sufficiently instantiated <-- py-call print result
```

This PR fixes it by using `swrite` which converts exceptions to strings correctly.

## How Has This Been Tested?
Start Docker using OpenAI provider. Check it works and not crashes when tries to use `(embed ...)` skill.

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
