### PR TITLE
[OMEGA-222] Add heartbeat api

### DIFF
--- a/src/loop.metta
+++ b/src/loop.metta
@@ -69,6 +69,7 @@
                         (change-state! &loops (- (get-state &loops) 1)))
           (let $prompt (getContext)
                (progn (log INFO "loop" (---------iteration $k))
+                      (heartbeat $k)
                       (let* (($msgrcv (string-safe (repr (receive))))
                              ($msgnew (prog1 (and (> (string_length $msgrcv) 0) (!= $msgrcv (get-state &prevmsg)))
                                              (if (> (string_length $msgrcv) 0) (change-state! &prevmsg $msgrcv) _)))

--- a/src/skills.metta
+++ b/src/skills.metta
@@ -79,6 +79,31 @@
      (collapse (match &self (= (prompt-extension $handle) $text) (remove-atom &self (= (prompt-extension $handle) $text))))
      True))
 
+; Heartbeat function is called at the start of each iteration of the agentic
+; loop. Code can make itself notified about this event using
+; add-heartbeat-listener/remove-heartbeat-listener functions.
+(= (heartbeat $iteration)
+   (let $_ (collapse (heartbeat-listener $_ $iteration)) ()))
+
+; placeholder to eliminate error when no heartbeat listener is added
+(= (heartbeat-listener placeholder $_) (empty))
+
+; Subscribe on heartbeat event notifications
+; $handle - symbol to identify the subscription
+; $callback - lambda to evaluate on event
+(= (add-heartbeat-listener $handle $callback)
+   (progn
+     (log INFO "skills" (strings-concat ("Add heartbeat listener " $handle)))
+     (add-atom &self (= (heartbeat-listener $handle $iter) ($callback $iter)))))
+
+; Unsubscribe from heartbeat event notifications
+; $handle - symbol to identify the subscription
+(= (remove-heartbeat-listener $handle)
+   (progn
+     (log INFO "skills" (strings-concat ("Remove heartbeat listener: " $handle)))
+     (collapse (match &self (= (heartbeat-listener $handle $arg) $body) (remove-atom &self (= (heartbeat-listener $handle $arg) $body))))
+     True))
+
 (= (read-file $file)
    (progn (translatePredicate (exists_file $file))
           (translatePredicate (read_file_to_string $file $content ()))

--- a/tests/src_skills.metta
+++ b/tests/src_skills.metta
@@ -22,3 +22,24 @@
          (remove-prompt-extension test-prompt)
          (contains-text (getPromptExtensions) "TEST PROMPT EXTENSION"))
        False)
+
+(= (on-heartbeat $iter)
+   (let $count (get-state &test_heartbeat_counter)
+     (change-state! &test_heartbeat_counter (+ $count $iter))))
+
+!(test (progn
+         (change-state! &test_heartbeat_counter 0)
+         (add-heartbeat-listener test-heartbeat (|-> ($iter) (on-heartbeat $iter)))
+         (heartbeat 1)
+         (heartbeat 2)
+         (remove-heartbeat-listener test-heartbeat)
+         (get-state &test_heartbeat_counter))
+       3)
+
+!(test (progn
+         (change-state! &test_heartbeat_counter 0)
+         (add-heartbeat-listener test-heartbeat (|-> ($iter) (on-heartbeat $iter)))
+         (remove-heartbeat-listener test-heartbeat)
+         (heartbeat 1)
+         (get-state &test_heartbeat_counter))
+       0)


### PR DESCRIPTION
## Description
This PR includes changes from #268 so should be reviewed and merged after #268 is merged.
The whole change includes the only commit https://github.com/asi-alliance/OmegaClaw-Core/pull/281/commits/e65e049bdf1ae738ef5e3c586ad2678778f5705b

In order to allow plugins execute the code on each agent loop iteration new heartbeat API is added.
There are two new functions:
- `(add-heartbeat-listener $handle $callback)` which adds a listener
- `(remove-heartbeat-listener $handle)` which removes the listener 

The example of usage is added as unit test `tests/src_skills.metta`.

## How Has This Been Tested?
Tested it by unit tests and added the example of hearbeat plugin which prints something on each iteration.

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
