### PR TITLE
channels/auth.py | remove dead logger assignment

### DIFF
--- a/channels/auth.py
+++ b/channels/auth.py
@@ -3,9 +3,6 @@ import os
 import time
 import urllib.request
 from pathlib import Path
-import logging
-
-logger = logging.getLogger(__name__)
 
 from src.logger import get_logger
 


### PR DESCRIPTION
## Description
Follow-up to #248, raised by @TossSky in review:

> Nit: channels/auth.py still has the old `import logging` and `logger = logging.getLogger(__name__)` right before `logger = get_logger(__name__)`; the first pair is now dead.

`logging` is not referenced anywhere else in the file, so both lines are removed.

## How Has This Been Tested?
No behaviour change - `logger` still resolves to `get_logger(__name__)`, which already overwrote the removed assignment. Verified the module imports cleanly and all `logger.*` call sites are unchanged.

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
