### PR TITLE
[OMEGA-243] Fix: Runtime Openai embeddings

### DIFF
--- a/Autotests/run_mandatory
+++ b/Autotests/run_mandatory
@@ -34,6 +34,7 @@ mock/test_transition_metta_to_remember_mock.py
 mock/test_transition_pin_to_remember_mock.py
 mock/test_workflow_plugin_mock.py
 mock_websocket/test_wschat_unit.py
+test_openai_runtime_embeddings.py
 test_prompt_grounding.py
 test_websearch_smoke.py
 unit/test_fileio_verified_writes.py

--- a/Autotests/test_openai_runtime_embeddings.py
+++ b/Autotests/test_openai_runtime_embeddings.py
@@ -1,0 +1,65 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RAG_MODULE_PATH = REPO_ROOT / "src" / "rag.py"
+MEMORY_METTA_PATH = REPO_ROOT / "src" / "memory.metta"
+
+
+def load_rag_module(monkeypatch):
+    created_clients = []
+
+    class FakeEmbeddings:
+        def create(self, *, model, input):
+            assert model == "text-embedding-3-large"
+            assert input == ["runtime probe"]
+            return types.SimpleNamespace(
+                data=[types.SimpleNamespace(embedding=[0.1, 0.2, 0.3])]
+            )
+
+    class FakeOpenAI:
+        def __init__(self, *, base_url=None, api_key=None):
+            self.base_url = base_url
+            self.api_key = api_key
+            self.embeddings = FakeEmbeddings()
+            created_clients.append(self)
+
+    openai_module = types.ModuleType("openai")
+    openai_module.OpenAI = FakeOpenAI
+    chromadb_module = types.ModuleType("chromadb")
+    config_module = types.ModuleType("config")
+    config_module.config_get_by_key = (
+        lambda key, default=None: "http://gateway:8080" if key == "GATEWAY_URL" else default
+    )
+    llm_module = types.ModuleType("lib_llm_ext")
+    llm_module.initLocalEmbedding = lambda: None
+    llm_module.useLocalEmbedding = lambda text: [0.0]
+
+    monkeypatch.setitem(sys.modules, "openai", openai_module)
+    monkeypatch.setitem(sys.modules, "chromadb", chromadb_module)
+    monkeypatch.setitem(sys.modules, "config", config_module)
+    monkeypatch.setitem(sys.modules, "lib_llm_ext", llm_module)
+
+    spec = importlib.util.spec_from_file_location("rag_under_test", RAG_MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module, created_clients
+
+
+def test_runtime_openai_embedding_uses_proxy_and_returns_single_vector(monkeypatch):
+    rag, clients = load_rag_module(monkeypatch)
+
+    assert rag.openai_embed("runtime probe") == [0.1, 0.2, 0.3]
+    assert len(clients) == 1
+    assert clients[0].base_url == "http://gateway:8080/openai/"
+    assert clients[0].api_key == "unused"
+
+
+def test_memory_metta_routes_openai_embeddings_to_rag_wrapper():
+    memory_metta = MEMORY_METTA_PATH.read_text(encoding="utf-8")
+
+    assert "(py-call (rag.openai_embed (string-safe $str)))" in memory_metta
+    assert "useGPTEmbedding" not in memory_metta

--- a/Autotests/test_openai_runtime_embeddings.py
+++ b/Autotests/test_openai_runtime_embeddings.py
@@ -38,6 +38,7 @@ def load_rag_module(monkeypatch):
     llm_module.initLocalEmbedding = lambda: None
     llm_module.useLocalEmbedding = lambda text: [0.0]
 
+    monkeypatch.syspath_prepend(str(REPO_ROOT))
     monkeypatch.setitem(sys.modules, "openai", openai_module)
     monkeypatch.setitem(sys.modules, "chromadb", chromadb_module)
     monkeypatch.setitem(sys.modules, "config", config_module)

--- a/src/memory.metta
+++ b/src/memory.metta
@@ -45,7 +45,7 @@
 (= (embed $str)
    (if (== (embeddingprovider) Local)
        (py-call (lib_llm_ext.useLocalEmbedding (string-safe $str)))
-       (useGPTEmbedding (string-safe $str))))
+       (py-call (rag.openai_embed (string-safe $str)))))
 
 (= (appendToHistory $addition)
    (append-file-raw (library OmegaClaw-Core ./memory/history.metta) (swrite $addition)))

--- a/src/rag.py
+++ b/src/rag.py
@@ -151,6 +151,12 @@ def openai_embed_batch(texts):
         raise RuntimeError(f"Embedding request failed: {e}") from e
     return [item.embedding for item in resp.data]
 
+
+def openai_embed(text):
+    """Embed one runtime memory string via the configured OpenAI route."""
+    return openai_embed_batch([text])[0]
+
+
 def local_embed_batch(texts):
     """Embed a list of texts via lib_llm_ext local embeddings."""
     if isinstance(texts, str):


### PR DESCRIPTION
## Description
Fixes runtime OpenAI embeddings by routing memory embedding requests through the proxy-aware `rag.py` implementation instead of the missing `useGPTEmbedding` procedure.

## How Has This Been Tested?
Added a mock test verifying the runtime embedding path uses `GATEWAY_URL/openai/`, returns an embedding vector, and no longer references `useGPTEmbedding`.

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
