### PR TITLE
[OMEGA-289] [FIX] telegram: queue sends issued before the adapter is ready instead of dropping them

### DIFF
--- a/Autotests/run_mandatory
+++ b/Autotests/run_mandatory
@@ -36,3 +36,4 @@ mock/test_workflow_plugin_mock.py
 mock_websocket/test_wschat_unit.py
 test_websearch_smoke.py
 unit/test_fileio_verified_writes.py
+unit/test_telegram_queue_until_connected.py

--- a/Autotests/unit/test_telegram_queue_until_connected.py
+++ b/Autotests/unit/test_telegram_queue_until_connected.py
@@ -1,0 +1,179 @@
+"""In-process unit tests for channels/telegram.py send-queueing.
+
+Sends issued before the poll loop has connected (or before a chat is bound)
+used to be dropped silently; now they are queued (bounded) and flushed in
+order once the adapter is ready.
+
+No container, no network, no token — same pattern as
+mock_websocket/test_wschat_unit.py: the module is loaded by file path and its
+`_api_call` layer is stubbed.
+"""
+import importlib.util
+import logging
+import os
+import sys
+
+import pytest
+
+_REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_CHANNELS_DIR = os.path.join(_REPO_ROOT, "channels")
+_TELEGRAM_PATH = os.path.join(_CHANNELS_DIR, "telegram.py")
+
+# telegram.py does `import auth` (a channels/ sibling) and
+# `from src.logger import get_logger` (repo-root package) at import time.
+for _p in (_REPO_ROOT, _CHANNELS_DIR):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def _load_telegram():
+    spec = importlib.util.spec_from_file_location("telegram_under_test", _TELEGRAM_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def tg():
+    return _load_telegram()
+
+
+def _capture_sends(module):
+    sent = []
+    module._api_call = (
+        lambda method, params=None, timeout=30, use_post=False: sent.append(params["text"])
+    )
+    return sent
+
+
+def _make_ready(module):
+    module._connected = True
+    module._chat_id = "12345"
+
+
+def test_send_before_connect_is_queued_not_dropped(tg, caplog):
+    caplog.set_level(logging.INFO)
+    sent = _capture_sends(tg)
+
+    tg.send_message("hello")
+
+    assert sent == []
+    assert len(tg._pending) == 1
+    assert "[SEND_QUEUE] queued chars=5" in caplog.text
+
+
+def test_connected_but_unbound_still_queues(tg, caplog):
+    caplog.set_level(logging.INFO)
+    sent = _capture_sends(tg)
+    tg._connected = True  # polling up, no chat bound yet (auto-bind mode)
+
+    tg.send_message("hello")
+
+    assert sent == []
+    assert len(tg._pending) == 1
+
+
+def test_queue_flushes_in_order_once_ready(tg, caplog):
+    caplog.set_level(logging.INFO)
+    sent = _capture_sends(tg)
+
+    tg.send_message("first")
+    tg.send_message("second")
+    _make_ready(tg)
+    tg._flush_pending()
+
+    assert sent == ["first", "second"]
+    assert len(tg._pending) == 0
+    assert "[SEND_FLUSH]" in caplog.text
+
+
+def test_new_send_delivers_queued_messages_first(tg, caplog):
+    caplog.set_level(logging.INFO)
+    sent = _capture_sends(tg)
+
+    tg.send_message("queued-early")
+    _make_ready(tg)
+    tg.send_message("sent-later")
+
+    assert sent == ["queued-early", "sent-later"]
+    assert len(tg._pending) == 0
+
+
+def test_full_queue_drops_oldest_with_warning(tg, caplog):
+    caplog.set_level(logging.INFO)
+    sent = _capture_sends(tg)
+    tg._PENDING_MAX = 3
+
+    for msg in ["m1", "m2", "m3", "m4"]:
+        tg.send_message(msg)
+
+    assert len(tg._pending) == 3
+    assert "[SEND_QUEUE] full (3): dropped oldest" in caplog.text
+
+    _make_ready(tg)
+    tg._flush_pending()
+    assert sent == ["m2", "m3", "m4"]
+
+
+def test_flush_stops_draining_when_delivery_fails(tg, caplog):
+    caplog.set_level(logging.INFO)
+    sent = []
+
+    def failing_second(method, params=None, timeout=30, use_post=False):
+        sent.append(params["text"])
+        if len(sent) == 2:
+            raise RuntimeError("boom")
+
+    tg._api_call = failing_second
+    tg.send_message("first")
+    tg.send_message("second")
+    tg.send_message("third")
+    _make_ready(tg)
+
+    tg._flush_pending()
+
+    assert sent == ["first", "second"], "third must not be attempted in the failing drain"
+    assert list(tg._pending) == ["third"], "undrained message stays queued for the next cycle"
+    assert "[SEND_FLUSH] delivery failed, stopping drain (1 still queued)" in caplog.text
+
+
+def test_ready_send_queues_behind_undrained_messages(tg, caplog):
+    caplog.set_level(logging.INFO)
+    sent = []
+
+    def failing_second(method, params=None, timeout=30, use_post=False):
+        sent.append(params["text"])
+        if len(sent) == 2:
+            raise RuntimeError("boom")
+
+    tg._api_call = failing_second
+    for m in ["m1", "m2", "m3", "m4"]:
+        tg.send_message(m)
+    _make_ready(tg)
+
+    tg.send_message("m5")
+
+    assert sent == ["m1", "m2"], "drain stopped at the failure"
+    assert list(tg._pending) == ["m3", "m4", "m5"], "ready send joins the queue, no overtaking"
+
+    tg._flush_pending()
+    assert sent == ["m1", "m2", "m3", "m4", "m5"], "next drain delivers in original order"
+
+
+def test_flush_stops_when_connection_lost_midway(tg, caplog):
+    caplog.set_level(logging.INFO)
+    sent = []
+
+    def api_then_disconnect(method, params=None, timeout=30, use_post=False):
+        sent.append(params["text"])
+        tg._connected = False  # connection drops after the first delivery
+
+    tg._api_call = api_then_disconnect
+    tg.send_message("first")
+    tg.send_message("second")
+    _make_ready(tg)
+
+    tg._flush_pending()
+
+    assert sent == ["first"]
+    assert list(tg._pending) == ["second"], "undelivered message stays queued"

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -4,6 +4,8 @@ import threading
 import time
 import urllib.parse
 import urllib.request
+from collections import deque
+
 import auth
 from src.logger import get_logger
 import channels
@@ -15,6 +17,7 @@ _running = False
 _last_message = ""
 _msg_lock = threading.Lock()
 _state_lock = threading.Lock()
+_flush_lock = threading.Lock()
 
 _bot_token = ""
 _api_base = ""
@@ -22,6 +25,9 @@ _chat_id = ""
 _poll_timeout = 20
 _offset = None
 _connected = False
+
+_PENDING_MAX = 50
+_pending = deque()  # sends issued before the adapter was ready (see send_message)
 
 _authenticated_user_id = None
 
@@ -184,7 +190,16 @@ def _poll_loop():
                 if state == "allow":
                     _set_last(f"{display_name}: {text}")
                 elif state == "auth_bound":
-                    send_message(f"Authentication successful for {display_name}.")
+                    # Enqueue instead of send_message so the poll thread never
+                    # blocks on _flush_lock; the flush below delivers it.
+                    _enqueue_pending(f"Authentication successful for {display_name}.")
+
+            # After update processing so a chat bound in THIS iteration
+            # (auto-bind/auth) flushes immediately, not one poll cycle later.
+            # Unlocked emptiness read: worst case a no-op flush or a
+            # one-cycle delay; _flush_pending re-checks under _state_lock.
+            if _pending:
+                _flush_pending(blocking=False)
         except Exception as exc:
             _connected = False
             logger.warning(f"Poll error: {exc}")
@@ -231,17 +246,48 @@ def stop_telegram():
     _running = False
 
 
-def send_message(text):
-    text = str(text).replace("\\n", "\n").replace("\r", "")
-    if not text:
-        return
-
+def _enqueue_pending(text):
     with _state_lock:
-        target_chat = _chat_id
+        dropped = len(_pending) >= _PENDING_MAX
+        if dropped:
+            _pending.popleft()
+        _pending.append(text)
+        queued = len(_pending)
+    if dropped:
+        logger.warning(f"[SEND_QUEUE] full ({_PENDING_MAX}): dropped oldest queued message")
+    logger.info(f"[SEND_QUEUE] queued chars={len(text)} ({queued} pending)")
 
-    if not _connected or not target_chat:
+
+def _flush_pending(blocking=True):
+    # _flush_lock serializes concurrent flushers so queued messages leave in
+    # order; _state_lock is never held across the network call. The poll
+    # thread passes blocking=False and skips a contended flush (another
+    # thread is already draining) instead of stalling getUpdates behind it.
+    if not _flush_lock.acquire(blocking=blocking):
         return
+    try:
+        while True:
+            with _state_lock:
+                if not _pending or not _connected or not _chat_id:
+                    return
+                text = _pending.popleft()
+                target_chat = _chat_id
+                remaining = len(_pending)
+            logger.info(f"[SEND_FLUSH] delivering queued message ({remaining} left)")
+            if not _deliver(text, target_chat):
+                # Stop the drain: the failed message is dropped (matching
+                # direct-send semantics), the rest stays queued and retries
+                # on the next poll-cycle flush — so a rate-limit burst cannot
+                # burn the whole queue in one failing drain.
+                logger.warning(
+                    f"[SEND_FLUSH] delivery failed, stopping drain ({remaining} still queued)"
+                )
+                return
+    finally:
+        _flush_lock.release()
 
+
+def _deliver(text, target_chat):
     max_len = 3900
     for i in range(0, len(text), max_len):
         chunk = text[i:i + max_len]
@@ -256,7 +302,34 @@ def send_message(text):
             )
         except Exception as exc:
             logger.exception(f"Send failed: {exc}")
