### PR TITLE
[OMEGA-318] Keep the Telegram authorization ledger usable after a damaged write

### DIFF
--- a/channels/auth.py
+++ b/channels/auth.py
@@ -179,6 +179,22 @@ def _channel_auth_group_path():
     return os.path.join(_MEMORY_DIRECTORY, _CHANNEL_DIR_NAME, _CHANNEL_AUTH_GROUP_FILE)
 
 
+def _append_json_line(path, payload):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    prefix = ""
+    try:
+        with open(path, "rb") as probe:
+            probe.seek(0, os.SEEK_END)
+            if probe.tell():
+                probe.seek(-1, os.SEEK_END)
+                if probe.read(1) != b"\n":
+                    prefix = "\n"
+    except FileNotFoundError:
+        pass
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(prefix + json.dumps(payload, separators=(",", ":")) + "\n")
+
+
 def load_channel_auth_state(channel_identifier):
     """Validate and load one channel's persisted owner and active groups."""
     channel_identifier = str(channel_identifier or "").strip()
@@ -187,7 +203,7 @@ def load_channel_auth_state(channel_identifier):
 
     def read_records(path, label):
         try:
-            with open(path, "r", encoding="utf-8") as source:
+            with open(path, "r", encoding="utf-8", errors="replace") as source:
                 records = []
                 for line_number, line in enumerate(source, 1):
                     if not line.strip():
@@ -263,10 +279,8 @@ def store_channel_authenticated_group_id(channel_identifier, group_id, authorize
         "authorized_by": authorized_by_user_id,
     }
     path = _channel_auth_group_path()
-    os.makedirs(os.path.dirname(path), exist_ok=True)
     try:
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        _append_json_line(path, payload)
     except OSError as e:
         raise RuntimeError("Failed to write channel authenticated group record") from e
     return True
@@ -284,7 +298,7 @@ def get_channel_saved_group_id(channel_identifier, group_id):
 
     authorized = False
     try:
-        with open(_channel_auth_group_path(), "r", encoding="utf-8") as f:
+        with open(_channel_auth_group_path(), "r", encoding="utf-8", errors="replace") as f:
             for line in f:
                 try:
                     record = json.loads(line)
@@ -354,10 +368,8 @@ def revoke_channel_group(channel_identifier, group_id, requester_user_id):
         "revoked": True,
     }
     path = _channel_auth_group_path()
-    os.makedirs(os.path.dirname(path), exist_ok=True)
     try:
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        _append_json_line(path, payload)
     except OSError as e:
         raise RuntimeError("Failed to write channel group revocation record") from e
 

--- a/tests/test_auth_standalone.py
+++ b/tests/test_auth_standalone.py
@@ -190,3 +190,34 @@ def test_load_channel_auth_state_skips_malformed_records(
         "Skipping malformed channel authenticated group record at line 2" in warning
         for warning in warnings
     )
+
+
+def test_load_channel_auth_state_skips_undecodable_bytes(monkeypatch, tmp_path):
+    auth = load_auth_module(monkeypatch)
+    monkeypatch.setattr(auth, "_MEMORY_DIRECTORY", str(tmp_path))
+
+    assert auth.store_channel_authenticated_user_id("TELEGRAM", "owner") is True
+    assert auth.store_channel_authenticated_group_id(
+        "TELEGRAM", "active", "owner"
+    ) is True
+    path = tmp_path / ".channel" / "authenticated-group.json"
+    with path.open("ab") as target:
+        target.write(b"\xff\xfe garbage\n")
+
+    assert auth.load_channel_auth_state("TELEGRAM") == ("owner", {"active"})
+
+
+def test_a_record_written_after_an_unterminated_one_is_kept(monkeypatch, tmp_path):
+    auth = load_auth_module(monkeypatch)
+    monkeypatch.setattr(auth, "_MEMORY_DIRECTORY", str(tmp_path))
+
+    assert auth.store_channel_authenticated_user_id("TELEGRAM", "owner") is True
+    assert auth.store_channel_authenticated_group_id(
+        "TELEGRAM", "active", "owner"
+    ) is True
+    path = tmp_path / ".channel" / "authenticated-group.json"
+    with path.open("a", encoding="utf-8") as target:
+        target.write('{"time":"2026-09-02T10:00:00Z","channel_ident')
+
+    assert auth.revoke_channel_group("TELEGRAM", "active", "owner") == "group_unbound"
+    assert auth.load_channel_auth_state("TELEGRAM") == ("owner", set())


### PR DESCRIPTION
Follow-up to #327, found while retesting OMEGA-318. Two defects in the group authorization ledger, both reachable when a write is interrupted.

## A revoked group comes back after a restart

A record cut short by an interrupted append has no trailing newline, so the next record is written onto the same line:

```
{"time":"2026-09-02T14:07:01Z",...,"group_id":"-5146542772","authorized_by":"8905552654"}
{"time":"2026-09-02T10:00:00Z","channel_ident{"time":"2026-09-02T19:12:48Z",...,"revoked":true}
```

The revocation is now part of an invalid line and is skipped on the next start, so a group the owner removed is authorized again. Reproduced on a live bot: `/unbind` confirmed, the group stayed silent for 60 seconds, and after a restart it answered.

`_append_json_line` writes a leading newline when the file does not end in one, so an earlier damaged record can no longer swallow later writes.

## Damage outside UTF-8 stops the agent from starting

`errors="replace"` was missing on the read paths, so undecodable bytes raised `UnicodeError`, which `load_channel_auth_state` turned into `RuntimeError` reaching main: container exit 2, no adapter, no polling, no owner DM. Such a line is now skipped the same way malformed JSON already is, keeping the failure inside the feature that owns the file.

Applied to the startup path and to the group lookup used by `/bind` and `/unbind`. `get_channel_saved_user_id` is deliberately unchanged, since an existing test fixes its wrapped-error behaviour.

## Tests

Two tests, both red without the change. Full suite: 42 passed.