### PR TITLE
[OMEGA-239] Register the new memory safety tests in run_mandatory

### DIFF
--- a/Autotests/run_mandatory
+++ b/Autotests/run_mandatory
@@ -14,8 +14,10 @@ mock/test_llm.py
 mock/test_memory_chromadb_mock.py
 mock/test_memory_history_byte_window_truncation_mock.py
 mock/test_memory_history_mock.py
+mock/test_memory_missing_history_file_mock.py
 mock/test_memory_pin_window_visibility_mock.py
 mock/test_pin_invisible_within_iteration_mock.py
+mock/test_prompt_missing_files_mock.py
 mock/test_rpc.py
 mock/test_run_error_script_mock.py
 mock/test_run_repeated_mock.py


### PR DESCRIPTION
The two tests this branch adds are not listed in `Autotests/run_mandatory`, so CI
never collects them. The feature ships with tests that never run, and a regression
in the safe history/prompt reading would go unnoticed.

Both are plain `mock/` tests using the `llm`/`comm` fixtures and the same `-t test`
container `run_mandatory` already brings up, so nothing extra is needed to run them
in the existing CI job.

This registers them, in alphabetical order:
- mock/test_memory_missing_history_file_mock.py
- mock/test_prompt_missing_files_mock.py

Verified on this branch head (e35f694):
- pytest --collect-only @run_mandatory: 52 tests collected (was 49)
- run_mandatory: 52 passed
- Without the OMEGA-239 change the same three cases fail ("Agent did not respond",
  "Agent crashed or failed to respond due to missing prompt"), with it they pass.