-            return
+            return False
+    return True
+
+
+def send_message(text):
+    text = str(text).replace("\\n", "\n").replace("\r", "")
+    if not text:
+        return
+
+    with _state_lock:
+        target_chat = _chat_id
+
+    if not _connected or not target_chat:
+        # Sends issued before polling is up (or before a chat is bound) used
+        # to be dropped silently — most visibly the agent's first message
+        # right after launch, which races the adapter's first getUpdates.
+        _enqueue_pending(text)
+        return
+
+    _flush_pending()
+    with _state_lock:
+        drain_incomplete = bool(_pending)
+    if drain_incomplete:
+        # A failed drain left older messages queued — join the queue instead
+        # of overtaking them, so delivery order stays chronological.
+        _enqueue_pending(text)
+        return
+    _deliver(text, target_chat)
 
 class TelegramChannel(channels.CommChannel):
 


### PR DESCRIPTION
## Description
Messages sent through `send_message` while the poll loop hasn't connected yet (or before a
chat is bound) are dropped silently. The window is real: `_connected` only turns true once the
first `getUpdates` long-poll *returns* — up to `poll_timeout` seconds after start — so the first
thing an agent says after launch can vanish. We observed exactly this on a live instance
running the #240 logging: the agent's post-restart status message (106 chars, 15 s after boot)
was skipped — `[SEND_SKIP] connected=False bound=True` — while the agent's history recorded it
as sent. In auto-bind setups the loss is broader: everything sent before the first user DM is gone.

