### PR TITLE
[OMEGA-313] feat: scheduled agent tasks (omegaclaw-cron)

### DIFF
--- a/Autotests/run_mandatory
+++ b/Autotests/run_mandatory
@@ -33,4 +33,5 @@ mock/test_transition_episodes_after_eviction_mock.py
 mock/test_transition_metta_to_remember_mock.py
 mock/test_transition_pin_to_remember_mock.py
 mock_websocket/test_wschat_unit.py
+test_scheduler.py
 test_websearch_smoke.py

--- a/Autotests/test_scheduler.py
+++ b/Autotests/test_scheduler.py
@@ -25,11 +25,15 @@ def _db():
     d = tempfile.mkdtemp(prefix="sch_")
     os.environ["OMEGACLAW_JOBS_DB"] = os.path.join(d, "jobs.db")
     os.environ["OMEGACLAW_SESSION_DB"] = os.path.join(d, "s.db")
+    # keep the durable-outbox default sink out of the repo's memory/ during tests
+    os.environ["OMEGACLAW_CRON_OUTBOX"] = os.path.join(d, "outbox.jsonl")
     sch.reset(os.environ["OMEGACLAW_JOBS_DB"])
+    return d
 
 
 def _clean():
-    for k in ("OMEGACLAW_JOBS_DB", "OMEGACLAW_SESSION_DB"):
+    for k in ("OMEGACLAW_JOBS_DB", "OMEGACLAW_SESSION_DB", "OMEGACLAW_CRON_OUTBOX",
+              "OMEGACLAW_JOB_WORKDIR_ROOTS"):
         os.environ.pop(k, None)
 
 
@@ -313,6 +317,101 @@ def test_run_now_does_not_resume_paused_or_reschedule():
         assert after["enabled"] == 0                       # still paused
         assert after["next_run"] == before["next_run"]     # not rescheduled
         assert sch.get_job("other")["last_status"] is None  # unrelated due job untouched
+    finally:
+        _clean()
+
+
+def test_setup_failure_isolated_from_tick():
+    """PR #276 review: a job whose SETUP raises (here: a workdir whose parent is a file, so
+    ``os.makedirs`` fails) must fail only ITSELF — the surrounding run_due() heartbeat must still
+    fire the other jobs due this tick (pre-fix, the exception aborted the whole tick)."""
+    d = _db()
+    try:
+        root = os.path.join(d, "roots")
+        os.makedirs(root)
+        os.environ["OMEGACLAW_JOB_WORKDIR_ROOTS"] = root
+        blocker = os.path.join(root, "blocker")           # a FILE where a dir is expected
+        open(blocker, "w").close()
+        bad_wd = os.path.join(blocker, "sub")             # passes the policy check, fails makedirs
+        assert sch.create_job("bad", "once", str(T0), workdir=bad_wd, now=T0)["ok"]
+        sch.create_job("good", "once", str(T0), prompt="p", now=T0)
+        ran, alerts = [], []
+        r = sch.run_due(now=T0 + 1, runner=lambda j, c: ran.append(j["id"]) or "ok",
+                        alert_fn=lambda j, m: alerts.append(j["id"]))
+        assert r["count"] == 2                            # tick did NOT abort
+        assert "good" in ran                              # the healthy job still fired
+        assert sch.get_job("good")["last_status"] == "ok"
+        assert sch.get_job("bad")["last_status"] == "error" and "bad" in alerts
+    finally:
+        _clean()
+
+
+def test_temp_workdir_created_then_cleaned_up():
+    """PR #276 review: a job with no explicit workdir gets a temp dir that exists DURING the run
+    and is removed AFTER — so a scheduled job can't leak a /tmp dir on every fire."""
+    _db()
+    try:
+        sch.create_job("t", "once", str(T0), prompt="p", now=T0)
+        seen = {}
+
+        def runner(job, ctx):
+            seen["wd"] = ctx["workdir"]
+            seen["during"] = os.path.isdir(ctx["workdir"])
+            return "ok"
+
+        sch.run_due(now=T0 + 1, runner=runner)
+        assert seen["during"] is True                     # available while the job runs
+        assert not os.path.exists(seen["wd"])             # cleaned up afterwards (no leak)
+    finally:
+        _clean()
+
+
+def test_workdir_policy_enforced_at_create():
+    """PR #276 review: a configured workdir is validated against the io-policy read_write roots —
+    inside is accepted, outside is rejected, undeterminable (no roots) is not blocked."""
+    d = _db()
+    try:
+        root = os.path.join(d, "allowed")
+        os.makedirs(root)
+        os.environ["OMEGACLAW_JOB_WORKDIR_ROOTS"] = root
+        assert sch.create_job("ins", "once", str(T0), workdir=os.path.join(root, "j"), now=T0)["ok"]
+        r = sch.create_job("out", "once", str(T0), workdir=os.path.join(d, "elsewhere"), now=T0)
+        assert r["ok"] is False and "io policy" in r["error"]
+        os.environ["OMEGACLAW_JOB_WORKDIR_ROOTS"] = ""     # explicitly undeterminable -> allow
+        assert sch.create_job("free", "once", str(T0), workdir="/anywhere/x", now=T0)["ok"]
+    finally:
+        _clean()
+
+
+def test_daemon_run_forever_fires_due_job():
+    """PR #276 review: run_forever() is the operator that actually drives the store — it fires a
+    due job on its own, sleeps BETWEEN ticks (not after the last), and is bounded by iterations."""
+    _db()
+    try:
+        # next_run is seeded far in the past (T0 ~ 1970) vs the real clock run_forever uses -> due
+        sch.create_job("iv", "interval", "60", prompt="p", delivery="chan", now=T0)
+        ran, slept = [], []
+        r = sch.run_forever(interval=5, iterations=2, sleep_fn=lambda s: slept.append(s),
+                            runner=lambda j, c: ran.append(j["id"]) or "out")
+        assert r["ticks"] == 2 and r["fired_total"] == 1
+        assert ran == ["iv"]                              # fired once, then no longer due
+        assert slept == [5]                               # slept between the two ticks only
+    finally:
+        _clean()
+
+
+def test_default_delivery_writes_to_outbox():
+    """PR #276 review: a fired job's output reaches a durable sink even with no delivery_fn wired —
+    run_due falls back to the outbox JSONL so results are captured, not silently dropped."""
+    _db()
+    try:
+        sch.create_job("d", "once", str(T0), prompt="p", delivery="chan", now=T0)
+        sch.run_due(now=T0 + 1)                            # default runner + no delivery_fn
+        outbox = os.environ["OMEGACLAW_CRON_OUTBOX"]
+        assert os.path.exists(outbox)
+        with open(outbox, encoding="utf-8") as fh:
+            recs = [json.loads(line) for line in fh if line.strip()]
+        assert any(x["job"] == "d" and x["kind"] == "delivery" and x["text"] for x in recs)
     finally:
         _clean()
 

