### PR TITLE
[OMEGA-306] Fix: Prevent channel auth takeover after restart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN git clone --depth 1 --branch "${FAISS_REF}" "${FAISS_REPO}" /faiss
 
 WORKDIR /faiss
 RUN cmake -B build -DFAISS_ENABLE_GPU=OFF -DFAISS_ENABLE_PYTHON=OFF -DBUILD_SHARED_LIBS=OFF \
- && cmake --build build --config Release --parallel 1 \
+ && cmake --build build --config Release --parallel \
  && cmake --install build
 
 WORKDIR /PeTTa

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN git clone --depth 1 --branch "${FAISS_REF}" "${FAISS_REPO}" /faiss
 
 WORKDIR /faiss
 RUN cmake -B build -DFAISS_ENABLE_GPU=OFF -DFAISS_ENABLE_PYTHON=OFF -DBUILD_SHARED_LIBS=OFF \
- && cmake --build build --config Release --parallel \
+ && cmake --build build --config Release --parallel 1 \
  && cmake --install build
 
 WORKDIR /PeTTa

--- a/channels/auth.py
+++ b/channels/auth.py
@@ -103,17 +103,11 @@ def store_channel_authenticated_user_id(channel_identifier, user_id):
     return True
 
 
-def get_channel_saved_user_id(channel_identifier, user_id):
-    # For any single run of OmegaClaw, allow only a single save of a user-id or verification    
-    global _user_ID_processed
-    if _user_ID_processed:
-        logger.warning(f"[{channel_identifier}] Warning: a user was already validated, ignoring")
-        return False
-
+def get_channel_authenticated_user_id(channel_identifier):
+    """Return the first owner persisted for a channel, if one exists."""
     channel_identifier = str(channel_identifier or "").strip()
-    user_id = str(user_id or "").strip()
-    if not user_id:
-        return False
+    if not channel_identifier:
+        raise ValueError("channel_identifier is required")
     try:
         path = _channel_auth_user_path()
         with open(path, "r", encoding="utf-8") as f:
@@ -125,29 +119,38 @@ def get_channel_saved_user_id(channel_identifier, user_id):
                 except (AttributeError, json.JSONDecodeError) as e:
                     logger.warning(f"Skipping malformed channel authenticated user record: {e}")
                     continue
-                if saved_channel_identifier == channel_identifier and saved_user_id == user_id:
-                    _user_ID_processed = True
-                    return True
+                if saved_channel_identifier == channel_identifier and saved_user_id:
+                    return saved_user_id
     except FileNotFoundError:
-        return False
+        return None
     except Exception as e:
         raise RuntimeError("Failed to read channel authenticated user records") from e
-    return False
+    return None
+
+
+def get_channel_saved_user_id(channel_identifier, user_id):
+    global _user_ID_processed
+    saved_user_id = get_channel_authenticated_user_id(channel_identifier)
+    if saved_user_id != str(user_id or "").strip():
+        return False
+    _user_ID_processed = True
+    return True
+
 
 def authenticate_channel_user(channel_identifier, user_id, auth_candidate=None):
+    # A persisted owner takes precedence over the reusable startup secret,
+    # including after a process restart.
+    saved_user_id = get_channel_authenticated_user_id(channel_identifier)
+    if saved_user_id is not None:
+        return "allow" if saved_user_id == str(user_id or "").strip() else "ignore"
+
     # A token is accepted only when it came from an explicit auth command.
-    # Otherwise see if there was a prior session with the user-id and channel.
     if auth_candidate is not None and verify_token(auth_candidate):
-       if store_channel_authenticated_user_id(channel_identifier, user_id):
+        if store_channel_authenticated_user_id(channel_identifier, user_id):
             label = str(channel_identifier).upper()
             logger.info(f"[{label}] Saved authenticated user ID")
             return "auth_bound"
-       else:
+        else:
             logger.error(f"[{label}] ERROR -- Unable to save user ID")
             return "ignore"
-    elif get_channel_saved_user_id(channel_identifier, user_id):
-        label = str(channel_identifier).upper()
-        logger.info(f"[{label}] Verified previously validated user ID")
-        return "allow"
-    else:
-        return "ignore"
+    return "ignore"

--- a/tests/test_auth_standalone.py
+++ b/tests/test_auth_standalone.py
@@ -67,9 +67,31 @@ def test_corrupt_saved_user_file_is_wrapped(monkeypatch, tmp_path):
         auth.get_channel_saved_user_id("IRC", "alice")
 
 
+def test_saved_owner_blocks_auth_secret_reuse_after_restart(monkeypatch, tmp_path):
+    monkeypatch.setenv("OMEGACLAW_AUTH_SECRET", "one-time-secret")
+
+    first_process = load_auth_module(monkeypatch)
+    monkeypatch.setattr(first_process, "_MEMORY_DIRECTORY", str(tmp_path))
+    assert first_process.authenticate_channel_user(
+        "IRC", "owner", "one-time-secret"
+    ) == "auth_bound"
+
+    restarted_process = load_auth_module(monkeypatch)
+    monkeypatch.setattr(restarted_process, "_MEMORY_DIRECTORY", str(tmp_path))
+    assert restarted_process.authenticate_channel_user(
+        "IRC", "attacker", "one-time-secret"
+    ) == "ignore"
+
+    owner_process = load_auth_module(monkeypatch)
+    monkeypatch.setattr(owner_process, "_MEMORY_DIRECTORY", str(tmp_path))
+    assert owner_process.authenticate_channel_user("IRC", "owner") == "allow"
+
+
 def test_plain_message_does_not_verify_a_token(monkeypatch):
     auth = load_auth_module(monkeypatch)
-    monkeypatch.setattr(auth, "verify_token", lambda candidate: pytest.fail("unexpected token check"))
-    monkeypatch.setattr(auth, "get_channel_saved_user_id", lambda *args: False)
+    monkeypatch.setattr(
+        auth, "verify_token", lambda candidate: pytest.fail("unexpected token check")
+    )
+    monkeypatch.setattr(auth, "get_channel_authenticated_user_id", lambda *args: None)
 
     assert auth.authenticate_channel_user("IRC", "alice") == "ignore"


### PR DESCRIPTION
## Description
Prevented channel-session takeover after an OmegaClaw restart by preserving and enforcing the originally authenticated owner.

## How Has This Been Tested?
Authenticated one IRC user, restarted OmegaClaw, then tried the same auth code from a second nickname. Confirmed the second nickname was ignored and the original user could continue messaging the bot.

## Checklist
- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
