### PR TITLE
[OMEGA-291] Add CI coverage for the OpenClaw delegation plugin

### DIFF
--- a/.github/workflows/autotests.yml
+++ b/.github/workflows/autotests.yml
@@ -54,6 +54,10 @@ jobs:
     env:
       AUTOTESTS_OMEGACLAW_CONTAINER: omegaclaw
       AUTOTESTS_OMEGACLAW_TAG: 'cicd-${{ github.run_id }}'
+      # Not a real credential: it authenticates against the stub Gateway that
+      # the openclaw fixture starts. It also gives test_credentials_scrubbed_mock
+      # a token that is really present, so that check can fail if one leaks.
+      OMEGACLAW_OPENCLAW_TOKEN: 'ci-openclaw-stub-token'
     steps:
       - name: Complete tag name
         run: |
@@ -99,7 +103,7 @@ jobs:
       - name: Autotests - Set up
         run: |
           chmod +x ./scripts/omegaclaw
-          ./scripts/omegaclaw start -p Test -t test -d singularitynet/omegaclaw:${{ env.AUTOTESTS_OMEGACLAW_TAG }}
+          ./scripts/omegaclaw start -p Test -t test -d singularitynet/omegaclaw:${{ env.AUTOTESTS_OMEGACLAW_TAG }} -g "http://host.docker.internal:18789"
           pip install pytest
           echo "Waiting for agent to become ready..."
           ready=

--- a/Autotests/mock/README.md
+++ b/Autotests/mock/README.md
@@ -65,41 +65,38 @@ source venv/bin/activate
 pytest -s -v mock/test_*_mock.py
 ```
 
-The `LlmMockController` and `CommMockServer` are provided by session-scoped fixtures in `mock/conftest.py`, so both are started once per pytest session. Expected output: `34 passed` (or `33 passed, 1 skipped` if `OMEGACLAW_GIT_TOKEN` is not set), plus whatever plugin-specific suites you have prerequisites for (see "OpenClaw plugin" below) - those are not counted in the `34`.
+The `LlmMockController`, `CommMockServer`, and the OpenClaw Gateway stub are provided by session-scoped fixtures in `mock/conftest.py`, so all three are started once per pytest session. Expected output: `42 passed`, minus the ones whose optional variables are unset - `test_git_push_to_remote_mock` skips without `OMEGACLAW_GIT_TOKEN`, and the six OpenClaw tests skip without `OMEGACLAW_OPENCLAW_TOKEN` (see "OpenClaw plugin" below).
 
 ## 5a. OpenClaw plugin (`test_openclaw_delegate_mock.py`)
 
-Unlike the rest of this suite, `mock/test_openclaw_delegate_mock.py` depends on infrastructure that lives outside the OmegaClaw container: an **OpenClaw Gateway**. The `openclaw` plugin (`plugins/openclaw/`) bridges the `delegate-task-to-openclaw-agent` skill to that Gateway over HTTP, so the skill it exercises makes a real network call - the LLM and comm channel are mocked as usual, but the delegation itself is not. Full Gateway setup (enabling the OpenResponses endpoint, registering an agent, getting the token) is documented in [`plugins/openclaw/README.md`](../../plugins/openclaw/README.md); read that first.
+`mock/test_openclaw_delegate_mock.py` exercises the `openclaw` plugin (`plugins/openclaw/`), whose `delegate-task-to-openclaw-agent` skill talks HTTP to an **OpenClaw Gateway**. The suite brings its own: the session-scoped `openclaw_gateway` fixture in `conftest.py` starts the stub in `mock/ocgw_stub.py`, which implements the same OpenResponses `POST /v1/responses` contract on port 18789. No external Gateway, no manual setup, and the file runs under a plain `pytest mock/test_*_mock.py` like everything else here.
 
-These tests do not start, stop, or configure the Gateway - exactly like the OmegaClaw container itself in steps 2–3 above, it must already be running and reachable (a mock Gateway stub or a live one) before you run this file. The token never reaches the agent process: a local Nginx proxy injects it (see "The token never reaches the agent process" in the plugin README), so the container must be started with the Gateway URL known *at launch*, not only in `config/config.yaml`. Before running it, check:
+The stub is what makes the interesting cases reachable at all. Its behaviour is steered by markers inside the delegated task, so a test can ask for a Gateway that stalls, refuses, or answers with nothing:
 
-1. **The plugin is enabled and pointed at your Gateway.** Add `-g <gateway URL>` when starting the container with `scripts/omegaclaw`:
+| Marker in the task text | Gateway behaviour |
+| --- | --- |
+| `OCGW_SLEEP:<seconds>` | holds the reply, used to prove delegation does not block the agent loop |
+| `OCGW_503:<n>` | answers `503` with `Retry-After` for the first `<n>` calls, then succeeds |
+| `OCGW_UNAUTHORIZED` | answers `401` regardless of the token |
+| `OCGW_NOTEXT` | answers `200` with a reasoning-only output and no visible text |
+| `Reply with exactly: X` | answers exactly `X` |
 
+The stub also records every request it served, so a test can assert what the Gateway actually saw rather than inferring it from the agent's history: whether Nginx injected the `Authorization` header, and whether two delegations really landed in separate sessions.
+
+Two things must still be true of the container, because the plugin is configured at launch:
+
+1. **Start it with `-g`**, which points Nginx's `/openclaw/` proxy at the stub and sets `openClawEnabled`/`openClawURL` - no `config/config.yaml` edit needed:
+
+   ```bash
+   env TEST_SERVER_IP=172.17.0.1 OMEGACLAW_OPENCLAW_TOKEN=<token> \
+     ./scripts/omegaclaw start -s 0000 -p Test -t test -d omegaclaw:mock -g "http://172.17.0.1:18789"
    ```
-   env TEST_SERVER_IP=172.17.0.1 ./scripts/omegaclaw start -s 0000 -p Test -t test -d omegaclaw:mock -g "http://<gateway-host>:18789"
-   ```
 
-   `-g` both configures Nginx's `/openclaw/` proxy target and sets `openClawEnabled`/`openClawURL` for the plugin - no manual `config/config.yaml` edit needed. (Starting the container by hand instead of through the script? Pass `openclaw_url=<gateway URL>` as a container argument same as `openaiapi_url=`, see `entrypoint.sh`.) `config/plugins.yaml` must still list the plugin:
+   Use the address the container reaches the host on: `172.17.0.1` under the default Docker bridge, `host.docker.internal` in CI. Starting the container by hand instead of through the script? Pass `openclaw_url=<gateway URL>` as a container argument, same as `openaiapi_url=` (see `entrypoint.sh`).
 