--- a/Autotests/test_scheduler.py
+++ b/Autotests/test_scheduler.py
@@ -1,0 +1,332 @@
+"""Unit tests for the cron/webhook scheduler (Issue #17).
+
+Pure-Python; imports src/scheduler.py directly against a temp jobs DB with an INJECTED clock
+(deterministic — no real waiting). Runs under pytest and standalone.
+"""
+import hashlib
+import hmac
+import json
+import os
+import sys
+import tempfile
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SRC = os.path.join(_REPO_ROOT, "src")
+for _p in (_SRC, _REPO_ROOT):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import scheduler as sch  # noqa: E402
+
+T0 = 1_000_000.0
+
+
+def _db():
+    d = tempfile.mkdtemp(prefix="sch_")
+    os.environ["OMEGACLAW_JOBS_DB"] = os.path.join(d, "jobs.db")
+    os.environ["OMEGACLAW_SESSION_DB"] = os.path.join(d, "s.db")
+    sch.reset(os.environ["OMEGACLAW_JOBS_DB"])
+
+
+def _clean():
+    for k in ("OMEGACLAW_JOBS_DB", "OMEGACLAW_SESSION_DB"):
+        os.environ.pop(k, None)
+
+
+def test_once_fires_once_then_done():
+    _db()
+    try:
+        ran = []
+        sch.create_job("o1", "once", str(T0 + 10), prompt="hi", now=T0)
+        assert sch.run_due(now=T0 + 5, runner=lambda j, c: ran.append(j["id"]))["count"] == 0
+        assert sch.run_due(now=T0 + 11, runner=lambda j, c: ran.append(j["id"]) or "out")["count"] == 1
+        assert sch.get_job("o1")["next_run"] is None                # done
+        assert sch.run_due(now=T0 + 999, runner=lambda j, c: "x")["count"] == 0
+        assert ran == ["o1"]
+    finally:
+        _clean()
+
+
+def test_interval_reschedules_and_cron_creates():
+    _db()
+    try:
+        sch.create_job("iv", "interval", "60", now=T0)
+        before = sch.get_job("iv")["next_run"]
+        sch.run_due(now=before + 0.1, runner=lambda j, c: "tick")
+        assert sch.get_job("iv")["next_run"] > before
+        assert sch.create_job("cr", "cron", "*/5 * * * *", now=T0)["ok"]
+        assert sch.create_job("bad", "cron", "not a cron", now=T0)["ok"] is False
+    finally:
+        _clean()
+
+
+def test_unsafe_id_and_runaway_interval_rejected():
+    _db()
+    try:
+        assert sch.create_job("../x", "once", str(T0))["ok"] is False
+        assert sch.create_job("a/b", "once", str(T0))["ok"] is False
+        assert sch.create_job("toofast", "interval", "0.1", now=T0)["ok"] is False
+    finally:
+        _clean()
+
+
+def test_restart_recovery_no_lost_or_duplicate():
+    _db()
+    try:
+        sch.create_job("survive", "once", str(T0), prompt="x", now=T0)
+        # "restart" = a fresh run_due call on the same persisted DB, long overdue
+        f1 = sch.run_due(now=T0 + 5000, runner=lambda j, c: "out")
+        f2 = sch.run_due(now=T0 + 9000, runner=lambda j, c: "out")
+        assert [f["id"] for f in f1["fired"]] == ["survive"]        # not lost
+        assert f2["count"] == 0                                     # not duplicated
+    finally:
+        _clean()
+
+
+def test_failure_alerts_and_empty_policy():
+    _db()
+    try:
+        alerts = []
+
+        def alert(job, msg):
+            alerts.append(job["id"])
+
+        sch.create_job("boom", "once", str(T0), prompt="boom", now=T0)
+        sch.run_due(now=T0 + 1, runner=lambda j, c: (_ for _ in ()).throw(RuntimeError("x")),
+                    alert_fn=alert)
+        assert "boom" in alerts
+
+        sch.create_job("silent", "once", str(T0), now=T0, on_empty="silent")
+        sch.create_job("noisy", "once", str(T0), now=T0, on_empty="alert")
+        a2 = []
+        sch.run_due(now=T0 + 1, runner=lambda j, c: "", alert_fn=lambda j, m: a2.append(j["id"]))
+        assert "noisy" in a2 and "silent" not in a2
+    finally:
+        _clean()
+
+
+def test_delivery_only_on_nonempty_success():
+    _db()
+    try:
+        delivered = []
+        sch.create_job("d", "once", str(T0), prompt="p", delivery="chan", now=T0)
+        sch.run_due(now=T0 + 1, runner=lambda j, c: "hello",
+                    delivery_fn=lambda job, out: delivered.append((job["id"], out)))
+        assert delivered == [("d", "hello")]
+    finally:
+        _clean()
+
+
+def test_context_chaining():
+    _db()
+    try:
+        sch.create_job("first", "once", str(T0), now=T0)
+        sch.run_due(now=T0 + 1, runner=lambda j, c: "FIRST-OUTPUT")
+        seen = {}
+        sch.create_job("second", "once", str(T0 + 5), chain_from="first", now=T0)
+        sch.run_due(now=T0 + 6, runner=lambda j, c: seen.setdefault("chain", c["chain_output"]) or "ok")
+        assert seen["chain"] == "FIRST-OUTPUT"
+    finally:
+        _clean()
+
+
+def test_recursion_guard():
+    _db()
+    try:
+        sch.create_job("r", "once", str(T0), now=T0)
+
+        def _runner(job, ctx):
+            return "nested=" + str(sch.create_job("child", "once", str(T0), now=T0)["ok"])
+
+        sch.run_due(now=T0 + 1, runner=_runner)
+        assert "nested=False" in sch.get_job("r")["last_output"]
+        assert sch.get_job("child") is None
+    finally:
+        _clean()
+
+
+def test_cron_respects_all_five_fields():
+    """Regression (PR #42 review): a `*` DOW must not short-circuit the minute/hour/dom/mon
+    checks (daily/monthly specs were firing every minute)."""
+    import calendar
+    import time as _t
+
+    def gm(s):
+        return _t.gmtime(calendar.timegm(_t.strptime(s, "%Y-%m-%d %H:%M")))
+
+    # 0 0 * * * must NOT match midday, and its next fire is the next midnight
+    assert sch._cron_matches("0 0 * * *", gm("2026-07-08 12:34")) is False
+    nxt = sch._cron_next("0 0 * * *", calendar.timegm(_t.strptime("2026-07-08 12:34", "%Y-%m-%d %H:%M")))
+    assert _t.strftime("%Y-%m-%d %H:%M", _t.gmtime(nxt)) == "2026-07-09 00:00"
+    # */5 from an off-minute → next 5-minute boundary
+    off = calendar.timegm(_t.strptime("2026-07-08 12:34", "%Y-%m-%d %H:%M"))
+    assert _t.strftime("%H:%M", _t.gmtime(sch._cron_next("*/5 * * * *", off))) == "12:35"
+    # DOW-specific spec: matches only when minute/hour also match (2026-07-06 is a Monday)
+    assert sch._cron_matches("0 9 * * 1", gm("2026-07-06 09:00")) is True
+    assert sch._cron_matches("30 9 * * 1", gm("2026-07-06 09:00")) is False   # minute mismatch
+    assert sch._cron_matches("0 9 * * 1", gm("2026-07-07 09:00")) is False    # Tuesday
+
+
+def test_webhook_transient_id_never_deletes_durable_job():
+    """Regression (PR #42 review): a webhook's transient job must not delete a pre-existing
+    durable job even if the generated id collides."""
+    import uuid
+    _db()
+    try:
+        sch.webhook_subscribe("gh", "", {"prompt": "x"})
+        fixed = "abcdef0123456789"
+
+        class _U:
+            hex = fixed
+        orig = uuid.uuid4
+        uuid.uuid4 = lambda: _U()
+        try:
+            sch.create_job("wh-gh-" + fixed, "once", "9999999999", prompt="DURABLE", now=0)
+            r = sch.webhook_event("gh", {"e": "push"}, runner=lambda j, c: "ok")
+        finally:
+            uuid.uuid4 = orig
+        assert r["ok"] is False and "already exists" in (r.get("error") or "")
+        assert sch.get_job("wh-gh-" + fixed) is not None          # durable job survived
+        assert sch.get_job("wh-gh-" + fixed)["prompt"] == "DURABLE"
+    finally:
+        _clean()
+
+
+def test_concurrent_heartbeats_run_due_occurrence_once():
+    """Regression (PR #42 re-review): two heartbeats that both SELECT the same due row (stale
+    select) must not both execute it — the atomic claim (CAS on next_run) lets exactly one win."""
+    _db()
+    try:
+        sch.create_job("race", "once", str(T0), prompt="hi", now=T0)
+        # both heartbeats selected the same due row at the same next_run
+        stale = sch.due_jobs(T0 + 1)[0]
+        ran = []
+        c1, c2 = sch.connect(), sch.connect()
+        try:
+            r1 = sch._execute_one(dict(stale), T0 + 1, lambda j, c: ran.append(j["id"]) or "o",
+                                  c1, advance=True)
+            r2 = sch._execute_one(dict(stale), T0 + 1, lambda j, c: ran.append(j["id"]) or "o",
+                                  c2, advance=True)
+        finally:
+            c1.close()
+            c2.close()
+        assert ran == ["race"], ran                    # ran exactly once
+        assert r1 is not None and r2 is None            # second lost the atomic claim
+        assert sch.get_job("race")["fires"] == 1        # persisted fire count reflects one run
+    finally:
+        _clean()
+
+
+def test_concurrent_run_due_threads_fire_once():
+    """Two concurrent run_due() threads racing the same due row fire it exactly once."""
+    import threading
+    _db()
+    try:
+        sch.create_job("r", "interval", "60", now=T0)
+        ran = []
+        barrier = threading.Barrier(2)
+        orig = sch.due_jobs
+
+        def patched(now, conn=None):
+            d = orig(now, conn=conn)
+            try:
+                barrier.wait(timeout=5)                 # both hold the due row before advancing
+            except threading.BrokenBarrierError:
+                pass
+            return d
+
+        sch.due_jobs = patched
+        try:
+            threads = [threading.Thread(target=lambda: sch.run_due(now=T0 + 5000,
+                                                                   runner=lambda j, c: ran.append(1)))
+                       for _ in range(2)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+        finally:
+            sch.due_jobs = orig
+        assert len(ran) == 1, ran
+        assert sch.get_job("r")["fires"] == 1
+    finally:
+        _clean()
+
+
+def test_webhook_signature_validation():
+    _db()
+    try:
+        secret = "shh"
+        sch.webhook_subscribe("gh", secret, {"prompt": "handle"})
+        payload = {"event": "push", "n": 1}
+        raw = json.dumps(payload, sort_keys=True).encode("utf-8")
+        good = hmac.new(secret.encode(), raw, hashlib.sha256).hexdigest()
+        assert sch.webhook_event("gh", payload, good, runner=lambda j, c: "ok")["ok"]
+        assert sch.webhook_event("gh", payload, "bad").get("rejected") is True
+        assert sch.webhook_event("gh", payload, None).get("rejected") is True
+        # unknown subscription
+        assert sch.webhook_event("nope", payload, good)["ok"] is False
+    finally:
+        _clean()
+
+
+def test_webhook_runner_receives_event_payload():
+    """Regression (PR #42 re-review): the runner must get the validated (nested) event in ctx."""
+    _db()
+    try:
+        sch.webhook_subscribe("gh", "", {"prompt": "handle"})
+        seen = {}
+        sch.webhook_event("gh", {"issue": {"title": "bug", "number": 7}, "repo": "acme"},
+                          runner=lambda job, ctx: seen.update({"event": ctx.get("event")}) or "ok")
+        assert seen["event"] == {"issue": {"title": "bug", "number": 7}, "repo": "acme"}
+    finally:
+        _clean()
+
+
+def test_invalid_cron_fails_closed():
+    """Regression (PR #42 re-review): a malformed cron (*/0, out-of-range, non-int) returns a
+    structured error instead of crashing (ZeroDivisionError) or silently never firing."""
+    _db()
+    try:
+        assert sch.create_job("z", "cron", "*/0 * * * *", now=T0)["ok"] is False
+        assert sch.create_job("r", "cron", "99 * * * *", now=T0)["ok"] is False
+        assert sch.create_job("n", "cron", "x * * * *", now=T0)["ok"] is False
+        assert sch.create_job("f", "cron", "* * *", now=T0)["ok"] is False       # wrong field count
+        assert sch.create_job("ok", "cron", "*/5 0 * * 1", now=T0)["ok"] is True  # valid still works
+    finally:
+        _clean()
+
+
+def test_run_now_does_not_resume_paused_or_reschedule():
+    """Regression (PR #42 re-review): a one-off `run` must not resume a paused job or change its
+    next_run, and must not fire other due jobs."""
+    _db()
+    try:
+        sch.create_job("p", "interval", "60", prompt="hi", now=T0)
+        sch.pause("p")
+        # an unrelated job is also due — run_now must NOT fire it
+        other = []
+        sch.create_job("other", "once", str(T0), now=T0)
+        before = sch.get_job("p")
+        r = sch.run_now("p", runner=lambda j, c: "done")
+        after = sch.get_job("p")
+        assert r["ok"] and r["fired"]["status"] == "ok"
+        assert after["enabled"] == 0                       # still paused
+        assert after["next_run"] == before["next_run"]     # not rescheduled
+        assert sch.get_job("other")["last_status"] is None  # unrelated due job untouched
+    finally:
+        _clean()
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print("ok:", fn.__name__)
+        except AssertionError as e:
+            failed += 1
+            print("FAIL:", fn.__name__, e)
+    if failed:
+        sys.exit(1)
+    print(f"\nAll {len(fns)} scheduler tests passed")

--- a/scripts/omegaclaw-cron
+++ b/scripts/omegaclaw-cron
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""OmegaClaw scheduler CLI — cron / interval / one-shot jobs + webhook subscriptions (Issue #17).
+
+  cron create <id> --kind once|interval|cron --spec <spec> [--prompt ..] [--on-empty silent|alert]
+  cron list | show <id> | pause <id> | resume <id> | remove <id>
+  cron run <id>                          force-run a job now
+  cron tick                              fire everything currently due (scheduler heartbeat)
+  cron webhook subscribe <id> --secret S [--prompt ..]
+  cron webhook list | remove <id>
+  cron webhook event <id> --payload '{...}' [--signature HEX]
+
+DB path: OMEGACLAW_JOBS_DB (default memory/jobs.db). Durable — survives restart.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_REPO_ROOT, "src"))
+
+import scheduler as sch  # noqa: E402
+
+
+def _out(args, obj, text):
+    if getattr(args, "json", False):
+        print(json.dumps(obj, indent=2, default=str))
+    else:
+        print(text)
+    return 0 if obj.get("ok", True) else 1
+
+
+def cmd_create(args):
+    r = sch.create_job(args.id, args.kind, args.spec, prompt=args.prompt or "",
+                       on_empty=args.on_empty, chain_from=args.chain_from or "")
+    return _out(args, r, "created {} ({}, next_run={})".format(args.id, args.kind, r.get("next_run"))
+                if r.get("ok") else "error: {}".format(r.get("error")))
+
+
+def cmd_list(args):
+    jobs = sch.list_jobs()
+    lines = ["jobs ({}):".format(len(jobs))]
+    for j in jobs:
+        lines.append("  {}  [{}] kind={} spec={} next_run={} last={} fires={}".format(
+            j["id"], "on" if j["enabled"] else "off", j["kind"], j["spec"],
+            j["next_run"], j["last_status"], j["fires"]))
+    return _out(args, {"ok": True, "jobs": jobs}, "\n".join(lines))
+
+
+def cmd_show(args):
+    j = sch.get_job(args.id)
+    if not j:
+        return _out(args, {"ok": False, "error": "no such job"}, "no such job: {}".format(args.id))
+    return _out(args, {"ok": True, "job": j}, json.dumps(j, indent=2, default=str))
+
+
+def cmd_pause(args):
+    return _out(args, sch.pause(args.id), "paused {}".format(args.id))
+
+
+def cmd_resume(args):
+    return _out(args, sch.resume(args.id), "resumed {}".format(args.id))
+
+
+def cmd_remove(args):
+    r = sch.remove(args.id)
+    return _out(args, r, "removed {}".format(args.id) if r.get("ok") else "no such job")
+
+
+def cmd_run(args):
+    r = sch.run_now(args.id)
+    return _out(args, r, "ran {} -> {}".format(args.id, (r.get("fired") or {}).get("status"))
+                if r.get("ok") else "error: {}".format(r.get("error")))
+
+
+def cmd_tick(args):
+    r = sch.run_due()
+    lines = ["fired {} due job(s):".format(r["count"])]
+    for f in r["fired"]:
+        lines.append("  {} -> {}{}".format(f["id"], f["status"], " (alerted)" if f["alerted"] else ""))
+    return _out(args, r, "\n".join(lines))
+
+
+def cmd_webhook(args):
+    action = args.webhook_action
+    if action == "subscribe":
+        r = sch.webhook_subscribe(args.id, args.secret or "", {"prompt": args.prompt or ""})
+        return _out(args, r, "subscribed {}".format(args.id) if r.get("ok") else r.get("error"))
+    if action == "list":
+        subs = sch.webhook_list()
+        return _out(args, {"ok": True, "subscriptions": subs},
+                    "webhooks:\n" + "\n".join("  {} secret={}".format(s["id"], s["has_secret"]) for s in subs))
+    if action == "remove":
+        return _out(args, sch.webhook_remove(args.id), "removed {}".format(args.id))
+    if action == "event":
+        payload = json.loads(args.payload) if args.payload else {}
+        r = sch.webhook_event(args.id, payload, args.signature)
+        return _out(args, r, "event {}: {}".format(args.id, "ran" if r.get("ok")
+                    else ("REJECTED" if r.get("rejected") else "error: " + str(r.get("error")))))
+    return _out(args, {"ok": False, "error": "unknown webhook action"}, "unknown webhook action")
+
+
+def build_parser():
+    jsn = argparse.ArgumentParser(add_help=False)
+    jsn.add_argument("--json", action="store_true")
+    p = argparse.ArgumentParser(prog="omegaclaw-cron", description="OmegaClaw scheduler CLI")
+    sub = p.add_subparsers(dest="command")
+
+    c = sub.add_parser("create", parents=[jsn])
+    c.add_argument("id")
+    c.add_argument("--kind", required=True, choices=["once", "interval", "cron"])
+    c.add_argument("--spec", required=True, help="epoch (once) | seconds (interval) | 5-field cron")
+    c.add_argument("--prompt", default="")
+    c.add_argument("--on-empty", dest="on_empty", default="silent", choices=["silent", "alert"])
+    c.add_argument("--chain-from", dest="chain_from", default="")
+    c.set_defaults(func=cmd_create)
+
+    for name, fn in (("list", cmd_list), ("tick", cmd_tick)):
+        sp = sub.add_parser(name, parents=[jsn])
+        sp.set_defaults(func=fn)
+    for name, fn in (("show", cmd_show), ("pause", cmd_pause), ("resume", cmd_resume),
+                     ("remove", cmd_remove), ("run", cmd_run)):
+        sp = sub.add_parser(name, parents=[jsn])
+        sp.add_argument("id")
+        sp.set_defaults(func=fn)
+
+    wh = sub.add_parser("webhook", parents=[jsn])
+    wha = wh.add_subparsers(dest="webhook_action")
+    ws = wha.add_parser("subscribe", parents=[jsn])
+    ws.add_argument("id")
+    ws.add_argument("--secret", default="")
+    ws.add_argument("--prompt", default="")
+    wha.add_parser("list", parents=[jsn])
+    wr = wha.add_parser("remove", parents=[jsn])
+    wr.add_argument("id")
+    we = wha.add_parser("event", parents=[jsn])
+    we.add_argument("id")
+    we.add_argument("--payload", default="{}")
+    we.add_argument("--signature", default=None)
+    wh.set_defaults(func=cmd_webhook)
+    return p
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    if not getattr(args, "func", None):
+        build_parser().print_help()
+        return 2
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/omegaclaw-cron
+++ b/scripts/omegaclaw-cron
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """OmegaClaw scheduler CLI — cron / interval / one-shot jobs + webhook subscriptions (Issue #17).
 
-  cron create <id> --kind once|interval|cron --spec <spec> [--prompt ..] [--on-empty silent|alert]
+  cron create <id> --kind once|interval|cron --spec <spec> [--prompt ..] [--workdir DIR]
+                   [--delivery TARGET] [--on-empty silent|alert]
   cron list | show <id> | pause <id> | resume <id> | remove <id>
   cron run <id>                          force-run a job now
-  cron tick                              fire everything currently due (scheduler heartbeat)
+  cron tick                              fire everything currently due (one heartbeat)
+  cron daemon [--interval S] [--max-ticks N]   run heartbeats continuously (the operator)
   cron webhook subscribe <id> --secret S [--prompt ..]
   cron webhook list | remove <id>
   cron webhook event <id> --payload '{...}' [--signature HEX]
@@ -33,6 +35,7 @@ def _out(args, obj, text):
 
 def cmd_create(args):
     r = sch.create_job(args.id, args.kind, args.spec, prompt=args.prompt or "",
+                       workdir=args.workdir or "", delivery=args.delivery or "",
                        on_empty=args.on_empty, chain_from=args.chain_from or "")
     return _out(args, r, "created {} ({}, next_run={})".format(args.id, args.kind, r.get("next_run"))
                 if r.get("ok") else "error: {}".format(r.get("error")))
@@ -75,11 +78,25 @@ def cmd_run(args):
 
 
 def cmd_tick(args):
-    r = sch.run_due()
+    # a manual heartbeat: wire the durable default delivery/alert sinks so a fired job's output
+    # is captured (not silently dropped) even from a one-off `tick`.
+    r = sch.run_due(delivery_fn=sch._default_delivery, alert_fn=sch._default_alert)
     lines = ["fired {} due job(s):".format(r["count"])]
     for f in r["fired"]:
         lines.append("  {} -> {}{}".format(f["id"], f["status"], " (alerted)" if f["alerted"] else ""))
     return _out(args, r, "\n".join(lines))
+
+
+def cmd_daemon(args):
+    # the operator that actually drives the store: loop run_due every --interval seconds until
+    # interrupted (or --max-ticks). Without this, jobs are only created, never fired.
+    iterations = args.max_ticks if args.max_ticks and args.max_ticks > 0 else None
+    if not getattr(args, "json", False):
+        print("omegaclaw-cron daemon: interval={}s max_ticks={}".format(
+            args.interval, iterations or "∞"), flush=True)
+    r = sch.run_forever(interval=args.interval, iterations=iterations)
+    return _out(args, r, "daemon stopped after {} tick(s), {} job(s) fired".format(
+        r["ticks"], r["fired_total"]))
 
 
 def cmd_webhook(args):
@@ -112,6 +129,10 @@ def build_parser():
     c.add_argument("--kind", required=True, choices=["once", "interval", "cron"])
     c.add_argument("--spec", required=True, help="epoch (once) | seconds (interval) | 5-field cron")
     c.add_argument("--prompt", default="")
+    c.add_argument("--workdir", default="", help="job working dir (must be within an io-policy "
+                   "read_write root); default: an auto-cleaned temp dir per run")
+    c.add_argument("--delivery", default="", help="delivery target label; when set, run output is "
+                   "delivered (default sink: memory/cron_outbox.jsonl)")
     c.add_argument("--on-empty", dest="on_empty", default="silent", choices=["silent", "alert"])
     c.add_argument("--chain-from", dest="chain_from", default="")
     c.set_defaults(func=cmd_create)
@@ -119,6 +140,12 @@ def build_parser():
     for name, fn in (("list", cmd_list), ("tick", cmd_tick)):
         sp = sub.add_parser(name, parents=[jsn])
         sp.set_defaults(func=fn)
+
+    d = sub.add_parser("daemon", parents=[jsn])
+    d.add_argument("--interval", type=float, default=60.0, help="seconds between heartbeats")
+    d.add_argument("--max-ticks", dest="max_ticks", type=int, default=0,
+                   help="stop after N ticks (0 = run until interrupted)")
+    d.set_defaults(func=cmd_daemon)
     for name, fn in (("show", cmd_show), ("pause", cmd_pause), ("resume", cmd_resume),
                      ("remove", cmd_remove), ("run", cmd_run)):
         sp = sub.add_parser(name, parents=[jsn])

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -11,7 +11,15 @@ adds first-class **durable job definitions** + a **scheduler** + a **webhook ada
 - ``run_due(now, runner)`` fires everything due at ``now`` — the clock is **injected**, so tests
   drive a simulated timeline deterministically. Each run executes in its **own session**
   (Issue #16), delivers non-empty output via a delivery hook, and on failure (or an empty result
-  when ``on_empty="alert"``) raises an **alert**; ``on_empty="silent"`` watchdogs stay quiet.
+  when ``on_empty="alert"``) raises an **alert**; ``on_empty="silent"`` watchdogs stay quiet. A
+  bad job (incl. a workdir the io policy forbids) fails **only itself** — it can't abort the tick.
+- ``run_forever(interval)`` is the **operator** that actually drives the store: the
+  ``omegaclaw-cron daemon`` heartbeat loops ``run_due`` so due jobs fire on their own. Its
+  ``delivery_fn``/``alert_fn`` default to a **durable outbox** (``memory/cron_outbox.jsonl``) so a
+  scheduled result/alert is never silently dropped; a live deployment injects channel-backed hooks
+  and a real agent ``runner`` here — that is the intended extension seam.
+- Each run gets a **working dir** (an explicit ``--workdir``, validated against the io policy's
+  read_write roots; else an auto-cleaned temp dir, removed after the run — no unbounded growth).
 - **Context chaining**: a job may consume the previous job's output.
 - Safeguards: **recursion is refused** while a job runs (no self-scheduling storms) and a
   per-job minimum interval guards against runaway loops.
@@ -27,6 +35,7 @@ import hashlib
 import hmac
 import json
 import os
+import shutil
 import sqlite3
 import tempfile
 import threading
@@ -56,6 +65,81 @@ def is_safe_skill_name(name: Any) -> bool:
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _MIN_INTERVAL = float(os.environ.get("OMEGACLAW_JOB_MIN_INTERVAL", "1"))   # runaway guard
+
+
+# --------------------------------------------------------------------------- io-policy guard
+
+def _allowed_workdir_roots() -> Optional[List[str]]:
+    """Read-write base paths a job workdir must sit under, or ``None`` when it can't be
+    determined (then the caller does NOT block). Priority: the explicit
+    ``OMEGACLAW_JOB_WORKDIR_ROOTS`` env (``os.pathsep``-separated — deterministic, stdlib-only) and
+    otherwise a best-effort read of the repo security policy's ``read_write`` list (needs the
+    optional yaml/py_landlock deps; absent on a bare host, so we fail open there)."""
+    env = os.environ.get("OMEGACLAW_JOB_WORKDIR_ROOTS")
+    if env is not None:
+        roots = [os.path.abspath(p) for p in env.split(os.pathsep) if p.strip()]
+        return roots or None
+    try:  # optional: profile.policy pulls yaml + py_landlock, unavailable on a bare test host
+        from profile import policy as _pol
+        fsp = _pol.FileSystemPolicy()
+        fsp.load_file(os.path.join(_REPO_ROOT, "profile", "policy.yaml"))
+        return [os.path.abspath(str(p)) for p in fsp._read_write] or None
+    except Exception:  # noqa: BLE001 - can't determine -> caller allows
+        return None
+
+
+def _workdir_allowed(workdir: str) -> bool:
+    """True iff ``workdir`` resolves inside an allowed read-write root (per the io policy). Returns
+    True when the policy is undeterminable so host-only runs aren't blocked; a configured policy
+    fails closed on a path outside its read_write roots (e.g. a job trying to write ``/etc``)."""
+    roots = _allowed_workdir_roots()
+    if not roots:
+        return True
+    real = os.path.realpath(os.path.abspath(workdir))
+    for root in roots:
+        r = os.path.realpath(root)
+        # rstrip so a root of "/" (realpath keeps its trailing sep) contains every subpath instead
+        # of comparing against "//"; normal roots have no trailing sep so this is a no-op.
+        if real == r or real.startswith(r.rstrip(os.sep) + os.sep):
+            return True
+    return False
+
+
+# --------------------------------------------------------------------------- durable output sink
+
+def _outbox_path() -> str:
+    env = os.environ.get("OMEGACLAW_CRON_OUTBOX")
+    if env:
+        return env if os.path.isabs(env) else os.path.join(_REPO_ROOT, env)
+    return os.path.join(_REPO_ROOT, "memory", "cron_outbox.jsonl")
+
+
+def _append_outbox(kind: str, job: Dict[str, Any], text: str) -> None:
+    """Append one run result/alert to the durable JSONL outbox (a policy read_write path), so a
+    scheduled run's output is captured rather than silently dropped. Best-effort: never raises."""
+    path = _outbox_path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        rec = {"ts": time.time(), "kind": kind, "job": job.get("id"),
+               "delivery": job.get("delivery") or "", "text": text}
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec) + "\n")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _default_delivery(job: Dict[str, Any], output: str) -> None:
+    """Default delivery sink: append the run output to the durable outbox. This is the seam a live
+    deployment overrides with a channel/provider push (see ``run_forever``)."""
+    _append_outbox("delivery", job, output)
+
+
+def _default_alert(job: Dict[str, Any], message: str) -> None:
+    """Default alert sink: record durably AND echo to stdout (so a bare `tick`/`daemon` surfaces
+    failures even without a wired alert channel)."""
+    _append_outbox("alert", job, message)
+    print("[scheduler] ALERT job={} {}".format(job.get("id"), message), flush=True)
+
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS jobs (
@@ -212,6 +296,8 @@ def create_job(job_id: str, kind: str, spec: str, *, prompt: str = "", skills: O
         return {"ok": False, "error": "recursive job creation refused while a job is running"}
     if not is_safe_skill_name(job_id):
         return {"ok": False, "error": "unsafe job id: {!r}".format(job_id)}
+    if workdir and not _workdir_allowed(workdir):
+        return {"ok": False, "error": "workdir not permitted by io policy: {}".format(workdir)}
     now = time.time() if now is None else now
     own = conn is None
     conn = conn or connect()
@@ -354,28 +440,50 @@ def _execute_one(job: Dict[str, Any], now: float, runner: Callable, conn: sqlite
     row = conn.execute("SELECT fires FROM jobs WHERE id=?", (jid,)).fetchone()
     fire_no = row[0] if row else (int(job.get("fires") or 0) + 1)
     sid = "cron-{}-{}".format(jid, fire_no)
-    wd = job.get("workdir") or tempfile.mkdtemp(prefix="omegaclaw-cron-{}-".format(jid))
-    os.makedirs(wd, exist_ok=True)
-    chain_out = None
-    if job.get("chain_from"):
-        prev = get_job(job["chain_from"], conn=conn)
-        chain_out = prev.get("last_output") if prev else None
-    ctx = {"job": job, "workdir": wd, "chain_output": chain_out, "now": now}
-    if extra_ctx:
-        ctx.update(extra_ctx)
-    try:
-        session_store.begin_session(sid, channel="cron", task=job.get("prompt") or jid)
-    except Exception:  # noqa: BLE001
-        pass
 
-    _in_run.active = True
+    # EVERYTHING that can raise for job-specific reasons (workdir resolution, dir creation, the
+    # runner itself) lives inside this try, so a bad job fails ONLY itself: an unhandled exception
+    # here can never propagate out of _execute_one and abort the surrounding run_due() heartbeat
+    # (which would skip every other job due this tick). The occurrence was already claimed above.
     status, output, err = "ok", "", None
+    wd = None
+    created_tmp = False
     try:
-        output = str(runner(job, ctx) or "")
-    except Exception as e:  # noqa: BLE001 - a job failure is isolated + alerted
+        configured = job.get("workdir") or ""
+        if configured:
+            if not _workdir_allowed(configured):
+                raise SchedulerError("workdir not permitted by io policy: {}".format(configured))
+            wd = configured
+        else:
+            wd = tempfile.mkdtemp(prefix="omegaclaw-cron-{}-".format(jid))
+            created_tmp = True                 # ephemeral: we own it, so we remove it after the run
+        os.makedirs(wd, exist_ok=True)
+
+        chain_out = None
+        if job.get("chain_from"):
+            prev = get_job(job["chain_from"], conn=conn)
+            chain_out = prev.get("last_output") if prev else None
+        ctx = {"job": job, "workdir": wd, "chain_output": chain_out, "now": now}
+        if extra_ctx:
+            ctx.update(extra_ctx)
+        try:
+            session_store.begin_session(sid, channel="cron", task=job.get("prompt") or jid)
+        except Exception:  # noqa: BLE001
+            pass
+
+        _in_run.active = True
+        try:
+            output = str(runner(job, ctx) or "")
+        finally:
+            _in_run.active = False
+    except Exception as e:  # noqa: BLE001 - setup OR job failure is isolated + alerted below
         status, err = "error", str(e)
     finally:
-        _in_run.active = False
+        # an ephemeral temp workdir is OURS: always remove it, so a job firing on a schedule can't
+        # leak a new /tmp dir on every run (unbounded disk growth). A job with an explicit workdir
+        # keeps it — the operator manages that directory's lifecycle.
+        if created_tmp and wd:
+            shutil.rmtree(wd, ignore_errors=True)
 
     _set(conn, jid, last_status=status, last_output=output)
     try:
@@ -393,13 +501,15 @@ def _execute_one(job: Dict[str, Any], now: float, runner: Callable, conn: sqlite
             _alert(alert_fn, job, "job produced empty output")
             alerted = True
         # on_empty == "silent": watchdog stays quiet
-    else:
-        if delivery_fn is not None and job.get("delivery"):
-            try:
-                delivery_fn(job, output)
-            except Exception:  # noqa: BLE001
-                pass
-        delivered = True
+    elif job.get("delivery"):
+        # deliver only when a destination is configured; fall back to the durable outbox sink so a
+        # scheduled result is captured even when no delivery_fn was wired (bare `tick`/`daemon`).
+        try:
+            (delivery_fn or _default_delivery)(job, output)
+            delivered = True
+        except Exception:  # noqa: BLE001
+            _alert(alert_fn, job, "delivery failed")
+            alerted = True
     return {"id": jid, "status": status, "session_id": sid, "next_run": nxt,
             "delivered": delivered, "alerted": alerted, "error": err}
 
@@ -425,14 +535,43 @@ def run_due(now: Optional[float] = None, runner: Optional[Callable] = None, *,
             conn.close()
 
 
+def run_forever(interval: float = 60.0, *, runner: Optional[Callable] = None,
+                delivery_fn: Optional[Callable] = None, alert_fn: Optional[Callable] = None,
+                iterations: Optional[int] = None, sleep_fn: Callable = time.sleep) -> Dict[str, Any]:
+    """Scheduler heartbeat — the operator that actually drives the store. A deployment runs
+    ``omegaclaw-cron daemon``; this loops ``run_due`` every ``interval`` seconds so due jobs fire
+    on their own (without this, jobs are only ever created, never run).
+
+    ``delivery_fn``/``alert_fn`` default to the durable file sinks so results/failures are never
+    silently dropped; a live deployment injects channel-backed hooks (and a real agent ``runner``)
+    here — that wiring is the intended extension seam. ``iterations`` bounds the loop (``None`` =
+    until interrupted); ``sleep_fn`` is injectable so tests drive it without real waiting. One
+    tick that raises never kills the heartbeat — it is caught and alerted."""
+    delivery_fn = delivery_fn or _default_delivery
+    alert_fn = alert_fn or _default_alert
+    ticks = fired_total = 0
+    try:
+        while iterations is None or ticks < iterations:
+            try:
+                r = run_due(runner=runner, delivery_fn=delivery_fn, alert_fn=alert_fn)
+                fired_total += r.get("count", 0)
+            except Exception as e:  # noqa: BLE001 - a bad tick must not stop the heartbeat
+                _alert(alert_fn, {"id": "<daemon>"}, "run_due crashed: {}".format(e))
+            ticks += 1
+            if iterations is not None and ticks >= iterations:
+                break
+            sleep_fn(interval)
+    except KeyboardInterrupt:  # pragma: no cover - graceful Ctrl-C on the CLI daemon
+        pass
+    return {"ok": True, "ticks": ticks, "fired_total": fired_total}
+
+
 def _alert(alert_fn, job, message):
-    if alert_fn is not None:
-        try:
-            alert_fn(job, message)
-        except Exception:  # noqa: BLE001
-            pass
-    else:
-        print("[scheduler] ALERT job={} {}".format(job.get("id"), message), flush=True)
+    fn = alert_fn or _default_alert
+    try:
+        fn(job, message)
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def run_now(job_id: str, runner: Optional[Callable] = None, **kw) -> Dict[str, Any]:

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -1,0 +1,638 @@
+"""Cron, webhook & event-triggered autonomous runs (Issue #17).
+
+OmegaClaw was interactive/benchmark-loop oriented; automation (monitors, daily summaries,
+recurring benchmarks, CI watchers, external event handlers) needed ad hoc shell wrappers. This
+adds first-class **durable job definitions** + a **scheduler** + a **webhook adapter**:
+
+- Jobs live in a durable SQLite store, so due jobs **survive a process restart** (the persisted
+  ``next_run`` means an overdue job still fires exactly once — never lost, never duplicated).
+- Schedules: ``once`` (at an epoch), ``interval`` (every N seconds), and a minimal 5-field
+  ``cron`` (``*`` / int / ``*/n`` / comma-lists).
+- ``run_due(now, runner)`` fires everything due at ``now`` — the clock is **injected**, so tests
+  drive a simulated timeline deterministically. Each run executes in its **own session**
+  (Issue #16), delivers non-empty output via a delivery hook, and on failure (or an empty result
+  when ``on_empty="alert"``) raises an **alert**; ``on_empty="silent"`` watchdogs stay quiet.
+- **Context chaining**: a job may consume the previous job's output.
+- Safeguards: **recursion is refused** while a job runs (no self-scheduling storms) and a
+  per-job minimum interval guards against runaway loops.
+- **Webhooks**: subscriptions carry an HMAC secret; an event with a bad/missing signature is
+  **rejected** (no run); a valid one triggers a run carrying validated event metadata.
+
+Stdlib only. DB path ``OMEGACLAW_JOBS_DB`` (default ``memory/jobs.db``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import sqlite3
+import tempfile
+import threading
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+try:
+    import session_store
+except ImportError:  # pragma: no cover
+    from src import session_store
+
+
+def is_safe_skill_name(name: Any) -> bool:
+    """True iff ``name`` is safe as a lookup key AND a filesystem path segment — rejects empties,
+    path separators, ``..`` traversal, absolute paths, and NULs. Inlined (from skill_loader) to keep
+    the scheduler independent of the skills subsystem; used to validate job/subscription ids that
+    become filesystem path segments."""
+    return (
+        isinstance(name, str) and bool(name)
+        and name not in (".", "..")
+        and ".." not in name
+        and "/" not in name and "\\" not in name
+        and not os.path.isabs(name)
+        and "\x00" not in name
+    )
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_MIN_INTERVAL = float(os.environ.get("OMEGACLAW_JOB_MIN_INTERVAL", "1"))   # runaway guard
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS jobs (
+    id TEXT PRIMARY KEY, kind TEXT, spec TEXT, prompt TEXT, skills TEXT, workdir TEXT,
+    delivery TEXT, on_empty TEXT, enabled INTEGER DEFAULT 1, created REAL,
+    next_run REAL, last_run REAL, last_status TEXT, last_output TEXT, fires INTEGER DEFAULT 0,
+    chain_from TEXT, meta TEXT
+);
+CREATE TABLE IF NOT EXISTS webhooks (
+    id TEXT PRIMARY KEY, secret TEXT, job_template TEXT, created REAL
+);
+CREATE INDEX IF NOT EXISTS idx_jobs_next ON jobs(enabled, next_run);
+"""
+
+_in_run = threading.local()   # recursion guard: create_job refused while a job runs
+
+
+class SchedulerError(Exception):
+    pass
+
+
+def db_path() -> str:
+    env = os.environ.get("OMEGACLAW_JOBS_DB")
+    if env:
+        return env if os.path.isabs(env) else os.path.join(_REPO_ROOT, env)
+    return os.path.join(_REPO_ROOT, "memory", "jobs.db")
+
+
+def connect(path: Optional[str] = None) -> sqlite3.Connection:
+    p = path or db_path()
+    if p != ":memory:":
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+    conn = sqlite3.connect(p, timeout=30)
+    conn.row_factory = sqlite3.Row
+    # wait (don't error) when another heartbeat holds the write lock; the atomic claim below
+    # serializes concurrent heartbeats so a due occurrence runs exactly once.
+    conn.execute("PRAGMA busy_timeout=30000")
+    conn.executescript(_SCHEMA)
+    conn.commit()
+    return conn
+
+
+def reset(path: Optional[str] = None) -> None:
+    p = path or db_path()
+    if p != ":memory:" and os.path.exists(p):
+        os.remove(p)
+
+
+# --------------------------------------------------------------------------- cron
+
+def _cron_field_match(field: str, value: int, lo: int, hi: int) -> bool:
+    if field == "*":
+        return True
+    for part in field.split(","):
+        if part.startswith("*/"):
+            try:
+                step = int(part[2:])
+                if step > 0 and value % step == 0:      # step<=0 is invalid, never matches
+                    return True
+            except ValueError:
+                pass
+        elif "-" in part:
+            try:
+                a, b = part.split("-", 1)
+                if int(a) <= value <= int(b):
+                    return True
+            except ValueError:
+                pass
+        else:
+            try:
+                if int(part) == value:
+                    return True
+            except ValueError:
+                pass
+    return False
+
+
+def _cron_matches(spec: str, t: time.struct_time) -> bool:
+    fields = spec.split()
+    if len(fields) != 5:
+        raise SchedulerError("cron spec must have 5 fields (m h dom mon dow): {!r}".format(spec))
+    m, h, dom, mon, dow = fields
+    # cron day-of-week: 0 or 7 = Sunday, 1=Mon..6=Sat. Python tm_wday: 0=Mon..6=Sun.
+    cron_dow = (t.tm_wday + 1) % 7                       # -> 0=Sun,1=Mon,..,6=Sat
+    dow_ok = (_cron_field_match(dow, cron_dow, 0, 6)
+              or (cron_dow == 0 and _cron_field_match(dow, 7, 0, 7)))   # accept "7" for Sunday
+    # ALL five fields must match (the dow term stays INSIDE the conjunction — a `*` dow must not
+    # short-circuit the minute/hour/day/month checks, which previously let daily specs fire every
+    # minute).
+    return (_cron_field_match(m, t.tm_min, 0, 59)
+            and _cron_field_match(h, t.tm_hour, 0, 23)
+            and _cron_field_match(dom, t.tm_mday, 1, 31)
+            and _cron_field_match(mon, t.tm_mon, 1, 12)
+            and dow_ok)
+
+
+def _validate_cron(spec: str) -> None:
+    """Raise SchedulerError for a malformed 5-field cron spec (bad step / range / token), so
+    create_job fails closed instead of storing a job that silently never fires (or crashes)."""
+    fields = spec.split()
+    if len(fields) != 5:
+        raise SchedulerError("cron spec must have 5 fields (m h dom mon dow): {!r}".format(spec))
+    ranges = [(0, 59), (0, 23), (1, 31), (1, 12), (0, 7)]
+    for field, (lo, hi) in zip(fields, ranges):
+        for part in field.split(","):
+            if part == "*":
+                continue
+            if part.startswith("*/"):
+                try:
+                    if int(part[2:]) <= 0:
+                        raise SchedulerError("cron step must be > 0: {!r}".format(part))
+                except ValueError:
+                    raise SchedulerError("cron step not an integer: {!r}".format(part))
+                continue
+            toks = part.split("-") if "-" in part else [part]
+            for tok in toks:
+                try:
+                    v = int(tok)
+                except ValueError:
+                    raise SchedulerError("cron field token not an integer: {!r}".format(tok))
+                if not (lo <= v <= hi):
+                    raise SchedulerError("cron token {} out of range [{}, {}]".format(v, lo, hi))
+
+
+def _cron_next(spec: str, after_epoch: float) -> Optional[float]:
+    """Next epoch (UTC, minute-aligned) strictly after ``after_epoch`` matching ``spec``."""
+    start = int(after_epoch // 60 + 1) * 60
+    for i in range(0, 366 * 24 * 60):        # cap: one year
+        cand = start + i * 60
+        if _cron_matches(spec, time.gmtime(cand)):
+            return float(cand)
+    return None
+
+
+def _compute_next(kind: str, spec: str, after: float) -> Optional[float]:
+    if kind == "once":
+        return float(spec)
+    if kind == "interval":
+        n = max(_MIN_INTERVAL, float(spec))
+        return after + n
+    if kind == "cron":
+        return _cron_next(spec, after)
+    raise SchedulerError("unknown job kind: {!r}".format(kind))
+
+
+# --------------------------------------------------------------------------- job store
+
+def create_job(job_id: str, kind: str, spec: str, *, prompt: str = "", skills: Optional[List[str]] = None,
+               workdir: str = "", delivery: str = "", on_empty: str = "silent",
+               chain_from: str = "", meta: Optional[Dict[str, Any]] = None, now: Optional[float] = None,
+               conn: Optional[sqlite3.Connection] = None) -> Dict[str, Any]:
+    """Create a durable job. ``now`` (injectable clock) seeds the first ``next_run``."""
+    if getattr(_in_run, "active", False):
+        return {"ok": False, "error": "recursive job creation refused while a job is running"}
+    if not is_safe_skill_name(job_id):
+        return {"ok": False, "error": "unsafe job id: {!r}".format(job_id)}
+    now = time.time() if now is None else now
+    own = conn is None
+    conn = conn or connect()
+    try:
+        if conn.execute("SELECT 1 FROM jobs WHERE id=?", (job_id,)).fetchone():
+            return {"ok": False, "error": "job already exists: {}".format(job_id)}
+        try:
+            if kind == "interval" and float(spec) < _MIN_INTERVAL:
+                return {"ok": False, "error": "interval below min {}s (runaway guard)".format(_MIN_INTERVAL)}
+            if kind == "cron":
+                _validate_cron(spec)                 # fail closed on a malformed cron spec
+            nxt = _compute_next(kind, spec, now)
+        except (SchedulerError, ValueError, ZeroDivisionError) as e:
+            return {"ok": False, "error": str(e)}
+        conn.execute(
+            "INSERT INTO jobs(id,kind,spec,prompt,skills,workdir,delivery,on_empty,enabled,created,"
+            "next_run,last_run,last_status,last_output,fires,chain_from,meta) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (job_id, kind, str(spec), prompt or "", json.dumps(skills or []),
+             workdir or "", delivery or "", on_empty, 1, now, nxt, None, None, None, 0,
+             chain_from or "", json.dumps(meta or {})))
+        conn.commit()
+        return {"ok": True, "id": job_id, "kind": kind, "next_run": nxt}
+    finally:
+        if own:
+            conn.close()
+
+
+def _set(conn, job_id, **fields):
+    cols = ", ".join("{}=?".format(k) for k in fields)
+    conn.execute("UPDATE jobs SET {} WHERE id=?".format(cols), (*fields.values(), job_id))
+    conn.commit()
+
+
+def list_jobs(conn: Optional[sqlite3.Connection] = None) -> List[Dict[str, Any]]:
+    own = conn is None
+    conn = conn or connect()
+    try:
+        return [dict(r) for r in conn.execute("SELECT * FROM jobs ORDER BY next_run").fetchall()]
+    finally:
+        if own:
+            conn.close()
+
+
+def get_job(job_id: str, conn: Optional[sqlite3.Connection] = None) -> Optional[Dict[str, Any]]:
+    own = conn is None
+    conn = conn or connect()
+    try:
+        r = conn.execute("SELECT * FROM jobs WHERE id=?", (job_id,)).fetchone()
+        return dict(r) if r else None
+    finally:
+        if own:
+            conn.close()
+
+
+def pause(job_id, conn=None):
+    return _toggle(job_id, 0, conn)
+
+
+def resume(job_id, conn=None):
+    return _toggle(job_id, 1, conn)
+
+
+def _toggle(job_id, enabled, conn):
+    own = conn is None
+    conn = conn or connect()
+    try:
+        if not conn.execute("SELECT 1 FROM jobs WHERE id=?", (job_id,)).fetchone():
+            return {"ok": False, "error": "no such job: {}".format(job_id)}
+        _set(conn, job_id, enabled=enabled)
+        return {"ok": True, "id": job_id, "enabled": bool(enabled)}
+    finally:
+        if own:
+            conn.close()
+
+
+def remove(job_id, conn=None):
+    own = conn is None
+    conn = conn or connect()
+    try:
+        cur = conn.execute("DELETE FROM jobs WHERE id=?", (job_id,))
+        conn.commit()
+        return {"ok": cur.rowcount > 0, "id": job_id}
+    finally:
+        if own:
+            conn.close()
+
+
+def due_jobs(now: float, conn: Optional[sqlite3.Connection] = None) -> List[Dict[str, Any]]:
+    own = conn is None
+    conn = conn or connect()
+    try:
+        rows = conn.execute("SELECT * FROM jobs WHERE enabled=1 AND next_run IS NOT NULL "
+                            "AND next_run <= ? ORDER BY next_run", (now,)).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        if own:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- execution
+
+def _default_runner(job: Dict[str, Any], ctx: Dict[str, Any]) -> str:
+    """Fallback runner: echoes the prompt. A live deployment passes a runner that
+    drives an actual agent run with the job's prompt/skills/workdir."""
+    return "ran job {} (prompt chars={})".format(job["id"], len(job.get("prompt") or ""))
+
+
+def _execute_one(job: Dict[str, Any], now: float, runner: Callable, conn: sqlite3.Connection, *,
+                 delivery_fn: Optional[Callable] = None, alert_fn: Optional[Callable] = None,
+                 advance: bool = True, extra_ctx: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Run ONE job in its own session + apply delivery/alert. ``advance`` reschedules next_run
+    (scheduled fire); a manual/one-off run passes ``advance=False`` so it does not mutate the
+    durable schedule/enabled state. ``extra_ctx`` merges into the runner ctx (webhooks inject the
+    validated event here)."""
+    jid = job["id"]
+    if advance:
+        # ATOMICALLY CLAIM this occurrence before running (durability + concurrency safety): the
+        # UPDATE's WHERE checks the exact next_run we selected, so if another heartbeat already
+        # advanced it, our rowcount is 0 and we skip — a due occurrence runs exactly once even
+        # with multiple concurrent schedulers against the same DB. Advancing first also means a
+        # crash mid-run cannot refire it.
+        try:
+            nxt = None if job["kind"] == "once" else _compute_next(job["kind"], job["spec"], now)
+        except (SchedulerError, ValueError, ZeroDivisionError):
+            nxt = None
+        cur = conn.execute(
+            "UPDATE jobs SET next_run=?, last_run=?, fires=fires+1 "
+            "WHERE id=? AND enabled=1 AND next_run=?",
+            (nxt, now, jid, job.get("next_run")))
+        conn.commit()
+        if cur.rowcount != 1:
+            return None                      # lost the claim -> another heartbeat is running it
+    else:
+        nxt = job.get("next_run")
+        conn.execute("UPDATE jobs SET last_run=?, fires=fires+1 WHERE id=?", (now, jid))
+        conn.commit()
+    # derive the session id from the PERSISTED (atomically-incremented) fire count, so concurrent
+    # attempts can never share a session id like cron-<job>-1.
+    row = conn.execute("SELECT fires FROM jobs WHERE id=?", (jid,)).fetchone()
+    fire_no = row[0] if row else (int(job.get("fires") or 0) + 1)
+    sid = "cron-{}-{}".format(jid, fire_no)
+    wd = job.get("workdir") or tempfile.mkdtemp(prefix="omegaclaw-cron-{}-".format(jid))
+    os.makedirs(wd, exist_ok=True)
+    chain_out = None
+    if job.get("chain_from"):
+        prev = get_job(job["chain_from"], conn=conn)
+        chain_out = prev.get("last_output") if prev else None
+    ctx = {"job": job, "workdir": wd, "chain_output": chain_out, "now": now}
+    if extra_ctx:
+        ctx.update(extra_ctx)
+    try:
+        session_store.begin_session(sid, channel="cron", task=job.get("prompt") or jid)
+    except Exception:  # noqa: BLE001
+        pass
+
+    _in_run.active = True
+    status, output, err = "ok", "", None
+    try:
+        output = str(runner(job, ctx) or "")
+    except Exception as e:  # noqa: BLE001 - a job failure is isolated + alerted
+        status, err = "error", str(e)
+    finally:
+        _in_run.active = False
+
+    _set(conn, jid, last_status=status, last_output=output)
+    try:
+        session_store.record_snapshot(sid, 1, {"status": status, "output_chars": len(output)})
+        session_store.end_session(sid, status)
+    except Exception:  # noqa: BLE001
+        pass
+
+    delivered = alerted = False
+    if status == "error":
+        _alert(alert_fn, job, "job failed: {}".format(err))
+        alerted = True
+    elif not output.strip():
+        if job.get("on_empty") == "alert":
+            _alert(alert_fn, job, "job produced empty output")
+            alerted = True
+        # on_empty == "silent": watchdog stays quiet
+    else:
+        if delivery_fn is not None and job.get("delivery"):
+            try:
+                delivery_fn(job, output)
+            except Exception:  # noqa: BLE001
+                pass
+        delivered = True
+    return {"id": jid, "status": status, "session_id": sid, "next_run": nxt,
+            "delivered": delivered, "alerted": alerted, "error": err}
+
+
+def run_due(now: Optional[float] = None, runner: Optional[Callable] = None, *,
+            delivery_fn: Optional[Callable] = None, alert_fn: Optional[Callable] = None,
+            conn: Optional[sqlite3.Connection] = None) -> Dict[str, Any]:
+    """Fire every job due at ``now`` (injected clock). Each runs in its own session; the persisted
+    ``next_run`` is advanced BEFORE running so a crash mid-run can't double-fire it."""
+    now = time.time() if now is None else now
+    runner = runner or _default_runner
+    own = conn is None
+    conn = conn or connect()
+    try:
+        fired = [r for r in (_execute_one(job, now, runner, conn, delivery_fn=delivery_fn,
+                                          alert_fn=alert_fn, advance=True)
+                             for job in due_jobs(now, conn=conn))
+                 if r is not None]   # r is None when this heartbeat lost the atomic claim
+        return {"ok": all(f["status"] != "error" for f in fired), "now": now,
+                "fired": fired, "count": len(fired)}
+    finally:
+        if own:
+            conn.close()
+
+
+def _alert(alert_fn, job, message):
+    if alert_fn is not None:
+        try:
+            alert_fn(job, message)
+        except Exception:  # noqa: BLE001
+            pass
+    else:
+        print("[scheduler] ALERT job={} {}".format(job.get("id"), message), flush=True)
+
+
+def run_now(job_id: str, runner: Optional[Callable] = None, **kw) -> Dict[str, Any]:
+    """Force-run a single job immediately (CLI ``cron run``), regardless of its schedule.
+
+    A one-off manual run: it executes ONLY this job (never other due jobs) and does NOT mutate
+    durable pause/resume (``enabled``) or ``next_run`` — running a paused job leaves it paused."""
+    delivery_fn = kw.pop("delivery_fn", None)
+    alert_fn = kw.pop("alert_fn", None)
+    conn = kw.pop("conn", None) or connect()
+    try:
+        job = get_job(job_id, conn=conn)
+        if not job:
+            return {"ok": False, "error": "no such job: {}".format(job_id)}
+        entry = _execute_one(job, time.time(), runner or _default_runner, conn,
+                             delivery_fn=delivery_fn, alert_fn=alert_fn, advance=False)
+        return {"ok": entry["status"] != "error", "fired": entry}
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------- webhooks
+
+def webhook_subscribe(sub_id: str, secret: str, job_template: Dict[str, Any],
+                      conn: Optional[sqlite3.Connection] = None) -> Dict[str, Any]:
+    if not is_safe_skill_name(sub_id):
+        return {"ok": False, "error": "unsafe subscription id"}
+    own = conn is None
+    conn = conn or connect()
+    try:
+        conn.execute("INSERT OR REPLACE INTO webhooks(id, secret, job_template, created) VALUES (?,?,?,?)",
+                     (sub_id, secret or "", json.dumps(job_template or {}), time.time()))
+        conn.commit()
+        return {"ok": True, "id": sub_id}
+    finally:
+        if own:
+            conn.close()
+
+
+def webhook_list(conn=None):
+    own = conn is None
+    conn = conn or connect()
+    try:
+        return [{"id": r["id"], "created": r["created"], "has_secret": bool(r["secret"])}
+                for r in conn.execute("SELECT * FROM webhooks ORDER BY created").fetchall()]
+    finally:
+        if own:
+            conn.close()
+
+
+def webhook_remove(sub_id, conn=None):
+    own = conn is None
+    conn = conn or connect()
+    try:
+        cur = conn.execute("DELETE FROM webhooks WHERE id=?", (sub_id,))
+        conn.commit()
+        return {"ok": cur.rowcount > 0, "id": sub_id}
+    finally:
+        if own:
+            conn.close()
+
+
+def _sign(secret: str, payload: bytes) -> str:
+    return hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+
+
+def webhook_event(sub_id: str, payload, signature: Optional[str] = None,
+                  runner: Optional[Callable] = None, conn: Optional[sqlite3.Connection] = None) -> Dict[str, Any]:
+    """Validate an incoming event and, if valid, run a one-shot job from the subscription
+    template carrying the event metadata. A bad/missing signature (when a secret is configured)
+    is REJECTED without running anything."""
+    own = conn is None
+    conn = conn or connect()
+    try:
+        row = conn.execute("SELECT * FROM webhooks WHERE id=?", (sub_id,)).fetchone()
+        if not row:
+            return {"ok": False, "error": "no such subscription: {}".format(sub_id)}
+        raw = payload if isinstance(payload, (bytes, bytearray)) else json.dumps(payload, sort_keys=True).encode("utf-8")
+        if row["secret"]:
+            if not signature or not hmac.compare_digest(_sign(row["secret"], raw), signature):
+                return {"ok": False, "error": "invalid signature", "rejected": True}
+        template = json.loads(row["job_template"] or "{}")
+        try:
+            event = payload if isinstance(payload, dict) else json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            event = {"raw": True}
+
+        def _webhook_runner(job, ctx):
+            # the validated, parsed event is injected into ctx by _execute_one(extra_ctx=...)
+            if runner is not None:
+                return runner(job, ctx)
+            keys = ",".join(sorted(event.keys())) if isinstance(event, dict) else "?"
+            return "webhook {} event handled (keys={})".format(sub_id, keys)
+        # Collision-resistant transient id (random suffix), and — critically — only remove the
+        # job if WE created it, so a webhook can never delete a pre-existing durable job whose id
+        # happens to collide (the old predictable modulo id + unconditional remove could).
+        import uuid
+        jid = "wh-{}-{}".format(sub_id, uuid.uuid4().hex[:16])
+        created = create_job(jid, "once", str(time.time()), prompt=template.get("prompt", ""),
+                             skills=template.get("skills"), on_empty=template.get("on_empty", "silent"),
+                             meta={"webhook": sub_id,
+                                   "event_keys": sorted(event.keys()) if isinstance(event, dict) else []},
+                             now=0, conn=conn)
+        if not created.get("ok"):
+            return {"ok": False, "error": "could not create transient webhook job: {}".format(
+                created.get("error")), "sub_id": sub_id, "event_valid": True}
+        try:
+            job = get_job(jid, conn=conn)
+            # run ONLY this transient job, passing the validated event into the runner ctx
+            entry = _execute_one(job, time.time(), _webhook_runner, conn, advance=False,
+                                 extra_ctx={"event": event})
+        finally:
+            remove(jid, conn=conn)   # transient — safe: this id is unique and we created it
+        return {"ok": bool(entry) and entry["status"] != "error", "sub_id": sub_id,
+                "fired": entry, "event_valid": True}
+    finally:
+        if own:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- selftest
+
+def _selftest() -> None:
+    dbp = os.path.join(tempfile.mkdtemp(prefix="scheduler_selftest_"), "jobs.db")
+    os.environ["OMEGACLAW_JOBS_DB"] = dbp
+    os.environ["OMEGACLAW_SESSION_DB"] = os.path.join(os.path.dirname(dbp), "s.db")
+    reset(dbp)
+
+    t0 = 1_000_000.0
+    ran = []
+
+    def runner(job, ctx):
+        ran.append(job["id"])
+        if job.get("meta") and "boom" in (job.get("prompt") or ""):
+            raise RuntimeError("kaboom")
+        return "output for " + job["id"]
+
+    # once + interval + cron creation
+    assert create_job("once1", "once", str(t0 + 10), prompt="hi", now=t0)["ok"]
+    assert create_job("iv1", "interval", "60", prompt="tick", now=t0)["ok"]
+    assert create_job("cr1", "cron", "*/5 * * * *", prompt="cronjob", now=t0)["ok"]
+    # unsafe id + too-fast interval refused
+    assert create_job("../x", "once", str(t0))["ok"] is False
+    assert create_job("fast", "interval", "0.1", now=t0)["ok"] is False
+
+    # nothing due before t0+10; once1 due at t0+10
+    assert run_due(now=t0 + 5, runner=runner)["count"] == 0
+    r = run_due(now=t0 + 11, runner=runner)
+    assert "once1" in [f["id"] for f in r["fired"]]
+    # once job is now done (next_run None) -> not due again
+    assert get_job("once1")["next_run"] is None
+    assert "once1" not in [f["id"] for f in run_due(now=t0 + 100, runner=runner)["fired"]]
+
+    # interval reschedules
+    before = get_job("iv1")["next_run"]
+    run_due(now=before + 0.1, runner=runner)
+    assert get_job("iv1")["next_run"] > before
+
+    # restart safety: a due job persisted; a fresh connection still sees + fires it once
+    reset(dbp)
+    create_job("survive", "once", str(t0), prompt="x", now=t0)
+    # simulate restart: new process reads same DB (overdue) -> fires exactly once, not lost/dup
+    f1 = run_due(now=t0 + 1000, runner=runner)
+    f2 = run_due(now=t0 + 2000, runner=runner)
+    assert [f["id"] for f in f1["fired"]] == ["survive"] and f2["count"] == 0
+
+    # failure -> alert
+    alerts = []
+    create_job("boomjob", "once", str(t0), prompt="boom", now=t0, meta={"x": 1})
+    rb = run_due(now=t0 + 1, runner=runner, alert_fn=lambda job, msg: alerts.append((job["id"], msg)))
+    assert rb["fired"][0]["status"] == "error" and alerts and alerts[0][0] == "boomjob"
+
+    # on_empty: silent stays quiet, alert alerts
+    create_job("emptysilent", "once", str(t0), now=t0, on_empty="silent")
+    create_job("emptyalert", "once", str(t0), now=t0, on_empty="alert")
+    a2 = []
+    run_due(now=t0 + 1, runner=lambda j, c: "", alert_fn=lambda j, m: a2.append(j["id"]))
+    assert "emptyalert" in a2 and "emptysilent" not in a2
+
+    # recursion guard: a runner can't create jobs
+    create_job("recur", "once", str(t0), now=t0)
+    def _recur_runner(job, ctx):
+        return "nested={}".format(create_job("child", "once", str(t0), now=t0)["ok"])
+    rr = run_due(now=t0 + 1, runner=_recur_runner)
+    assert "nested=False" in get_job("recur")["last_output"]
+
+    # webhook: valid signature runs, invalid rejected
+    secret = "shh-secret"
+    webhook_subscribe("gh", secret, {"prompt": "handle push"})
+    import json as _json
+    payload = {"event": "push", "repo": "x"}
+    raw = _json.dumps(payload, sort_keys=True).encode("utf-8")
+    good = _sign(secret, raw)
+    assert webhook_event("gh", payload, good, runner=lambda j, c: "handled")["ok"]
+    assert webhook_event("gh", payload, "deadbeef").get("rejected") is True
+    assert webhook_event("gh", payload, None).get("rejected") is True
+
+    del os.environ["OMEGACLAW_JOBS_DB"], os.environ["OMEGACLAW_SESSION_DB"]
+    print("scheduler self-tests passed")
+
+
+if __name__ == "__main__":
+    _selftest()

--- a/src/session_store.py
+++ b/src/session_store.py
@@ -1,0 +1,473 @@
+"""Session persistence, transcript search & resumable snapshots (Issue #16).
+
+OmegaClaw has raw logs + `history.metta`, but no user-facing session database to ask "where did
+we leave off?", search prior decisions, compare runs, or resume interrupted work without parsing
+logs. This adds a queryable **SQLite** store with **full-text search** and **resumable
+snapshots**.
+
+Design:
+- stdlib ``sqlite3``; a small schema (sessions / messages / tool_calls / snapshots) plus an FTS5
+  search index (transparent LIKE fallback if FTS5 is unavailable).
+- Two ingestion paths: a live **recording API** (``begin_session`` / ``record_message`` /
+  ``record_tool_call`` / ``record_snapshot`` / ``end_session``) and ``ingest_trace`` which
+  backfills from the reasoning-trace JSONL every run already writes (so 100% of runs get a
+  session id + searchable metadata).
+- **Resume** returns the latest snapshot + recent context — reconstructed state independent of
+  the raw prompt log.
+
+DB path: ``OMEGACLAW_SESSION_DB`` (default ``<repo>/memory/sessions.db``, a runtime file).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from typing import Any, Dict, List, Optional
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY, started_at REAL, ended_at REAL, provider TEXT, channel TEXT,
+    task TEXT, status TEXT, turns INTEGER DEFAULT 0, meta TEXT
+);
+CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, turn INTEGER, role TEXT,
+    text TEXT, ts REAL
+);
+CREATE TABLE IF NOT EXISTS tool_calls (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, turn INTEGER, tool TEXT,
+    args TEXT, result TEXT, ok INTEGER, ts REAL
+);
+CREATE TABLE IF NOT EXISTS snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, turn INTEGER, state TEXT, ts REAL
+);
+CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
+CREATE INDEX IF NOT EXISTS idx_tool_session ON tool_calls(session_id);
+CREATE INDEX IF NOT EXISTS idx_snap_session ON snapshots(session_id);
+"""
+
+
+def db_path() -> str:
+    env = os.environ.get("OMEGACLAW_SESSION_DB")
+    if env:
+        return env if os.path.isabs(env) else os.path.join(_REPO_ROOT, env)
+    return os.path.join(_REPO_ROOT, "memory", "sessions.db")
+
+
+_HAS_FTS: Dict[str, bool] = {}
+
+
+def connect(path: Optional[str] = None) -> sqlite3.Connection:
+    p = path or db_path()
+    if p != ":memory:":
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+    conn = sqlite3.connect(p)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_SCHEMA)
+    # FTS5 search index over all searchable content; LIKE fallback if unavailable.
+    if p not in _HAS_FTS:
+        try:
+            conn.execute("CREATE VIRTUAL TABLE IF NOT EXISTS search_fts USING fts5("
+                         "session_id UNINDEXED, kind UNINDEXED, content)")
+            _HAS_FTS[p] = True
+        except sqlite3.OperationalError:
+            conn.execute("CREATE TABLE IF NOT EXISTS search_like ("
+                         "session_id TEXT, kind TEXT, content TEXT)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_like_session ON search_like(session_id)")
+            _HAS_FTS[p] = False
+    conn.commit()
+    return conn
+
+
+def _has_fts(conn: sqlite3.Connection) -> bool:
+    return _HAS_FTS.get(_conn_path(conn), True)
+
+
+def _conn_path(conn: sqlite3.Connection) -> str:
+    try:
+        for _seq, name, fname in conn.execute("PRAGMA database_list"):
+            if name == "main":
+                return fname or ":memory:"
+    except sqlite3.Error:
+        pass
+    return db_path()
+
+
+def _clear_session_rows(conn: sqlite3.Connection, session_id: str) -> None:
+    """Drop all dependent rows for a session id (messages/tool_calls/snapshots/search index).
+
+    There are no FK cascades, so a reused/collided id must be cleared explicitly — otherwise
+    stale transcript/search content bleeds into the new session (a correctness + privacy issue,
+    PR #40 review)."""
+    for tbl in ("messages", "tool_calls", "snapshots"):
+        conn.execute("DELETE FROM {} WHERE session_id=?".format(tbl), (session_id,))
+    if _has_fts(conn):
+        # FTS5 ignores DELETE ... WHERE <unindexed col>; delete by rowid instead.
+        rowids = [r[0] for r in conn.execute(
+            "SELECT rowid FROM search_fts WHERE session_id=?", (session_id,)).fetchall()]
+        for rid in rowids:
+            conn.execute("DELETE FROM search_fts WHERE rowid=?", (rid,))
+    else:
+        conn.execute("DELETE FROM search_like WHERE session_id=?", (session_id,))
+
+
+def _index(conn: sqlite3.Connection, session_id: str, kind: str, content: str) -> None:
+    content = content or ""
+    if _has_fts(conn):
+        conn.execute("INSERT INTO search_fts(session_id, kind, content) VALUES (?,?,?)",
+                     (session_id, kind, content))
+    else:
+        conn.execute("INSERT INTO search_like(session_id, kind, content) VALUES (?,?,?)",
+                     (session_id, kind, content))
+
+
+# --------------------------------------------------------------------------- recording API
+
+def begin_session(session_id: str, *, provider: str = "", channel: str = "", task: str = "",
+                  meta: Optional[Dict[str, Any]] = None, conn: Optional[sqlite3.Connection] = None) -> str:
+    own = conn is None
+    conn = conn or connect()
+    try:
+        # begin = a FRESH session: clear any prior rows for a reused/collided id so stale
+        # transcript/search content can't bleed in (replace semantics), transactionally.
+        _clear_session_rows(conn, session_id)
+        meta_str = json.dumps(meta or {}, ensure_ascii=False)
+        conn.execute(
+            "INSERT OR REPLACE INTO sessions(id, started_at, ended_at, provider, channel, task, "
+            "status, turns, meta) VALUES (?,?,?,?,?,?,?,?,?)",
+            (session_id, time.time(), None, provider, channel, task or "",
+             "active", 0, meta_str))
+        _index(conn, session_id, "task", task or "")
+        conn.commit()
+    finally:
+        if own:
+            conn.close()
+    return session_id
+
+
+def record_message(session_id: str, turn: int, role: str, text: str,
+                   conn: Optional[sqlite3.Connection] = None) -> None:
+    own = conn is None
+    conn = conn or connect()
+    try:
+        conn.execute("INSERT INTO messages(session_id, turn, role, text, ts) VALUES (?,?,?,?,?)",
+                     (session_id, turn, role, text or "", time.time()))
+        _index(conn, session_id, "message", "{}: {}".format(role, text or ""))
+        conn.execute("UPDATE sessions SET turns = MAX(turns, ?) WHERE id=?", (turn, session_id))
+        conn.commit()
+    finally:
+        if own:
+            conn.close()
+
+
+def record_tool_call(session_id: str, turn: int, tool: str, args: str = "", result: str = "",
+                     ok: bool = True, conn: Optional[sqlite3.Connection] = None) -> None:
+    own = conn is None
+    conn = conn or connect()
+    try:
+        conn.execute("INSERT INTO tool_calls(session_id, turn, tool, args, result, ok, ts) "
+                     "VALUES (?,?,?,?,?,?,?)",
+                     (session_id, turn, tool, args or "",
+                      result or "", 1 if ok else 0, time.time()))
+        _index(conn, session_id, "tool", "{} {} {}".format(tool, args or "", result or ""))
+        conn.commit()
+    finally:
+        if own:
+            conn.close()
+
+
+def record_snapshot(session_id: str, turn: int, state: Dict[str, Any],
+                    conn: Optional[sqlite3.Connection] = None) -> None:
+    """Persist a resumable context snapshot. Independent of raw prompt logs."""
+    own = conn is None
+    conn = conn or connect()
+    try:
+        blob = json.dumps(state, ensure_ascii=False)
+        conn.execute("INSERT INTO snapshots(session_id, turn, state, ts) VALUES (?,?,?,?)",
+                     (session_id, turn, blob, time.time()))
+        conn.commit()
+    finally:
+        if own:
+            conn.close()
+
+
+def end_session(session_id: str, status: str = "done", conn: Optional[sqlite3.Connection] = None) -> None:
+    own = conn is None
+    conn = conn or connect()
+    try:
+        conn.execute("UPDATE sessions SET ended_at=?, status=? WHERE id=?",
+                     (time.time(), status, session_id))
+        conn.commit()
+    finally:
+        if own:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- query API
+
+def list_sessions(limit: int = 50, conn: Optional[sqlite3.Connection] = None) -> List[Dict[str, Any]]:
+    own = conn is None
+    conn = conn or connect()
+    try:
+        rows = conn.execute(
+            "SELECT id, started_at, ended_at, provider, channel, task, status, turns "
+            "FROM sessions ORDER BY started_at DESC LIMIT ?", (limit,)).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        if own:
+            conn.close()
+
+
+def search(query: str, limit: int = 5, conn: Optional[sqlite3.Connection] = None) -> List[Dict[str, Any]]:
+    """Full-text search over sessions; returns the most relevant sessions (id + task + snippet)."""
+    own = conn is None
+    conn = conn or connect()
+    try:
+        results: List[Dict[str, Any]] = []
+        seen = set()
+        if _has_fts(conn):
+            try:
+                rows = conn.execute(
+                    "SELECT session_id, content FROM search_fts WHERE search_fts MATCH ? "
+                    "ORDER BY rank LIMIT ?", (_fts_query(query), limit * 4)).fetchall()
+            except sqlite3.OperationalError:
+                rows = []
+        else:
+            rows = conn.execute(
+                "SELECT session_id, content FROM search_like WHERE content LIKE ? LIMIT ?",
+                ("%" + query + "%", limit * 4)).fetchall()
+        for r in rows:
+            sid = r["session_id"]
+            if sid in seen:
+                continue
+            seen.add(sid)
+            srow = conn.execute("SELECT id, task, status, started_at FROM sessions WHERE id=?",
+                                (sid,)).fetchone()
+            if srow:
+                results.append({"session_id": sid, "task": srow["task"], "status": srow["status"],
+                                "snippet": (r["content"] or "")[:160]})
+            if len(results) >= limit:
+                break
+        return results
+    finally:
+        if own:
+            conn.close()
+
+
+def _fts_query(query: str) -> str:
+    """Turn a free-text query into a safe FTS5 MATCH (prefix-OR of the terms)."""
+    terms = [t for t in "".join(c if (c.isalnum() or c.isspace()) else " " for c in query).split() if t]
+    if not terms:
+        return '""'
+    return " OR ".join('"{}"*'.format(t) for t in terms)
+
+
+def show(session_id: str, conn: Optional[sqlite3.Connection] = None) -> Dict[str, Any]:
+    own = conn is None
+    conn = conn or connect()
+    try:
+        s = conn.execute("SELECT * FROM sessions WHERE id=?", (session_id,)).fetchone()
+        if not s:
+            return {"ok": False, "error": "no such session: {}".format(session_id)}
+        msgs = conn.execute("SELECT turn, role, text FROM messages WHERE session_id=? ORDER BY id",
+                            (session_id,)).fetchall()
+        tools = conn.execute("SELECT turn, tool, args, result, ok FROM tool_calls WHERE session_id=? "
+                             "ORDER BY id", (session_id,)).fetchall()
+        return {"ok": True, "session": dict(s), "messages": [dict(m) for m in msgs],
+                "tool_calls": [dict(t) for t in tools]}
+    finally:
+        if own:
+            conn.close()
+
+
+def resume(session_id: str, recent: int = 5, conn: Optional[sqlite3.Connection] = None) -> Dict[str, Any]:
+    """Reconstruct enough state to continue: the latest snapshot + recent messages/tool calls."""
+    own = conn is None
+    conn = conn or connect()
+    try:
+        s = conn.execute("SELECT id, task, status, turns FROM sessions WHERE id=?",
+                         (session_id,)).fetchone()
+        if not s:
+            return {"ok": False, "error": "no such session: {}".format(session_id)}
+        snap = conn.execute("SELECT turn, state FROM snapshots WHERE session_id=? "
+                            "ORDER BY id DESC LIMIT 1", (session_id,)).fetchone()
+        msgs = conn.execute("SELECT turn, role, text FROM messages WHERE session_id=? "
+                            "ORDER BY id DESC LIMIT ?", (session_id, recent)).fetchall()
+        tools = conn.execute("SELECT turn, tool, result, ok FROM tool_calls WHERE session_id=? "
+                             "ORDER BY id DESC LIMIT ?", (session_id, recent)).fetchall()
+        state = None
+        if snap:
+            try:
+                state = json.loads(snap["state"])
+            except (ValueError, TypeError):
+                state = {"raw": snap["state"]}
+        return {"ok": True, "session_id": session_id, "task": s["task"], "status": s["status"],
+                "turns": s["turns"], "latest_snapshot": state,
+                "resume_turn": snap["turn"] if snap else (s["turns"] or 0),
+                "recent_messages": [dict(m) for m in reversed(msgs)],
+                "recent_tool_calls": [dict(t) for t in reversed(tools)]}
+    finally:
+        if own:
+            conn.close()
+
+
+def export(session_id: str, conn: Optional[sqlite3.Connection] = None) -> Dict[str, Any]:
+    """Full session export (JSON-serializable)."""
+    data = show(session_id, conn=conn)
+    if not data.get("ok"):
+        return data
+    own = conn is None
+    conn = conn or connect()
+    try:
+        snaps = conn.execute("SELECT turn, state, ts FROM snapshots WHERE session_id=? ORDER BY id",
+                             (session_id,)).fetchall()
+        data["snapshots"] = [dict(s) for s in snaps]
+        return data
+    finally:
+        if own:
+            conn.close()
+
+
+# --------------------------------------------------------------------------- trace ingest
+
+def ingest_trace(path: str, conn: Optional[sqlite3.Connection] = None) -> Dict[str, Any]:
+    """Backfill sessions from a reasoning-trace JSONL (what every run writes via ``src.tracing``).
+
+    Maps the ACTUAL tracing phases — ``iteration_start`` / ``llm_call`` / ``action_parse`` /
+    ``policy_decision`` / ``iteration_result`` / ``error`` / ``iteration_end`` — into messages +
+    tool calls. Produces useful **searchable summaries even without bodies** (tool names,
+    provider/model, result size, error codes); when ``OMEGACLAW_TRACE_BODIES`` was set, the
+    prompt/response/result/failed-action bodies are ingested too. Best-effort per line.
+    """
+    own = conn is None
+    conn = conn or connect()
+    ingested = set()
+    n = 0
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except ValueError:
+                    continue
+                sid = ev.get("session_id")
+                if not sid:
+                    continue
+                if sid not in ingested:
+                    begin_session(sid, task="(ingested from trace)", conn=conn)
+                    ingested.add(sid)
+                turn = ev.get("iteration") or ev.get("turn_id") or 0
+                phase = ev.get("phase")
+
+                if phase in ("llm_call", "llm"):
+                    provider, model = ev.get("provider") or "", ev.get("model") or ""
+                    if provider:
+                        conn.execute("UPDATE sessions SET provider=? WHERE id=? AND (provider IS NULL OR provider='')",
+                                     (provider, sid))
+                    body = ev.get("response_body") or ev.get("response")
+                    text = body or "llm_call provider={} model={} response_chars={}".format(
+                        provider or "?", model or "?", ev.get("response_chars", "?"))
+                    record_message(sid, turn, "assistant", text, conn=conn)
+                elif phase in ("iteration_start", "input"):
+                    body = ev.get("input_body") or ev.get("input")
+                    if body:
+                        record_message(sid, turn, "user", body, conn=conn)
+                elif phase == "action_parse":
+                    tools = ev.get("tools") or []
+                    record_message(sid, turn, "system", "action_parse source={} ok={} tools={}".format(
+                        ev.get("source"), ev.get("ok"), ",".join(str(t) for t in tools)), conn=conn)
+                    for t in tools:                       # one tool_call per parsed tool (searchable)
+                        record_tool_call(sid, turn, str(t), "", "(parsed)", ev.get("ok") is not False, conn=conn)
+                elif phase == "policy_decision":
+                    record_tool_call(sid, turn, ev.get("tool") or "policy",
+                                     "risk={}".format(ev.get("risk")), ev.get("reason") or "",
+                                     ev.get("allowed") is not False, conn=conn)
+                elif phase in ("iteration_result", "result"):
+                    body = ev.get("result_body") or ev.get("result_text")
+                    record_tool_call(sid, turn, "result", "",
+                                     body or "result_chars={}".format(ev.get("result_chars", "?")),
+                                     True, conn=conn)
+                elif phase == "error":
+                    record_tool_call(sid, turn, ev.get("code") or ev.get("error_type") or "error",
+                                     ev.get("failed_action") or "",
+                                     ev.get("repair_hint") or ev.get("message") or "", False, conn=conn)
+                n += 1
+        for sid in ingested:
+            end_session(sid, "ingested", conn=conn)
+        conn.commit()
+        return {"ok": True, "sessions": len(ingested), "events": n}
+    except OSError as e:
+        return {"ok": False, "error": str(e)}
+    finally:
+        if own:
+            conn.close()
+
+
+def reset(path: Optional[str] = None) -> None:
+    """Test helper: delete the on-disk DB (and clear the FTS-availability cache)."""
+    p = path or db_path()
+    _HAS_FTS.pop(p, None)
+    if p != ":memory:" and os.path.exists(p):
+        os.remove(p)
+
+
+# --------------------------------------------------------------------------- selftest
+
+def _selftest() -> None:
+    import tempfile
+
+    dbp = os.path.join(tempfile.mkdtemp(prefix="session_store_selftest_"), "s.db")
+    os.environ["OMEGACLAW_SESSION_DB"] = dbp
+    reset(dbp)
+
+    begin_session("s1", provider="Test", channel="irc", task="deploy the widget service")
+    record_message("s1", 1, "user", "please deploy the widget service to staging")
+    record_message("s1", 1, "assistant", "starting deploy; running build")
+    record_tool_call("s1", 1, "shell", "make build", "build ok", True)
+    record_snapshot("s1", 1, {"task": "deploy widget", "step": "build done", "next": "run deploy"})
+    end_session("s1", "interrupted")
+
+    begin_session("s2", task="write the quarterly report")
+    record_message("s2", 1, "user", "draft the quarterly finance report")
+    end_session("s2", "done")
+
+    # search finds the right session
+    hits = search("widget deploy")
+    assert hits and hits[0]["session_id"] == "s1", hits
+    assert search("quarterly")[0]["session_id"] == "s2"
+
+    # resume reconstructs state
+    r = resume("s1")
+    assert r["ok"] and r["latest_snapshot"]["next"] == "run deploy" and r["resume_turn"] == 1
+    assert any("deploy" in m["text"] for m in r["recent_messages"])
+
+    # show + export
+    assert show("s1")["session"]["status"] == "interrupted"
+    assert export("s1")["snapshots"][0]["turn"] == 1
+
+    # content is persisted verbatim (no redaction at rest) and round-trips through show/export
+    begin_session("s3", task="use the api")
+    record_message("s3", 1, "assistant", "the plan is to ship the deploy tonight")
+    record_tool_call("s3", 1, "shell", "echo hello", "done")
+    assert "ship the deploy tonight" in json.dumps(show("s3"))
+
+    # ingest a trace JSONL
+    trace = os.path.join(tempfile.mkdtemp(), "t.jsonl")
+    with open(trace, "w", encoding="utf-8") as f:
+        f.write(json.dumps({"session_id": "tr1", "iteration": 1, "phase": "llm", "response": "hello world"}) + "\n")
+        f.write(json.dumps({"session_id": "tr1", "iteration": 1, "phase": "result", "result_text": "sent"}) + "\n")
+    ing = ingest_trace(trace)
+    assert ing["ok"] and ing["sessions"] == 1 and show("tr1")["ok"]
+
+    del os.environ["OMEGACLAW_SESSION_DB"]
+    print("session_store self-tests passed")
+
+
+if __name__ == "__main__":
+    _selftest()


### PR DESCRIPTION
## Description
Fixes #275. Adds a scheduler for time-based agent tasks.

- `src/scheduler.py` — cron / interval / one-shot jobs and webhook subscriptions, persisted in a SQLite jobs DB, with HMAC-verified webhook delivery. Job runs are recorded via the session store; stored text is scrubbed via the shared redactor. `is_safe_skill_name` is **inlined** (validates job/subscription ids that become filesystem path segments) so the scheduler carries no dependency on the skills subsystem.
- `scripts/omegaclaw-cron` — CLI to add / list / remove / run jobs.

**Depends on #266** (redaction) and **#274** (session_store) — both files are included in this branch and drop out on rebase as those PRs merge.

## How Has This Been Tested?
`Autotests/test_scheduler.py` (pure-Python, stdlib `sqlite3`/`hmac`, host-runnable), registered in `run_mandatory` — cron/interval/one-shot scheduling + next-run computation, job add/list/remove/run, webhook HMAC verification (valid/invalid signatures), the transient-webhook-id-never-deletes-a-durable-job regression, and id path-safety. Run: `cd Autotests && python3 test_scheduler.py` → 16/16 pass.

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
