### PR TITLE
[OMEGA-304] Fix: remove unconditional ALERT_FAILED prompt instruction

### DIFF
--- a/Autotests/mock/test_last_skill_results_visible_next_turn_mock.py
+++ b/Autotests/mock/test_last_skill_results_visible_next_turn_mock.py
@@ -89,4 +89,11 @@ def test_last_skill_results_visible_next_turn_mock(llm, comm):
         c.ok("sentinel in lastresults",
              f"found in {len(relevant)} subsequent iteration prompt(s)")
 
+        deprecated_instruction = "you must rectify ALERT_FAILED skill use cases"
+        if any(deprecated_instruction in ln for ln in relevant):
+            c.fail("no unconditional failure instruction",
+                   f"found deprecated prompt text: {deprecated_instruction!r}")
+        c.ok("no unconditional failure instruction",
+             "LAST_SKILL_USE_RESULTS contains feedback without failure guidance")
+
         c.done()

--- a/src/loop.metta
+++ b/src/loop.metta
@@ -39,7 +39,7 @@
                          " toolName4 arg4" (newline)
                          " toolName5 arg5" (newline)
                          " SAVE_PERMANENT_FILES_DIR: " (memoryDirectory)
-                         " LAST_SKILL_USE_RESULTS: you must rectify ALERT_FAILED skill use cases " (last_chars (get-state &lastresults) (maxFeedback)) 
+                         " LAST_SKILL_USE_RESULTS: " (last_chars (get-state &lastresults) (maxFeedback))
                          " HISTORY: " (getHistory) 
                          " TIME: " (get_time_as_string)))))
 


### PR DESCRIPTION
## Description
Removed the unconditional ALERT_FAILED remediation instruction from LAST_SKILL_USE_RESULTS.

## How Has This Been Tested?
- Built and ran the local Docker image.
- Verified a successful write-file call creates the expected file.
- Confirmed runtime logs no longer contain the removed instruction.

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