-   ```yaml
-   - name: openclaw
-     loader: metta
-     location: "{REPO}/plugins/openclaw"
-   ```
+2. **Export `OMEGACLAW_OPENCLAW_TOKEN`.** The stub accepts exactly this value, so the tests fail if Nginx does not inject it. Nginx reads it before the agent's environment is scrubbed, which is also what gives `test_credentials_scrubbed_mock.py` a real token to catch a leak of - with the variable unset, that assertion passes without proving anything.
 
-   On container startup the log should show `openclaw-plugin: OpenClaw integration is enabled`; if it says "disabled" or errors about a missing `openClawURL`, the tests will fail before ever reaching the Gateway - fix the startup command.
-
-2. **The token is exported to the container.** `OMEGACLAW_OPENCLAW_TOKEN=<token> ./scripts/omegaclaw start ... -g "<gateway URL>"` (or `docker run -e OMEGACLAW_OPENCLAW_TOKEN=<token> ...` if starting by hand). It must match the Gateway's `OPENCLAW_GATEWAY_TOKEN`. Nginx reads it before the agent's environment is scrubbed and injects it into the `Authorization` header itself - `test_credentials_scrubbed_mock.py` asserts it never reaches the agent process, same as the LLM provider keys.
-
-3. **The Gateway is reachable at the URL you passed to `-g`**, with the OpenResponses endpoint enabled and `openClawAgent` (`main` by default) present in `agents.entries`. Sanity-check it independently with the `curl` snippet in the plugin README before assuming the test is broken.
-
-Because this file needs a prerequisite the rest of the suite doesn't, run it on its own rather than relying on it being swept up by a broad `test_*_mock.py` glob in an environment without a Gateway configured:
-
-```
-pytest -s -v mock/test_openclaw_delegate_mock.py
-```
-
-If a test hangs waiting on `send`, check the container logs first - the skill's own error message (unreachable Gateway, `401 Unauthorized`, unknown agent, ...) is usually self-explanatory and listed in the plugin README's troubleshooting table.
+If the token is unset the suite skips, since the plugin cannot be exercised at all. If the token is set but the container was started without `-g`, the fixture fails instead of skipping: a token with a disabled plugin means the run would look green while testing nothing.
 
 ## 6. Tear down
 
@@ -111,7 +108,7 @@ This removes the `omegaclaw` container and the `omegaclaw-memory` volume created
 
 # Tests description
 
-All 34 tests follow the same pattern: the test registers a fixed mock-LLM answer for the prompt via `llm.set_answer(prompt, response)`, delivers the prompt to the agent over the test channel via `comm.send_message(prompt)`, then verifies the resulting skill calls and side effects (filesystem, `history.metta`, ChromaDB, docker logs). Because the LLM is deterministic, no `try_with_clarification` retries are needed; every test either passes on the first attempt or fails outright.
+All 42 tests follow the same pattern: the test registers a fixed mock-LLM answer for the prompt via `llm.set_answer(prompt, response)`, delivers the prompt to the agent over the test channel via `comm.send_message(prompt)`, then verifies the resulting skill calls and side effects (filesystem, `history.metta`, ChromaDB, docker logs). The OpenClaw group additionally drives the stub Gateway, whose replies are real rather than scripted. Because the LLM is deterministic, no `try_with_clarification` retries are needed; every test either passes on the first attempt or fails outright.
 
 ## Creating files
 
@@ -381,7 +378,7 @@ Verifies that provider keys, channel tokens, and the auth secret are scrubbed fr
 
 ## OpenClaw plugin (`test_openclaw_delegate_mock.py`)
 
-Requires a running, configured OpenClaw Gateway - see "5a. OpenClaw plugin" above before running these. Unlike every other test in this file, the mocked LLM only decides *to call* `delegate-task-to-openclaw-agent`; the skill itself is not scripted and makes a real HTTP call to the Gateway, so its result is genuine, not canned.
+The Gateway is the stub started by the `openclaw_gateway` fixture - see "5a. OpenClaw plugin" above. Unlike every other test in this file, the mocked LLM only decides *to call* `delegate-task-to-openclaw-agent`; the skill itself is not scripted and makes a real HTTP call, so its result is genuine, not canned.
 
 Delegation is asynchronous, so these tests assert two stages: the acceptance envelope returned immediately (captured with `write-file`), and the `OPENCLAW_RESULT ...` line the plugin appends to `history.metta` once the Gateway answers (polled with `wait_for_history_keyword`).
 
@@ -407,3 +404,40 @@ Verifies the "new session per delegation" contract from the plugin README: two i
 
 - Mock answer: two `(metta (write-file ... (delegate-task-to-openclaw-agent "Reply with exactly: FIRST-<run_id>" / "SECOND-<run_id>")))` calls, then `(send "Both delegations saved <run_id>")`.
 - Checks: both envelopes are `accepted` with different `id` values; an `id=<task id> status=ok` record for each of them later reaches history (keyed on the task id for the reason given under test 35); the run's slice of history carries two distinct `responseId=` values. The scoping to this run's window keeps ids left by test 35 from satisfying the check on their own.
