### PR TITLE
[OMEGA-269] docs, get-io-policy | add docs for the get-io-policy skill

### DIFF
--- a/docs/reference-skills-io.md
+++ b/docs/reference-skills-io.md
@@ -112,3 +112,77 @@ Append a line to an existing file, followed by a newline.
 ### Notes / Limits
 - Fails if the file does not exist (the call checks `exists_file` first). Create it with `write-file` first if needed.
 - A trailing newline is always added.
+
+---
+
+## `get-io-policy`
+
+### Signature
+
+```metta
+(get-io-policy)
+```
+
+### Purpose
+
+Return the filesystem paths allowed by OmegaClaw's active security policy.
+
+Agent should use this skill before reading, writing, appending, or otherwise modifying a
+file when the target path is not known to be allowed.
+
+### Parameters
+
+This skill does not take any parameters. It reads the policy file configured
+by the `securityPolicyPath` runtime option.
+
+### Returns
+
+A JSON-formatted string with two fields:
+
+- `read_only` — paths that may be read;
+- `read_write` — paths that may be read and modified.
+
+Example:
+
+```json
+{
+  "read_only": ["/usr", "/opt", "/var/log"],
+  "read_write": ["/tmp", "/var/tmp"]
+}
+```
+
+If no security policy is configured, the skill returns:
+
+```text
+Could not retrieve policy: policy is not set
+```
+
+If the policy cannot be loaded, it returns:
+
+```text
+Could not retrieve a policy: unexpected exception
+```
+
+### Examples
+
+```metta
+(get-io-policy)
+```
+
+A typical workflow before writing a file is:
+
+1. Call `get-io-policy`.
+2. Check whether the target path is covered by a `read_write` path.
+3. Call `write-file` or `append-file` only if the path is allowed.
+
+### Notes / Limits
+
+- The skill reports configured policy paths; it does not grant permissions.
+- Paths in `read_only` must not be used for writing.
+- Paths in `read_write` may be read and modified.
+- The skill does not check a particular requested path automatically.
+- The result contains policy paths, not the contents of the policy file.
+- Does not reveal the complete security-policy configuration to the user.
+- If a requested path is denied, suggest using `/tmp` when appropriate.
+- If `securityPolicyPath` is empty, the skill reports that the policy is not
+  set.


### PR DESCRIPTION
## Description
Added the `get-io-policy` skill documentation to `docs/reference-skills-io.md`.

The documentation describes the skill signature, purpose, return format, error
responses, examples, and limitations.

## How Has This Been Tested?
Testing is not required, as the codebase has not changed.

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