This PR queues unready sends and flushes them once the adapter is ready:

```
... | INFO     | telegram | [SEND_QUEUE] queued chars=106 (1 pending)
... | INFO     | telegram | [SEND_FLUSH] delivering queued message (0 left)
... | WARNING  | telegram | [SEND_QUEUE] full (50): dropped oldest queued message
... | WARNING  | telegram | [SEND_FLUSH] delivery failed, stopping drain (2 still queued)
```

Design notes:
- Bounded queue (50 messages; oldest dropped with a warning) — a pre-connect flood can't grow
  memory silently. Count-based bound; recency wins over stale boot messages.
- The flush runs from the poll loop after update processing, so a chat auto-bound in that very
  iteration is served immediately; the poll thread uses a non-blocking lock acquire so
  `getUpdates` never stalls behind a drain another thread is running. (When the poll thread
  drains itself, sends are inline — same as the existing auth confirmation on main.)
- Ordering is chronological end-to-end: a new ready send flushes the queue first, and if a
  failed drain left messages behind, it joins the queue instead of overtaking them.
- If a queued delivery fails mid-drain, the drain stops: the failed message is dropped
  (matching direct-send semantics today, and avoiding a poison message pinning the queue head)
  and the rest stays queued for the next poll-cycle flush — a rate-limit burst can't burn the
  whole queue in one failing drain.
- The queue intentionally survives `stop_telegram`/`start_telegram`, so an in-process reconnect
  loses nothing. Corollary (accepted): in auto-bind, messages queued before a rebind deliver to
  the newly bound chat — the same trust model as auto-bind itself.
- The chunked delivery path is unchanged — extracted into `_deliver()`, byte-identical apart
  from returning delivery success.

Possible follow-ups (not in this PR to keep it minimal): a bounded retry for the failed
head-of-line message with 429 `retry_after` backoff (would pair with #18, which proposes the
same for LLM-provider calls); a byte-size cap alongside the count bound.

Relation to #240 (send-status logging / chunk hardening): complementary — #240 made these drops
visible, this PR removes them; the queueing supersedes #240's `[SEND_SKIP]` log-and-drop in the
unready branch. Both touch `send_message`, so whichever lands second gets a mechanical rebase
(#240's per-chunk ok/fail counters map onto `_deliver`'s success return as `fails == 0`).
Suggested order: #240 first (older, smaller), this second.

## How Has This Been Tested?
`Autotests/unit/test_telegram_queue_until_connected.py` — 8 in-process unit tests
(module loaded by file path, `_api_call` stubbed; no container, network, or token), wired into
`Autotests/run_mandatory`: queued-not-dropped (disconnected, and connected-but-unbound),
in-order flush, ready-send-flushes-first, no overtaking after a failed drain, bounded drop,
drain stop on delivery failure, drain stop on mid-flush disconnect. The poll-loop trigger and
auth-bound enqueue paths are not unit-tested (driving `_poll_loop` needs a live thread — scope
cut).

Run: `pytest Autotests/unit/test_telegram_queue_until_connected.py`

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
