### PR TITLE
[OMEGA-292] Add plugin location to sys.path in the MeTTa loader

### DIFF
--- a/src/plugin.metta
+++ b/src/plugin.metta
@@ -23,6 +23,8 @@
            (let $path (joinPath ($location $name)) ())
            (let $space (atom-concat & (atom-concat plugin- $name)) ())
            (log INFO "plugin" (strings-concat ("Loading MeTTa plugin " $name " from " $path ".metta")))
+           ; put the plugin folder on sys.path so it can py-call into its own .py files
+           (let $addpathrc (py-call (plugin.addLocationToPath $location)) ())
              (if (== () (collapse (import! $space $path)))
                (Error (_loadMettaPlugin $name $location) (strings-concat ("Cannot import " $name " plugin from " $path)))
                (progn

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -64,6 +64,14 @@ class PythonPlugin:
     def __init__(self, mod):
         self.mod = mod
 
+def addLocationToPath(location):
+    """Add a plugin's folder to sys.path so a plugin made of several files can
+    import its own modules. Used by the Python loader for multi-file Python
+    plugins, and by the MeTTa loader so a MeTTa plugin can py-call into its own
+    .py file."""
+    global _REPO
+    sys.path.append(str(pathlib.Path(location.format(REPO=_REPO)).resolve()))
+
 def loadPythonPlugin(name, location):
     """Python plugin loader implementation. If location of the plugin is
     specified it imports "<location>/<name>.py" file. Imports <name> Python
@@ -77,12 +85,12 @@ def loadPythonPlugin(name, location):
         logger.info(f"_initPythonPlugin: loading {name} plugin from PYTHONPATH using Python module loader")
         mod = importlib.import_module(name)
     else:
+        # adding location into sys.path to be able loading plugins which
+        # consist of multiple files
+        addLocationToPath(location)
         location = pathlib.Path(location.format(REPO=_REPO)).resolve()
         modpath = location.joinpath(f"{name}.py").resolve()
         logger.info(f"_initPythonPlugin: loading {name} plugin from {modpath} using Python module loader")
-        # adding location into sys.path to be able loading plugins which
-        # consist of multiple files
-        sys.path.append(str(location))
         spec = importlib.util.spec_from_file_location(name, modpath)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)


### PR DESCRIPTION
## Description
MeTTa-loaded plugins can't `py-call` into their own `.py` files. The Python loader (`src/plugin.py`) puts each plugin's folder on `sys.path`; the MeTTa loader (`src/plugin.metta`) never does, so a MeTTa plugin that imports a sibling `.py` dies at load with `ModuleNotFoundError` and the whole plugin is dropped.

@vsbogd hit this directly on #228:

> I faced some issues with import Python modules when plugin was loaded by MeTTa loader before.

**Why it has to land:** it blocks every mixed MeTTa/Python plugin. The health/status endpoint on #228 is exactly that shape — a MeTTa plugin driving its own Python HTTP server — so it can't be finished until this is fixed. The change factors the `sys.path` logic into `addLocationToPath` and calls it from both loaders, matching the Python loader's existing behavior.

## How Has This Been Tested?
Built the runtime image and loaded a MeTTa plugin that `py-call`s a sibling `.py`:
- With the fix: loads and returns (`PATHPROBE-OK … pong-from-sibling-py`).
- Reverting only `plugin.metta` on the same image: `ModuleNotFoundError: No module named 'probe_helper'`.
- All existing plugins still load (11 Python + the `workflow` MeTTa plugin); `initPlugins` returns cleanly.

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