+
+### 38. test_delegate_stays_async_under_a_slow_gateway_mock
+
+The one test that can tell an asynchronous delegation from a synchronous one. The rest of this group answers against a Gateway that replies instantly, so a blocking implementation would clear their budgets too.
+
+- Mock answer: `(delegate-task-to-openclaw-agent "OCGW_SLEEP:30 Reply with exactly: SLOW-<run_id>") (send "Long delegation started <run_id>")`, then a second, unrelated prompt answered with `(send "STILL-ALIVE-<run_id>")`.
+- Checks: the acknowledgement lands within 15s while the Gateway is still holding the reply for 30s, so a delegation that blocked the loop cannot pass; the unrelated prompt is answered before the Gateway releases; the slow reply still reaches history afterwards.
+
+### 39. test_delegate_reports_gateway_rejection_mock
+
+A Gateway rejection must reach the agent instead of disappearing, since the skill returns before the call is made.
+
+- Mock answer: `(metta (write-file "<out>.json" (delegate-task-to-openclaw-agent "OCGW_UNAUTHORIZED <run_id>"))) (send "Refused delegation checked <run_id>")`.
+- Checks: the envelope still says `accepted`; an `id=<task id> status=error` record carrying `401` later reaches history; the agent stays responsive throughout.
+
+### 40. test_delegate_retries_a_starting_gateway_mock
+
+A Gateway that is still booting answers `503`, which the worker retries up to `STARTUP_RETRY_ATTEMPTS` times.
+
+- Mock answer: `(metta (write-file "<out>.json" (delegate-task-to-openclaw-agent "OCGW_503:2 Reply with exactly: RETRIED-<run_id>"))) (send "Retry delegation started <run_id>")`.
+- Checks: the agent acknowledges without waiting out the retries, so they run off the loop; the delegation eventually succeeds with `status=ok`; the stub recorded three attempts, two refused and one served, rather than a single call.
+
+### 41. test_delegate_reports_a_reply_without_text_mock
+
+A terminal response whose `output` holds only reasoning items carries no visible reply, and must not be reported as an empty success.
+
+- Mock answer: `(metta (write-file "<out>.json" (delegate-task-to-openclaw-agent "OCGW_NOTEXT <run_id>"))) (send "Empty reply checked <run_id>")`.
+- Checks: the agent survives; an `id=<task id> status=error` record reaches history.
+
+### 42. test_delegation_is_authenticated_by_the_proxy_mock
+
+The delegation path is authenticated by Nginx rather than by the agent, checked at the receiving end.
+
+- Mock answer: `(delegate-task-to-openclaw-agent "Reply with exactly: TOKEN-<run_id>") (send "Token delegation sent <run_id>")`.
+- Checks: the stub recorded at least one request whose `Authorization` header matched the token, and no request arrived without that header. Since the agent process never holds the token, a matching header can only have come from the proxy.
+
+The other half of this property - that `OMEGACLAW_OPENCLAW_TOKEN` never reaches the agent process - belongs to `test_credentials_scrubbed_mock.py`, which reads the environment the agent dumps for itself. Do not check it with `dexec`: `docker exec` starts a new process from the container's own configuration, which does carry the token by design, so such a check fails while the scrubbing works correctly.

--- a/Autotests/mock/conftest.py
+++ b/Autotests/mock/conftest.py
@@ -19,11 +19,16 @@ needed. We monkey-patch helpers at session start to drop those waits
 and lower POLL, which leaves Autotests/helpers.py untouched for live
 runs.
 """
+import os
+import re
+import subprocess
+
 import pytest
 
 import helpers
 from comm import CommMockServer, COMM_MOCK_PORT
 from llm import LlmMockController, LLM_MOCK_PORT
+from ocgw_stub import GATEWAY_PORT, GatewayStub
 
 
 def _mock_checker_exit(self, _exc_type, _exc_val, _exc_tb):
@@ -60,3 +65,38 @@ def comm():
         yield server
     finally:
         server.stop(5)
+
+
+@pytest.fixture(scope="session")
+def openclaw_gateway():
+    token = os.environ.get("OMEGACLAW_OPENCLAW_TOKEN", "")
+    if not token:
+        pytest.skip("OMEGACLAW_OPENCLAW_TOKEN is not set, so the openclaw plugin cannot be "
+                    "exercised; start the container with -g <gateway url> and the token")
+    # A token with the plugin disabled means the container was started without
+    # -g. Fail here instead of skipping: the token is always set in CI, so a
+    # skip would hide a suite that checks nothing.
+    #
+    # Match the runtime log line, not the phrase: the container log also carries
+    # the MeTTa source dump and its prolog translation, so the plain text
+    # appears even when the plugin is off.
+    container = os.environ.get("OMEGACLAW_CONTAINER", "omegaclaw")
+    logs = subprocess.run(["docker", "logs", container],
+                          capture_output=True, text=True, errors="replace")
+    enabled = re.search(r"\|\s*openclaw-plugin\s*\|\s*\"OpenClaw integration is enabled\"",
+                        logs.stdout + logs.stderr)
+    if not enabled:
+        pytest.fail("OMEGACLAW_OPENCLAW_TOKEN is set but the openclaw plugin is disabled in "
+                    f"container {container!r}: start it with -g <gateway url> "
+                    f"pointing at port {GATEWAY_PORT}")
+    stub = GatewayStub(token).start()
+    try:
+        yield stub
+    finally:
+        stub.stop(5)
+
+
+@pytest.fixture
+def gateway(openclaw_gateway):
+    openclaw_gateway.recorder.reset()
+    return openclaw_gateway

--- a/Autotests/mock/ocgw_stub.py
+++ b/Autotests/mock/ocgw_stub.py
@@ -1,0 +1,173 @@
+"""Stub OpenClaw Gateway implementing the OpenResponses POST /v1/responses contract.
+
+The `openclaw_gateway` fixture in conftest.py starts it, so the delegation
+tests carry their own Gateway rather than needing an external one. It uses
+the standard library only.
+
+Markers inside the delegated task text choose how the Gateway answers, since
+the task text is the one thing a test controls all the way through:
+
+    OCGW_SLEEP:<seconds>   hold the reply, used to prove delegation is async
+    OCGW_503:<n>           answer 503 + Retry-After for the first <n> calls
+    OCGW_UNAUTHORIZED      answer 401 regardless of the token
+    OCGW_NOTEXT            answer 200 with a reasoning-only output
+    Reply with exactly: X  answer exactly X
+
+The stub records every request, so a test can check what the Gateway received
+instead of inferring it from the agent's history: whether Nginx injected the
+token, and whether two delegations landed in separate sessions.
+"""
+import json
+import re
+import threading
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+GATEWAY_PORT = 18789
+RESPONSES_PATH = "/v1/responses"
+
+
+class GatewayRecorder:
+    def __init__(self, token):
+        self.token = token
+        self.requests = []
+        self._lock = threading.Lock()
+        self._counter = 0
+        self._503_seen = {}
+
+    def record(self, entry):
+        with self._lock:
+            self.requests.append(entry)
+
+    def next_response_id(self):
+        with self._lock:
+            self._counter += 1
+            return f"resp_{self._counter}_{uuid.uuid4().hex[:12]}"
+
+    def count_503(self, key):
+        with self._lock:
+            seen = self._503_seen.get(key, 0)
+            self._503_seen[key] = seen + 1
+            return seen
+
+    def reset(self):
+        with self._lock:
+            self.requests = []
+            self._503_seen = {}
+
+    def authorized_requests(self):
+        return [r for r in self.requests if r["auth_ok"]]
+
+    def response_ids(self):
+        return [r["response_id"] for r in self.requests if r.get("response_id")]
+
+
+def _make_handler(recorder):
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, *args):
+            pass
+
+        def _reply(self, code, payload, extra_headers=None):
+            body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            for key, value in (extra_headers or {}).items():
+                self.send_header(key, value)
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            self._reply(200, {"status": "alive"})
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            raw = self.rfile.read(length).decode("utf-8", "replace")
+            auth = self.headers.get("Authorization", "")
+            try:
+                body = json.loads(raw)
+            except ValueError:
+                body = {}
+            task = str(body.get("input", ""))
+
+            entry = {
+                "path": self.path,
+                "agent": self.headers.get("x-openclaw-agent-id", ""),
+                "auth_header_present": bool(auth),
+                "auth_ok": bool(recorder.token) and auth == f"Bearer {recorder.token}",
+                "model": body.get("model"),
+                "input": task,
+                "response_id": None,
+                "received_at": time.time(),
+            }
+
+            if self.path != RESPONSES_PATH:
+                entry["outcome"] = "404"
+                recorder.record(entry)
+                return self._reply(404, {"error": {"message": "unknown endpoint",
+                                                   "type": "not_found"}})
+
+            if not entry["auth_ok"] or "OCGW_UNAUTHORIZED" in task:
+                entry["outcome"] = "401"
+                recorder.record(entry)
+                return self._reply(401, {"error": {"message": "invalid or missing token",
+                                                   "type": "invalid_token"}})
+
+            retries = re.search(r"OCGW_503:(\d+)", task)
+            if retries and recorder.count_503(task) < int(retries.group(1)):
+                entry["outcome"] = "503"
+                recorder.record(entry)
+                return self._reply(503, {"error": {"message": "gateway is starting",
+                                                   "type": "server_starting"}},
+                                   {"Retry-After": "1"})
+
+            delay = re.search(r"OCGW_SLEEP:(\d+)", task)
+            if delay:
+                time.sleep(int(delay.group(1)))
+
+            response_id = recorder.next_response_id()
+            entry["response_id"] = response_id
+
+            if "OCGW_NOTEXT" in task:
+                entry["outcome"] = "200 no-text"
+                recorder.record(entry)
+                return self._reply(200, {"id": response_id,
+                                         "output": [{"type": "reasoning", "summary": []}]})
+
+            exact = re.search(r"Reply with exactly:\s*(.+?)\s*$", task, re.S)
+            reply = exact.group(1).strip() if exact else f"ack: {task[:200]}"
+            entry["outcome"] = "200 ok"
+            entry["reply"] = reply
+            recorder.record(entry)
+            return self._reply(200, {
+                "id": response_id,
+                "object": "response",
+                "status": "completed",
+                "output": [
+                    {"type": "reasoning", "summary": []},
+                    {"type": "message", "role": "assistant",
+                     "content": [{"type": "output_text", "text": reply}]},
+                ],
+            })
+
+    return Handler
+
+
+class GatewayStub:
+    def __init__(self, token, port=GATEWAY_PORT):
+        self.recorder = GatewayRecorder(token)
+        self._server = ThreadingHTTPServer(("0.0.0.0", port), _make_handler(self.recorder))
+        self._server.daemon_threads = True
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def start(self):
+        self._thread.start()
+        return self
+
+    def stop(self, timeout=5):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout)

--- a/Autotests/mock/test_openclaw_delegate_mock.py
+++ b/Autotests/mock/test_openclaw_delegate_mock.py
@@ -18,6 +18,7 @@ Run:
 """
 import json
 import re
