### PR TITLE
[FIX] Redact/gate raw LLM response logging (privacy)

### DIFF
--- a/Autotests/run_mandatory
+++ b/Autotests/run_mandatory
@@ -33,4 +33,5 @@ mock/test_transition_episodes_after_eviction_mock.py
 mock/test_transition_metta_to_remember_mock.py
 mock/test_transition_pin_to_remember_mock.py
 mock_websocket/test_wschat_unit.py
+test_llm_logging.py
 test_websearch_smoke.py

--- a/Autotests/test_llm_logging.py
+++ b/Autotests/test_llm_logging.py
@@ -1,0 +1,184 @@
+"""Unit tests for gated/redacted raw LLM response logging (Issue #3).
+
+Pure-Python: no Docker. ``lib_llm_ext`` imports ``openai``, which is not installed
+on the host/CI runner, so we stub it before import. Runs under pytest and as a
+standalone script (``python3 Autotests/test_llm_logging.py``).
+"""
+import io
+import json
+import os
+import sys
+import tempfile
+import types
+from contextlib import redirect_stdout
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# `lib_llm_ext` moved into the providers/ package during the upstream plugin migration; add both
+# providers/ (so `import lib_llm_ext` resolves) and the repo root (so its `from src.*` imports work).
+_PROVIDERS = os.path.join(_REPO_ROOT, "providers")
+for _p in (_PROVIDERS, _REPO_ROOT):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# Stub openai so `import lib_llm_ext` works without the real dependency.
+# `openai.OpenAI` is referenced in a type annotation evaluated at import time.
+if "openai" not in sys.modules:
+    _openai_stub = types.ModuleType("openai")
+    _openai_stub.OpenAI = object  # satisfies `Optional[openai.OpenAI]`
+    sys.modules["openai"] = _openai_stub
+
+import lib_llm_ext as llm  # noqa: E402
+
+# A response mixing normal prose with several secret shapes.
+GH_TOKEN = "ghp_" + "A1b2C3d4E5f6G7h8I9j0" + "KLMNOP"
+GH_PAT = "github_pat_" + "11ABCDEFG0" + "abcdefghijklmnopqrstuv"
+OPENAI_KEY = "sk-" + "A1b2C3d4E5f6G7h8I9j0K1l2"
+ANTHROPIC_KEY = "sk-ant-" + "api03-" + "ZyXwVuTsRqPoNmLkJiHg"
+BEARER = "Bearer abcDEF123456ghiJKL789"
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+B64_SECRET = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIzNDU2Nzg5"  # >=40
+SECRETS = [GH_TOKEN, GH_PAT, OPENAI_KEY, ANTHROPIC_KEY, "abcDEF123456ghiJKL789", AWS_KEY, B64_SECRET]
+
+RESPONSE = (
+    "Sure, here is the plan. Use this GitHub token " + GH_TOKEN + " and PAT " + GH_PAT +
+    ". OpenAI key " + OPENAI_KEY + ", Anthropic " + ANTHROPIC_KEY +
+    ". Auth header: " + BEARER + ". AWS " + AWS_KEY + ". blob=" + B64_SECRET + ". Done."
+)
+NORMAL_SENTINEL = "here is the plan"
+
+
+def _capture_log(**env):
+    """Run _log_raw under a temporary env and return captured stdout."""
+    saved = {k: os.environ.get(k) for k in ("OMEGACLAW_DEBUG_LLM_RAW", "OMEGACLAW_LLM_LOG_PATH")}
+    for k in saved:
+        os.environ.pop(k, None)
+    os.environ.update({k: v for k, v in env.items() if v is not None})
+    buf = io.StringIO()
+    try:
+        with redirect_stdout(buf):
+            llm._log_raw("OpenAI", "gpt-test", RESPONSE)
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    return buf.getvalue()
+
+
+# --- default (no raw) ----------------------------------------------------
+
+def test_default_logs_metadata_not_raw():
+    out = _capture_log()
+    assert "[LLM_RAW]" in out
+    assert "provider=OpenAI" in out and "model=gpt-test" in out
+    assert "chars=%d" % len(RESPONSE) in out
+    assert "trace=" in out
+    assert "<redacted; set OMEGACLAW_DEBUG_LLM_RAW=1>" in out
+    # The raw body and its secrets must NOT appear.
+    assert NORMAL_SENTINEL not in out
+    for s in SECRETS:
+        assert s not in out, f"secret leaked by default: {s!r}"
+
+
+def test_default_never_leaks_github_token():
+    out = _capture_log()
+    assert GH_TOKEN not in out and GH_PAT not in out
+
+
+# --- debug (raw, redacted) ----------------------------------------------
+
+def test_debug_shows_redacted_raw():
+    out = _capture_log(OMEGACLAW_DEBUG_LLM_RAW="1")
+    # raw context is present (normal prose shows through)...
+    assert NORMAL_SENTINEL in out
+    # ...but no secret appears verbatim.
+    for s in SECRETS:
+        assert s not in out, f"secret leaked in debug mode: {s!r}"
+    assert "[REDACTED:" in out
+
+
+def test_debug_truthy_values():
+    for val in ("1", "true", "YES", "on"):
+        out = _capture_log(OMEGACLAW_DEBUG_LLM_RAW=val)
+        assert NORMAL_SENTINEL in out, f"{val} should enable raw"
+    # a falsey value stays default
+    out = _capture_log(OMEGACLAW_DEBUG_LLM_RAW="0")
+    assert NORMAL_SENTINEL not in out
+
+
+# --- redact_secrets unit -------------------------------------------------
+
+def test_redact_each_pattern():
+    cases = {
+        "openai": OPENAI_KEY,
+        "anthropic": ANTHROPIC_KEY,
+        "github_ghp": GH_TOKEN,
+        "github_pat": GH_PAT,
+        "aws": AWS_KEY,
+        "base64": B64_SECRET,
+    }
+    for name, secret in cases.items():
+        red = llm.redact_secrets(f"value is {secret} end")
+        assert secret not in red, f"{name} not redacted: {red}"
+        assert "[REDACTED:" in red
+
+
+def test_redact_bearer_keeps_scheme():
+    red = llm.redact_secrets("Authorization: " + BEARER)
+    assert "abcDEF123456ghiJKL789" not in red
+    assert "Bearer" in red and "[REDACTED:bearer]" in red
+
+
+def test_redact_preserves_normal_text():
+    text = "The quick brown fox jumps over the lazy dog 42 times."
+    assert llm.redact_secrets(text) == text
+
+
+# --- JSONL log -----------------------------------------------------------
+
+def test_jsonl_metadata_only_by_default():
+    with tempfile.NamedTemporaryFile("r", suffix=".jsonl", delete=False) as f:
+        path = f.name
+    try:
+        _capture_log(OMEGACLAW_LLM_LOG_PATH=path)
+        with open(path) as fh:
+            rec = json.loads(fh.readline())
+        assert rec["provider"] == "OpenAI" and rec["chars"] == len(RESPONSE) and "trace" in rec
+        assert "raw" not in rec  # no raw by default
+    finally:
+        os.unlink(path)
+
+
+def test_jsonl_includes_redacted_raw_in_debug():
+    with tempfile.NamedTemporaryFile("r", suffix=".jsonl", delete=False) as f:
+        path = f.name
+    try:
+        _capture_log(OMEGACLAW_DEBUG_LLM_RAW="1", OMEGACLAW_LLM_LOG_PATH=path)
+        with open(path) as fh:
+            rec = json.loads(fh.readline())
+        assert "raw" in rec
+        for s in SECRETS:
+            assert s not in rec["raw"], f"secret leaked in JSONL: {s!r}"
+    finally:
+        os.unlink(path)
+
+
+def _run_standalone():
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+    if failures:
+        print(f"\n{failures} test(s) failed")
+        sys.exit(1)
+    print("\nall llm logging tests passed")
+
+
+if __name__ == "__main__":
+    _run_standalone()

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ If you want to skip preloading the knowledge then run `export IMPORT_KB_ON_START
 | `TG_BOT_TOKEN` | Telegram bot token. |
 | `MM_BOT_TOKEN` | Mattermost bot token. |
 | `SL_BOT_TOKEN` | Slack bot token (`xoxb-...`). |
+| `OMEGACLAW_DEBUG_LLM_RAW` | `1`/`true` to log raw model responses (for debugging). Default off — raw bodies are **not** logged; only metadata (provider, model, timestamp, char count, trace id). When enabled, common secret/token formats are best-effort redacted (not a guarantee). |
+| `OMEGACLAW_LLM_LOG_PATH` | Optional path to append per-response JSONL log records (metadata always; redacted raw only when `OMEGACLAW_DEBUG_LLM_RAW` is set). |
 
 ---
 

--- a/providers/lib_llm_ext.py
+++ b/providers/lib_llm_ext.py
@@ -1,16 +1,55 @@
 import os, hashlib
+import json
+import time
+import uuid
 import openai
 from typing import Optional, Tuple, Dict, Any
 
 PROMPT_DELIMITER = ":-:-:-:"
 
 from src.logger import get_logger
+# Shared redactor (Issue #3) — kept dependency-light so logging never leaks secrets/PII.
+try:
+    from src.redaction import redact_secrets
+except ImportError:  # pragma: no cover - flat import path
+    from redaction import redact_secrets
 
 
 logger = get_logger(__name__)
 
+
+def _raw_logging_enabled() -> bool:
+    return (os.environ.get("OMEGACLAW_DEBUG_LLM_RAW") or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _log_raw(provider: str, model: str, raw: str) -> None:
-    logger.debug(f"[LLM_RAW] provider={provider} model={model} chars={len(raw or '')} raw={raw!r}")
+    """Redacted, gated raw-response logging (Issue #3, ported onto the plugin providers package).
+
+    Metadata only by default; the raw body is emitted (redacted via
+    ``src.redaction.redact_secrets``) ONLY when ``OMEGACLAW_DEBUG_LLM_RAW`` is set. Optional JSONL
+    sink via ``OMEGACLAW_LLM_LOG_PATH``. This replaces upstream's ``raw={raw!r}`` debug line, which
+    would emit unredacted model output to the logs (a privacy regression for this fork)."""
+    ts = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
+    raw = raw or ""
+    chars = len(raw)
+    trace = uuid.uuid4().hex[:8]
+    debug = _raw_logging_enabled()
+
+    body = repr(redact_secrets(raw)) if debug else "<redacted; set OMEGACLAW_DEBUG_LLM_RAW=1>"
+    # Issue #3 contract: the metadata line is ALWAYS observable (never gated behind a log level),
+    # so it uses print rather than logger.debug (which config/logging.conf suppresses at INFO).
+    print(f"[LLM_RAW] ts={ts} trace={trace} provider={provider} model={model} chars={chars} raw={body}")
+
+    log_path = os.environ.get("OMEGACLAW_LLM_LOG_PATH")
+    if log_path:
+        record = {"ts": ts, "trace": trace, "provider": provider, "model": model, "chars": chars}
+        if debug:
+            record["raw"] = redact_secrets(raw)
+        try:
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except OSError as exc:  # best-effort; never break the chat path
+            print(f"[LLM_RAW] WARNING could not write OMEGACLAW_LLM_LOG_PATH ({log_path}): {exc}")
 
 def _split_system_user(content: str) -> Tuple[str, str]:
     """
@@ -157,5 +196,3 @@ def useLocalEmbedding(atom):
         atom,
         normalize_embeddings=True
     ).tolist()
-
-

--- a/src/redaction.py
+++ b/src/redaction.py
@@ -1,0 +1,59 @@
+"""Best-effort secret redaction (extracted from lib_llm_ext.py for Issue #3/#7 reuse).
+
+Stdlib-only, no third-party imports, so both ``lib_llm_ext`` (raw LLM logging) and
+``tracing`` (reasoning traces, Issue #7) can share one redactor without pulling in ``openai``.
+It detects common secret/token formats plus long base64-ish runs and replaces them with a
+typed ``[REDACTED:<kind>]`` marker. Best-effort: it does not guarantee every secret is caught.
+"""
+
+import re
+
+_REDACTION_PATTERNS = [
+    # Anthropic keys (check before the generic sk- rule).
+    ("anthropic_key", re.compile(r"sk-ant-[A-Za-z0-9_\-]{8,}")),
+    # OpenAI keys, incl. project keys (sk-, sk-proj-).
+    ("openai_key", re.compile(r"sk-(?:proj-)?[A-Za-z0-9_\-]{16,}")),
+    # GitHub tokens: ghp_/gho_/ghu_/ghs_/ghr_ and fine-grained github_pat_.
+    ("github_token", re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})\b")),
+    # AWS access key id.
+    ("aws_key", re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b")),
+    # HTTP bearer tokens (redact the token, keep the scheme).
+    ("bearer", re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._\-]{12,}")),
+    # Long high-entropy-ish base64/hex runs (>=40 chars). Conservative: requires a
+    # contiguous token of base64 alphabet, so normal prose is not mangled.
+    ("secret", re.compile(r"\b[A-Za-z0-9+/_\-]{40,}={0,2}\b")),
+]
+
+
+def redact_secrets(text: str) -> str:
+    """Replace secret-looking substrings with a typed ``[REDACTED:<kind>]`` marker.
+
+    Best-effort: detects common secret/token formats (known key/token shapes plus
+    long base64-ish runs) and leaves ordinary text intact. It does not guarantee
+    that every possible secret is caught.
+    """
+    if not text:
+        return text
+    out = text
+    for kind, pattern in _REDACTION_PATTERNS:
+        if kind == "bearer":
+            out = pattern.sub(lambda m: f"{m.group(1)}[REDACTED:bearer]", out)
+        else:
+            out = pattern.sub(f"[REDACTED:{kind}]", out)
+    return out
+
+
+def _selftest():
+    """Lightweight self-tests runnable without pytest/Docker."""
+    assert redact_secrets("key sk-ant-abcd1234efgh").endswith("[REDACTED:anthropic_key]")
+    assert "[REDACTED:openai_key]" in redact_secrets("use sk-proj-ABCDEFGHIJKLMNOP1234")
+    assert "[REDACTED:github_token]" in redact_secrets("tok ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345")
+    assert "[REDACTED:aws_key]" in redact_secrets("id AKIAIOSFODNN7EXAMPLE here")
+    assert "Bearer [REDACTED:bearer]" in redact_secrets("Authorization: Bearer abcdef123456ghijkl")
+    assert redact_secrets("just some ordinary text") == "just some ordinary text"
+    assert redact_secrets("") == ""
+    print("redaction self-tests passed")
+
+
+if __name__ == "__main__":
+    _selftest()


### PR DESCRIPTION
## Description
Fixes #265. `providers/lib_llm_ext.py::_log_raw` previously logged the raw model response verbatim (`raw={raw!r}`), which can persist private user text, tool results, or echoed credentials to logs. This change makes it **metadata-only by default** (provider, model, timestamp, char count, trace id). The raw body is emitted **only** when `OMEGACLAW_DEBUG_LLM_RAW` is set, and even then is passed through a best-effort secret redactor (`src/redaction.py`, stdlib-only) that masks common OpenAI/Anthropic keys, GitHub/AWS tokens, bearer tokens, and long base64-ish secrets as `[REDACTED:<kind>]`. An optional JSONL sink (`OMEGACLAW_LLM_LOG_PATH`) records the same metadata (plus redacted raw only in debug). Both env vars are documented in the README configuration table.

`src/redaction.py` is stdlib-only and import-light, so logging never pulls heavy deps and cannot itself leak.

## How Has This Been Tested?
Added `Autotests/test_llm_logging.py` (host-runnable, `openai` stubbed — no network), registered in `Autotests/run_mandatory`. Scenarios:
- default logs metadata, not the raw body;
- default never leaks a GitHub token embedded in a response;
- `OMEGACLAW_DEBUG_LLM_RAW=1` shows the raw body redacted;
- each redaction pattern masks its secret while preserving surrounding text;
- JSONL sink writes metadata-only by default and redacted-raw in debug.

Run: `cd Autotests && python3 test_llm_logging.py` → all pass. `python3 src/redaction.py` runs its self-test.

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