+import time
 
 from helpers import (
     Checker, dexec, make_prompt, read_history, wait_for_history_keyword,
@@ -27,6 +28,10 @@ from helpers import (
 # The delegated task travels to a real agent and back, so allow for a slow
 # Gateway; the skill call itself must still return within one iteration.
 RESULT_TIMEOUT = 180
+# The stub holds a reply for this long. The acknowledgement budget below is
+# shorter, so a delegation that blocked the loop could not meet it.
+SLOW_GATEWAY_SECONDS = 30
+ACK_BUDGET_SECONDS = 15
 # Same shape helper.TS_RE requires to slice history into episodes.
 HISTORY_BLOCK_RE = re.compile(r'\("\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"')
 
@@ -36,7 +41,7 @@ def _read_json(path):
     return json.loads(raw)
 
 
-def test_delegate_isolated_and_success_mock(llm, comm):
+def test_delegate_isolated_and_success_mock(llm, comm, gateway):
     with Checker("delegate-task-to-openclaw-agent mock") as c:
         print(f"\n=== OmegaClaw: openclaw delegate mock (run-id {c.run_id}) ===", flush=True)
 
@@ -134,7 +139,7 @@ def test_delegate_isolated_and_success_mock(llm, comm):
         c.done()
 
 
-def test_delegate_empty_message_mock(llm, comm):
+def test_delegate_empty_message_mock(llm, comm, gateway):
     with Checker("delegate-task-to-openclaw-agent empty message mock") as c:
         print(f"\n=== OmegaClaw: openclaw delegate empty mock (run-id {c.run_id}) ===", flush=True)
 
@@ -170,7 +175,7 @@ def test_delegate_empty_message_mock(llm, comm):
         c.done()
 
 
-def test_delegate_new_session_per_call_mock(llm, comm):
+def test_delegate_new_session_per_call_mock(llm, comm, gateway):
     with Checker("delegate-task-to-openclaw-agent new session per call mock") as c:
         print(f"\n=== OmegaClaw: openclaw delegate session isolation mock (run-id {c.run_id}) ===", flush=True)
 
@@ -233,5 +238,224 @@ def test_delegate_new_session_per_call_mock(llm, comm):
             c.fail("session isolation",
                    f"expected two distinct responseId values, found: {response_ids or 'none'}")
         c.ok("session isolation", f"{len(response_ids)} distinct responseId values")
+
+        c.done()
+
+
+def test_delegate_stays_async_under_a_slow_gateway_mock(llm, comm, gateway):
+    with Checker("delegate-task-to-openclaw-agent stays async") as c:
+        print(f"\n=== OmegaClaw: openclaw slow-gateway mock (run-id {c.run_id}) ===", flush=True)
+
+        c.step(f"delegate a task the Gateway holds for {SLOW_GATEWAY_SECONDS}s")
+        prompt = make_prompt(c.run_id, "Delegate a long task.")
+        llm.set_answer(
+            request=prompt,
+            response=(
+                f'(delegate-task-to-openclaw-agent '
+                f'"OCGW_SLEEP:{SLOW_GATEWAY_SECONDS} Reply with exactly: SLOW-{c.run_id}")\n'
+                f'(send "Long delegation started {c.run_id}")'
+            ),
+        )
+        started = time.time()
+        if not comm.send_message(prompt):
+            c.fail("comm", "could not deliver the prompt within timeout")
+
+        # Shorter than the Gateway delay on purpose: a blocking delegation
+        # cannot answer this fast.
+        send_arg = wait_for_skill_call(c.run_id, "send", timeout=ACK_BUDGET_SECONDS,
+                                       arg_substr="Long delegation started")
+        acknowledged_after = time.time() - started
+        if not send_arg:
+            c.fail("async", f"no acknowledgement within {ACK_BUDGET_SECONDS}s; "
+                            "the delegation is blocking the agent loop")
+        c.ok("async", f"acknowledged in {acknowledged_after:.1f}s "
+                      f"against a {SLOW_GATEWAY_SECONDS}s Gateway")
+
+        c.step("an unrelated prompt is answered while the delegation is still pending")
+        second_id = c.run_id + 1
+        second = make_prompt(second_id, "Answer with the marker.")
+        llm.set_answer(request=second, response=f'(send "STILL-ALIVE-{c.run_id}")')
+        if not comm.send_message(second):
+            c.fail("comm", "could not deliver the second prompt within timeout")
+        alive = wait_for_skill_call(second_id, "send", timeout=ACK_BUDGET_SECONDS,
+                                    arg_substr=f"STILL-ALIVE-{c.run_id}")
+        answered_after = time.time() - started
+        if not alive:
+            c.fail("responsive", "the agent went unresponsive while a delegation was pending "
+                                 f"({answered_after:.1f}s in)")
+        if answered_after >= SLOW_GATEWAY_SECONDS:
+            c.fail("responsive", f"the second answer only arrived at {answered_after:.1f}s, "
+                                 "i.e. after the Gateway released the loop")
+        c.ok("responsive", f"second prompt answered at {answered_after:.1f}s")
+
+        c.step("the slow reply still reaches history once the Gateway answers")
+        if not wait_for_history_keyword(c.run_id, [f"SLOW-{c.run_id}"],
+                                        timeout=SLOW_GATEWAY_SECONDS + RESULT_TIMEOUT):
+            c.fail("result", "the slow delegation never produced a history record")
+        c.ok("result", "slow delegation result reached history")
+
+        c.done()
+
+
+def test_delegate_reports_gateway_rejection_mock(llm, comm, gateway):
+    with Checker("delegate-task-to-openclaw-agent reports a rejection") as c:
+        print(f"\n=== OmegaClaw: openclaw rejection mock (run-id {c.run_id}) ===", flush=True)
+
+        out_path = f"/tmp/openclaw_401_{c.run_id}.json"
+
+        c.step("delegate a task the Gateway refuses with 401")
+        prompt = make_prompt(c.run_id, "Delegate a task that will be refused.")
+        llm.set_answer(
+            request=prompt,
+            response=(
+                f'(metta (write-file "{out_path}" '
+                f'(delegate-task-to-openclaw-agent "OCGW_UNAUTHORIZED {c.run_id}")))\n'
+                f'(send "Refused delegation checked {c.run_id}")'
+            ),
+        )
+        if not comm.send_message(prompt):
+            c.fail("comm", "could not deliver the prompt within timeout")
+
+        if not wait_for_skill_call(c.run_id, "send", timeout=30,
+                                   arg_substr="Refused delegation checked"):
+            c.fail("send", "the agent did not stay responsive through a refused delegation")
+        c.ok("send", "the refusal did not disturb the agent loop")
+
+        c.step("the task is still accepted up front, since the skill returns before the call")
+        accepted = _read_json(out_path)
+        if accepted.get("status") != "accepted":
+            c.fail("status", f"expected the envelope to accept the task, got: {accepted}")
+        c.ok("envelope", f"{accepted}")
+
+        c.step("the failure reaches history as an error record carrying the reason")
+        matched = wait_for_history_keyword(
+            c.run_id,
+            [f"id={accepted['id']} status=error", "401"],
+            timeout=RESULT_TIMEOUT,
+            require_all=True,
+        )
+        if not matched:
+            c.fail("result", f"no failing OPENCLAW_RESULT for {accepted['id']} "
+                             f"within {RESULT_TIMEOUT}s")
+        c.ok("result", "the rejection was reported to the agent rather than swallowed")
+
+        c.done()
+
+
+def test_delegate_retries_a_starting_gateway_mock(llm, comm, gateway):
+    with Checker("delegate-task-to-openclaw-agent retries a starting Gateway") as c:
+        print(f"\n=== OmegaClaw: openclaw startup-retry mock (run-id {c.run_id}) ===", flush=True)
+
+        out_path = f"/tmp/openclaw_503_{c.run_id}.json"
+        marker = f"RETRIED-{c.run_id}"
+
+        c.step("delegate a task the Gateway rejects twice with 503 before answering")
+        prompt = make_prompt(c.run_id, "Delegate a task to a starting Gateway.")
+        llm.set_answer(
+            request=prompt,
+            response=(
+                f'(metta (write-file "{out_path}" (delegate-task-to-openclaw-agent '
+                f'"OCGW_503:2 Reply with exactly: {marker}")))\n'
+                f'(send "Retry delegation started {c.run_id}")'
+            ),
+        )
+        if not comm.send_message(prompt):
+            c.fail("comm", "could not deliver the prompt within timeout")
+
+        if not wait_for_skill_call(c.run_id, "send", timeout=30,
+                                   arg_substr="Retry delegation started"):
+            c.fail("send", "the agent did not acknowledge; retries must run off the loop")
+        c.ok("send", "retries did not stall the agent loop")
+
+        accepted = _read_json(out_path)
+        c.step("the delegation eventually succeeds and reaches history")
+        matched = wait_for_history_keyword(
+            c.run_id,
+            [f"id={accepted['id']} status=ok", marker],
+            timeout=RESULT_TIMEOUT,
+            require_all=True,
+        )
+        if not matched:
+            c.fail("result", f"the retried delegation never succeeded within {RESULT_TIMEOUT}s")
+        c.ok("result", "the delegation succeeded after the Gateway finished starting")
+
+        c.step("the Gateway saw the retries rather than a single call")
+        attempts = [r for r in gateway.recorder.requests if "OCGW_503:2" in r["input"]]
+        if len(attempts) < 3:
+            c.fail("retry", f"expected 3 attempts (2 refused, 1 served), saw {len(attempts)}")
+        c.ok("retry", f"{len(attempts)} attempts reached the Gateway")
+
+        c.done()
+
+
+def test_delegate_reports_a_reply_without_text_mock(llm, comm, gateway):
+    with Checker("delegate-task-to-openclaw-agent reports an empty Gateway reply") as c:
+        print(f"\n=== OmegaClaw: openclaw no-text mock (run-id {c.run_id}) ===", flush=True)
+
+        out_path = f"/tmp/openclaw_notext_{c.run_id}.json"
+
+        c.step("delegate a task the Gateway answers without any visible text")
+        prompt = make_prompt(c.run_id, "Delegate a task answered without text.")
+        llm.set_answer(
+            request=prompt,
+            response=(
+                f'(metta (write-file "{out_path}" '
+                f'(delegate-task-to-openclaw-agent "OCGW_NOTEXT {c.run_id}")))\n'
+                f'(send "Empty reply checked {c.run_id}")'
+            ),
+        )
+        if not comm.send_message(prompt):
+            c.fail("comm", "could not deliver the prompt within timeout")
+
+        if not wait_for_skill_call(c.run_id, "send", timeout=30,
+                                   arg_substr="Empty reply checked"):
+            c.fail("send", "the agent did not survive a reply carrying no text")
+        c.ok("send", "the agent stayed responsive")
+
+        accepted = _read_json(out_path)
+        c.step("the empty reply is reported as an error rather than an empty success")
+        if not wait_for_history_keyword(c.run_id, [f"id={accepted['id']} status=error"],
+                                        timeout=RESULT_TIMEOUT):
+            c.fail("result", "an empty Gateway reply was not reported as an error")
+        c.ok("result", "reported as an error record")
+
+        c.done()
+
+
+def test_delegation_is_authenticated_by_the_proxy_mock(llm, comm, gateway):
+    with Checker("delegation is authenticated by the proxy, not by the agent") as c:
+        print(f"\n=== OmegaClaw: openclaw token-injection mock (run-id {c.run_id}) ===", flush=True)
+
+        c.step("delegate a task and let it reach the Gateway")
+        prompt = make_prompt(c.run_id, "Delegate a task.")
+        llm.set_answer(
+            request=prompt,
+            response=(
+                f'(delegate-task-to-openclaw-agent "Reply with exactly: TOKEN-{c.run_id}")\n'
+                f'(send "Token delegation sent {c.run_id}")'
+            ),
+        )
+        if not comm.send_message(prompt):
+            c.fail("comm", "could not deliver the prompt within timeout")
+        if not wait_for_skill_call(c.run_id, "send", timeout=30,
+                                   arg_substr="Token delegation sent"):
+            c.fail("send", "the agent did not acknowledge the delegation")
+        if not wait_for_history_keyword(c.run_id, [f"TOKEN-{c.run_id}"], timeout=RESULT_TIMEOUT):
+            c.fail("result", "the delegation never completed")
+
+        c.step("the Gateway received a correctly authenticated request")
+        served = gateway.recorder.requests
+        authorized = gateway.recorder.authorized_requests()
+        if not authorized:
+            c.fail("auth", "no authenticated request reached the Gateway; "
+                           "the proxy did not inject the token")
+        c.ok("auth", f"{len(authorized)} authenticated request(s) reached the Gateway")
+
+        c.step("every delegation carried the header, none arrived bare")
+        bare = [r for r in served if not r["auth_header_present"]]
+        if bare:
+            c.fail("auth", f"{len(bare)} request(s) reached the Gateway without an "
+                           "Authorization header")
+        c.ok("auth", "the proxy authenticated every delegation")
 
         c.done()

--- a/Autotests/mock/test_openclaw_delegate_mock.py
+++ b/Autotests/mock/test_openclaw_delegate_mock.py
@@ -246,13 +246,16 @@ def test_delegate_stays_async_under_a_slow_gateway_mock(llm, comm, gateway):
     with Checker("delegate-task-to-openclaw-agent stays async") as c:
         print(f"\n=== OmegaClaw: openclaw slow-gateway mock (run-id {c.run_id}) ===", flush=True)
 
+        out_path = f"/tmp/openclaw_slow_{c.run_id}.json"
+
         c.step(f"delegate a task the Gateway holds for {SLOW_GATEWAY_SECONDS}s")
         prompt = make_prompt(c.run_id, "Delegate a long task.")
         llm.set_answer(
             request=prompt,
             response=(
+                f'(metta (write-file "{out_path}" '
                 f'(delegate-task-to-openclaw-agent '
-                f'"OCGW_SLEEP:{SLOW_GATEWAY_SECONDS} Reply with exactly: SLOW-{c.run_id}")\n'
+                f'"OCGW_SLEEP:{SLOW_GATEWAY_SECONDS} Reply with exactly: SLOW-{c.run_id}")))\n'
                 f'(send "Long delegation started {c.run_id}")'
             ),
         )
@@ -289,10 +292,21 @@ def test_delegate_stays_async_under_a_slow_gateway_mock(llm, comm, gateway):
         c.ok("responsive", f"second prompt answered at {answered_after:.1f}s")
 
         c.step("the slow reply still reaches history once the Gateway answers")
-        if not wait_for_history_keyword(c.run_id, [f"SLOW-{c.run_id}"],
-                                        timeout=SLOW_GATEWAY_SECONDS + RESULT_TIMEOUT):
-            c.fail("result", "the slow delegation never produced a history record")
-        c.ok("result", "slow delegation result reached history")
+        try:
+            envelope = _read_json(out_path)
+        except json.JSONDecodeError as e:
+            c.fail("json", f"Failed to parse the skill result: {e}")
+        task_id = envelope.get("id")
+        if envelope.get("status") != "accepted" or not task_id:
+            c.fail("envelope", f"expected an accepted envelope, got: {envelope}")
+        # Matching the id and the ok status, not the marker on its own: the marker
+        # is part of the delegated task text, so it also shows up in a failed record.
+        if not wait_for_history_keyword(c.run_id,
+                                        [f"id={task_id} status=ok", f"reply=SLOW-{c.run_id}"],
+                                        timeout=SLOW_GATEWAY_SECONDS + RESULT_TIMEOUT,
+                                        require_all=True):
+            c.fail("result", "the slow delegation never produced a successful history record")
+        c.ok("result", f"slow delegation result reached history as {task_id}")
 
         c.done()
 

--- a/Autotests/run_mandatory
+++ b/Autotests/run_mandatory
@@ -17,6 +17,7 @@ mock/test_memory_history_byte_window_truncation_mock.py
 mock/test_memory_history_mock.py
 mock/test_memory_missing_history_file_mock.py
 mock/test_memory_pin_window_visibility_mock.py
+mock/test_openclaw_delegate_mock.py
 mock/test_pin_invisible_within_iteration_mock.py
 mock/test_prompt_missing_files_mock.py
 mock/test_rpc.py
@@ -38,3 +39,4 @@ test_openai_runtime_embeddings.py
 test_prompt_grounding.py
 test_websearch_smoke.py
 unit/test_fileio_verified_writes.py
+unit/test_openclaw_unit.py

--- a/Autotests/unit/test_openclaw_unit.py
+++ b/Autotests/unit/test_openclaw_unit.py
@@ -1,0 +1,253 @@
+"""In-process unit tests for plugins/openclaw/openclaw.py.
+
+The module is loaded by file path and runs without a container, a network, or
+a Gateway, the same way unit/test_fileio_verified_writes.py does. `config` and
+`requests` are stubbed before the import, so this file needs nothing beyond
+pytest and is safe to keep in run_mandatory.
+"""
+import importlib.util
+import json
+import os
+import sys
+import threading
+import types
+
+import pytest
+
+_REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_OPENCLAW_PATH = os.path.join(_REPO_ROOT, "plugins", "openclaw", "openclaw.py")
+
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+class _Response:
+    def __init__(self, status_code=200, payload=None, reason="", headers=None, ok=None):
+        self.status_code = status_code
+        self._payload = payload
+        self.reason = reason
+        self.headers = headers or {}
+        self.ok = (status_code < 400) if ok is None else ok
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+def _install_stubs():
+    config_stub = types.ModuleType("config")
+    config_stub.config_get_by_key = lambda key, default=None: None
+    sys.modules["config"] = config_stub
+
+    if "requests" not in sys.modules:
+        try:
+            import requests  # noqa: F401
+        except ImportError:
+            requests_stub = types.ModuleType("requests")
+
+            class _RequestException(Exception):
+                pass
+
+            requests_stub.RequestException = _RequestException
+            requests_stub.Session = object
+            requests_stub.Response = _Response
+            sys.modules["requests"] = requests_stub
+
+
+def _load_openclaw():
+    _install_stubs()
+    spec = importlib.util.spec_from_file_location("openclaw_under_test", _OPENCLAW_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def oc():
+    module = _load_openclaw()
+    module._completed = []
+    module._in_flight = 0
+    module._seq = 0
+    yield module
+    module._completed = []
+    module._in_flight = 0
+
+
+def test_empty_message_is_refused_without_a_worker(oc):
+    for message in ("", "   ", "\n\t "):
+        result = json.loads(oc.send(message, "http://gw", "main"))
+        assert result["status"] == "error"
+        assert result["type"] == "invalid_input"
+    assert oc._in_flight == 0
+    assert oc.take_completed() == ""
+
+
+def test_accepted_envelope_carries_id_and_task_echo(oc, monkeypatch):
+    monkeypatch.setattr(oc, "_run", lambda *a, **k: json.dumps({"status": "ok", "reply": "r"}))
+    accepted = json.loads(oc.send("a task worth doing", "http://gw", "main"))
+    assert accepted["status"] == "accepted"
+    assert accepted["id"] == "oc-1"
+    assert accepted["task"] == "a task worth doing"
+
+    long_task = "y" * (oc.TASK_ECHO_CHARS + 50)
+    accepted = json.loads(oc.send(long_task, "http://gw", "main"))
+    assert accepted["id"] == "oc-2"
+    assert len(accepted["task"]) == oc.TASK_ECHO_CHARS
+
+
+def test_busy_once_max_in_flight_is_reached(oc, monkeypatch):
+    release = threading.Event()
+    monkeypatch.setattr(
+        oc, "_run",
+        lambda *a, **k: (release.wait(10), json.dumps({"status": "ok", "reply": "r"}))[1],
+    )
+    accepted = [json.loads(oc.send(f"task {i}", "http://gw", "main"))
+                for i in range(oc.MAX_IN_FLIGHT)]
+    assert [a["status"] for a in accepted] == ["accepted"] * oc.MAX_IN_FLIGHT
+
+    refused = json.loads(oc.send("one too many", "http://gw", "main"))
+    assert refused["status"] == "error"
+    assert refused["type"] == "busy"
+    assert oc._in_flight == oc.MAX_IN_FLIGHT
+
+    release.set()
+    for _ in range(100):
+        if oc._in_flight == 0:
+            break
+        threading.Event().wait(0.1)
+    assert oc._in_flight == 0
+    assert len(oc.take_completed().splitlines()) == oc.MAX_IN_FLIGHT
+    assert oc.take_completed() == ""
+
+
+def test_worker_crash_still_produces_a_record(oc, monkeypatch):
+    def _boom(*a, **k):
+        raise RuntimeError("worker exploded")
+
+    monkeypatch.setattr(oc, "_run", _boom)
+    oc.send("a task", "http://gw", "main")
+    for _ in range(100):
+        if oc._in_flight == 0:
+            break
+        threading.Event().wait(0.1)
+    record = oc.take_completed()
+    assert "OPENCLAW_RESULT id=oc-1" in record
+    assert "status=error" in record
+    assert "worker exploded" in record
+
+
+def test_record_is_a_single_quote_free_line(oc):
+    result = json.dumps({"status": "ok", "responseId": "resp_1", "reply": 'he said "hi"\nand left'})
+    record = oc._record("oc-7", 'a "quoted"\ntask', result)
+    assert record.startswith("OPENCLAW_RESULT id=oc-7 ")
+    assert "status=ok" in record
+    assert "responseId=resp_1" in record
+    assert '"' not in record
+    assert "\n" not in record
+
+
+def test_record_survives_an_unparsable_result(oc):
+    record = oc._record("oc-8", "task", "not json at all")
+    assert "status=error" in record
+    assert "not json at all" in record
+
+
+def test_reply_is_truncated_to_max_reply_chars(oc):
+    huge = "z" * (oc.MAX_REPLY_CHARS * 2)
+    record = oc._record("oc-9", "task", json.dumps({"status": "ok", "reply": huge}))
+    assert record.count("z") == oc.MAX_REPLY_CHARS
+
+
+def test_flatten_collapses_whitespace_and_quotes(oc):
+    assert oc._flatten('a  "b"\n\tc', 100) == "a 'b' c"
+    assert oc._flatten("abcdef", 3) == "abc"
+    assert oc._flatten(None, 100) == "None"
+
+
+def test_extract_reply_reads_message_items_only(oc):
+    payload = {
+        "id": "resp_42",
+        "output": [
+            {"type": "reasoning", "summary": []},
+            {"type": "message", "content": [
+                {"type": "output_text", "text": "first"},
+                {"type": "refusal", "text": "ignored"},
+            ]},
+            {"type": "message", "content": [{"type": "output_text", "text": "second"}]},
+        ],
+    }
+    result = json.loads(oc._extract_reply(payload))
+    assert result["status"] == "ok"
+    assert result["responseId"] == "resp_42"
+    assert result["reply"] == "first\nsecond"
+
+
+@pytest.mark.parametrize("payload", [
+    {"output": []},
+    {"output": [{"type": "reasoning", "summary": []}]},
+    {"output": [{"type": "message", "content": [{"type": "output_text", "text": "   "}]}]},
+    {},
+])
+def test_extract_reply_rejects_a_reply_without_text(oc, payload):
+    with pytest.raises(oc.OpenClawError):
+        oc._extract_reply(payload)
+
+
+def test_http_error_maps_503_to_a_retryable_startup_error(oc):
+    response = _Response(503, {"error": {"message": "booting", "type": "server_starting"}},
+                         headers={"Retry-After": "7"})
+    error = oc._http_error(response)
+    assert isinstance(error, oc.OpenClawStartupError)
+    assert error.retry_after == 7.0
+    assert "booting" in error.msg
+
+    response = _Response(503, {"error": {"message": "booting"}}, headers={"Retry-After": "soon"})
+    assert oc._http_error(response).retry_after == 1.0
+
+
+def test_http_error_maps_other_codes_to_a_plain_error(oc):
+    response = _Response(401, {"error": {"message": "bad token", "type": "invalid_token"}})
+    error = oc._http_error(response)
+    assert not isinstance(error, oc.OpenClawStartupError)
+    assert "401" in error.msg and "bad token" in error.msg
+
+    response = _Response(500, ValueError("not json"), reason="Server Error")
+    assert "Server Error" in oc._http_error(response).msg
+
+
+def test_endpoint_rewrites_websocket_schemes(oc):
+    assert oc._endpoint("http://gw:1/") == "http://gw:1" + oc.RESPONSES_PATH
+    assert oc._endpoint("  https://gw  ") == "https://gw" + oc.RESPONSES_PATH
+    assert oc._endpoint("ws://gw:1") == "http://gw:1" + oc.RESPONSES_PATH
+    assert oc._endpoint("wss://gw") == "https://gw" + oc.RESPONSES_PATH
+
+
+def test_request_target_prefers_the_proxy_and_sends_no_token(oc, monkeypatch):
+    monkeypatch.setattr(oc, "config_get_by_key", lambda key, default=None: "http://localhost:8080/")
+    monkeypatch.setenv("OMEGACLAW_OPENCLAW_TOKEN", "must-not-be-used")
+    url, headers = oc._request_target("http://gw:18789")
+    assert url == "http://localhost:8080/openclaw" + oc.RESPONSES_PATH
+    assert headers == {}
+
+
+def test_request_target_falls_back_to_a_direct_call_with_the_token(oc, monkeypatch):
+    monkeypatch.setattr(oc, "config_get_by_key", lambda key, default=None: None)
+    monkeypatch.setenv("OMEGACLAW_OPENCLAW_TOKEN", "s3cret")
+    url, headers = oc._request_target("http://gw:18789")
+    assert url == "http://gw:18789" + oc.RESPONSES_PATH
+    assert headers == {"Authorization": "Bearer s3cret"}
+
+
+def test_request_target_refuses_when_it_cannot_authenticate(oc, monkeypatch):
+    monkeypatch.setattr(oc, "config_get_by_key", lambda key, default=None: None)
+    monkeypatch.setenv("OMEGACLAW_OPENCLAW_TOKEN", "   ")
+    with pytest.raises(oc.OpenClawError):
+        oc._request_target("http://gw:18789")
+
+
+def test_take_completed_drains_once(oc):
+    oc._completed = ["first", "second"]
+    assert oc.take_completed() == "first\nsecond"
+    assert oc.take_completed() == ""


### PR DESCRIPTION
@paul-v-snet

## Description

Adds the test coverage OMEGA-291 was opened for. `Autotests/mock/test_openclaw_delegate_mock.py` is listed in neither `run_mandatory` nor `run_optional` and is not under `tests/`, so no CI job runs it yet.

Registering the file alone would not be enough, since the suite needs a Gateway and CI starts the container without one. This does both halves.

- `Autotests/unit/test_openclaw_unit.py` imports the plugin directly and covers the history record format, reply truncation, quote escaping, the in-flight cap and the drain path. No container, no network, no Gateway.
- `Autotests/mock/ocgw_stub.py` is a stdlib Gateway stub driven by markers in the task text (slow reply, 503, missing text). `mock/conftest.py` starts it in-process for the session, so nothing external has to be running.
- `test_openclaw_delegate_mock.py` gains the cases the current three tests cannot tell apart: delegation staying asynchronous under a slow Gateway, retry on 503, the 401 branch, and a reply carrying no text.
- `autotests.yml` starts the agent with `-g http://host.docker.internal:18789` and sets a stub token at job level. That token is not a credential, it authenticates against the in-process stub, and it also gives `test_credentials_scrubbed_mock` a value that is really present so the check can fail if one ever leaks.
- Both files are registered in `run_mandatory`.

With no Gateway configured the Gateway-dependent tests skip. With a token set but the container started without `-g` they fail with one explicit message, so a suite that checks nothing cannot pass quietly.

No runtime code is touched. Everything lives under `Autotests/` and `.github/workflows/autotests.yml`.

## How Has This Been Tested?

- With the CI configuration from this PR: `@run_mandatory` `101 passed` in 344s, plugin suite `8 passed`, unit file `20 passed`, `tests/pytest.sh` `12 passed`, MeTTa unit tests clean.
- With a workflow left un-updated (no `-g`, no token): `101 tests collected` rc=0, full run `93 passed, 8 skipped` rc=0.
- With a token set but no `-g`: `8 errors`, each naming the missing `-g`.

## Checklist

- [x] The code generated by LLM is reviewed by the PR creator
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR

Verdict: PASS
