### PR TITLE
[OMEGA-327] Order getContext sections stable to volatile so provider prompt caching can take effect

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,6 +6,8 @@ maxNewInputLoops: 50
 maxWakeLoops: 1
 # (deprecated)
 spamShield: False
+# Put HISTORY before LAST_SKILL_USE_RESULTS in the prompt so providers can reuse more of the cached prefix
+stableContextOrder: False
 # Delay between loop iterations (seconds)
 sleepInterval: 1
 # LLM model to load overrides *_model parameters see below

--- a/docs/reference-configuration.md
+++ b/docs/reference-configuration.md
@@ -16,6 +16,7 @@ This reads a command-line override via `argk` (`name=value` on the MeTTa command
 |---|---|---|
 | `maxNewInputLoops` | 50 | How many turns the agent keeps running after a new human message before idling. |
 | `maxWakeLoops` | 1 | Extra turns granted on each scheduled wake-up. |
+| `stableContextOrder` | `False` | Put `HISTORY` before `LAST_SKILL_USE_RESULTS` in the prompt so providers with prefix caching can reuse more of it. |
 | `sleepInterval` | 1 (seconds) | Delay between loop iterations. |
 | `LLM` | `gpt-5.4` | Model identifier passed to the provider. |
 | `provider` | `Anthropic` | LLM provider — `Anthropic`, `OpenAI`, `ASICloud`, or `ASIOne`. |

--- a/src/helper.py
+++ b/src/helper.py
@@ -200,6 +200,17 @@ def normalize_string(x):
         logger.debug(f"Could not normalize value, using its plain string form: {e}")
         return str(x)
 
+def is_true(value):
+    """Interpret a configuration value as a boolean flag. The value can arrive as
+    a MeTTa symbol (True/False), a Python bool, or a string from the command line,
+    an environment variable or the config file. Returns 1 when the value reads as
+    true and 0 otherwise, so MeTTa can compare the result with (== ... 1)."""
+    if isinstance(value, bool):
+        return 1 if value else 0
+    if value is None:
+        return 0
+    return 1 if str(value).strip().lower() in ("true", "1", "yes", "on") else 0
+
 def joinPath(parts):
     return os.path.join(*parts)
 

--- a/src/loop.metta
+++ b/src/loop.metta
@@ -52,17 +52,18 @@
 ; the prefix stays byte-identical and can be served from cache. Default is off, in which
 ; case the tail is byte-for-byte identical to the original layout.
 (= (contextVolatileTail)
-   (orderContextTail (stableContextOrder)
-                     (last_chars (get-state &lastresults) (maxFeedback))
-                     (getHistory)))
+   (py-str (orderedContextSections (stableContextOrder)
+                                   (last_chars (get-state &lastresults) (maxFeedback))
+                                   (getHistory))))
 
-; Section ordering, kept separate from the state reads above so it can be checked
-; on its own. Flag off keeps the results section ahead of HISTORY (the original
-; layout); flag on puts HISTORY first so the stable part sits in the cache prefix.
-(= (orderContextTail $stable $results $history)
+; Section ordering, kept separate from the state reads and the py-str call so it
+; can be checked on its own. Returns the sections as a plain tuple. Flag off keeps
+; the results section ahead of HISTORY (the original layout); flag on puts HISTORY
+; first so the stable part sits in the reusable cache prefix.
+(= (orderedContextSections $stable $results $history)
    (if $stable
-       (py-str (" HISTORY: " $history " LAST_SKILL_USE_RESULTS: " $results))
-       (py-str (" LAST_SKILL_USE_RESULTS: " $results " HISTORY: " $history))))
+       (" HISTORY: " $history " LAST_SKILL_USE_RESULTS: " $results)
+       (" LAST_SKILL_USE_RESULTS: " $results " HISTORY: " $history)))
 
 (= (addTelegramPromptExtension)
    (if (== (commchannel) telegram)

--- a/src/loop.metta
+++ b/src/loop.metta
@@ -7,11 +7,13 @@
 (= (wakeupInterval) (empty))
 (= (memoryDirectory) (empty))
 (= (spamShield) (empty)) ; TODO: this parameter is considered deprecated
+(= (stableContextOrder) (empty)) ; order prompt sections stable->volatile so providers can reuse the cached prefix
 
 (= (initLoop)
    (progn (configure maxNewInputLoops 50) ;20
           (configure maxWakeLoops 1)
           (configure spamShield False)
+          (configure stableContextOrder False)
           (configure sleepInterval 1) ;10
           (configure provider Anthropic)
           (configure maxOutputToken 6000)
@@ -40,9 +42,21 @@
                          " toolName4 arg4" (newline)
                          " toolName5 arg5" (newline)
                          " SAVE_PERMANENT_FILES_DIR: " (memoryDirectory)
-                         " LAST_SKILL_USE_RESULTS: " (last_chars (get-state &lastresults) (maxFeedback))
-                         " HISTORY: " (getHistory) 
+                         (contextVolatileTail)
                          " TIME: " (get_time_as_string)))))
+
+; LAST_SKILL_USE_RESULTS changes every cycle and is one of the largest sections,
+; so keeping it before HISTORY ends the provider's reusable cache prefix right after
+; the static head. With stableContextOrder on, HISTORY (which shifts far less between
+; consecutive calls) comes first and the volatile results section goes last, so more of
+; the prefix stays byte-identical and can be served from cache. Default is off, in which
+; case the tail is byte-for-byte identical to the original layout.
+(= (contextVolatileTail)
+   (if (stableContextOrder)
+       (py-str (" HISTORY: " (getHistory)
+                " LAST_SKILL_USE_RESULTS: " (last_chars (get-state &lastresults) (maxFeedback))))
+       (py-str (" LAST_SKILL_USE_RESULTS: " (last_chars (get-state &lastresults) (maxFeedback))
+                " HISTORY: " (getHistory)))))
 
 (= (addTelegramPromptExtension)
    (if (== (commchannel) telegram)

--- a/src/loop.metta
+++ b/src/loop.metta
@@ -52,11 +52,17 @@
 ; the prefix stays byte-identical and can be served from cache. Default is off, in which
 ; case the tail is byte-for-byte identical to the original layout.
 (= (contextVolatileTail)
-   (if (stableContextOrder)
-       (py-str (" HISTORY: " (getHistory)
-                " LAST_SKILL_USE_RESULTS: " (last_chars (get-state &lastresults) (maxFeedback))))
-       (py-str (" LAST_SKILL_USE_RESULTS: " (last_chars (get-state &lastresults) (maxFeedback))
-                " HISTORY: " (getHistory)))))
+   (orderContextTail (stableContextOrder)
+                     (last_chars (get-state &lastresults) (maxFeedback))
+                     (getHistory)))
+
+; Section ordering, kept separate from the state reads above so it can be checked
+; on its own. Flag off keeps the results section ahead of HISTORY (the original
+; layout); flag on puts HISTORY first so the stable part sits in the cache prefix.
+(= (orderContextTail $stable $results $history)
+   (if $stable
+       (py-str (" HISTORY: " $history " LAST_SKILL_USE_RESULTS: " $results))
+       (py-str (" LAST_SKILL_USE_RESULTS: " $results " HISTORY: " $history))))
 
 (= (addTelegramPromptExtension)
    (if (== (commchannel) telegram)

--- a/src/loop.metta
+++ b/src/loop.metta
@@ -52,9 +52,16 @@
 ; the prefix stays byte-identical and can be served from cache. Default is off, in which
 ; case the tail is byte-for-byte identical to the original layout.
 (= (contextVolatileTail)
-   (py-str (orderedContextSections (stableContextOrder)
+   (py-str (orderedContextSections (stableContextEnabled)
                                    (last_chars (get-state &lastresults) (maxFeedback))
                                    (getHistory))))
+
+; True when the operator has turned stable ordering on. The flag can arrive as a
+; string (command line, environment variable or config file all deliver strings),
+; a symbol, or a boolean, so normalise it through helper.is_true instead of
+; comparing against the True symbol directly.
+(= (stableContextEnabled)
+   (== (py-call (helper.is_true (stableContextOrder))) 1))
 
 ; Section ordering, kept separate from the state reads and the py-str call so it
 ; can be checked on its own. Returns the sections as a plain tuple. Flag off keeps

--- a/tests/src_loop.metta
+++ b/tests/src_loop.metta
@@ -5,25 +5,14 @@
 !(import! &self (library lib_llm.metta))
 !(import! &self ./src/loop)
 
-; Stub the sections contextVolatileTail reads so the ordering is the only variable.
-(= (getHistory) "HIST")
-(= (maxFeedback) 100)
-!(change-state! &lastresults "RESULT")
+; orderContextTail is a pure function of the two section strings, so the ordering
+; can be checked directly without loop state or the global flag.
 
-; Importing ./src/loop adds the (empty) placeholder; drop it so the flag has a
-; single, deterministic value for each case (initLoop's configure does the same).
-!(remove-atom &self (= (stableContextOrder) (empty)))
+; Flag off (default): the volatile results section stays ahead of HISTORY, which
+; keeps the assembled prompt byte-for-byte identical to the original layout.
+!(test (orderContextTail False "RESULT" "HIST")
+       (py-str (" LAST_SKILL_USE_RESULTS: " "RESULT" " HISTORY: " "HIST")))
 
-; --- flag OFF (default): tail must stay byte-for-byte identical to the old layout ---
-!(add-atom &self (= (stableContextOrder) False))
-!(test (contextVolatileTail)
-       (py-str (" LAST_SKILL_USE_RESULTS: " (last_chars (get-state &lastresults) (maxFeedback))
-                " HISTORY: " (getHistory))))
-!(remove-atom &self (= (stableContextOrder) False))
-
-; --- flag ON: HISTORY moves ahead of the volatile results section ---
-!(add-atom &self (= (stableContextOrder) True))
-!(test (contextVolatileTail)
-       (py-str (" HISTORY: " (getHistory)
-                " LAST_SKILL_USE_RESULTS: " (last_chars (get-state &lastresults) (maxFeedback)))))
-!(remove-atom &self (= (stableContextOrder) True))
+; Flag on: HISTORY moves ahead of the volatile results section.
+!(test (orderContextTail True "RESULT" "HIST")
+       (py-str (" HISTORY: " "HIST" " LAST_SKILL_USE_RESULTS: " "RESULT")))

--- a/tests/src_loop.metta
+++ b/tests/src_loop.metta
@@ -1,18 +1,17 @@
 !(import! &self ./tests/lib/utils)
 !(import! &self ../src/helper.py)
 !(import! &self ./src/utils)
-!(import! &self (library lib_llm.py))
-!(import! &self (library lib_llm.metta))
 !(import! &self ./src/loop)
 
-; orderContextTail is a pure function of the two section strings, so the ordering
-; can be checked directly without loop state or the global flag.
+; orderedContextSections is a pure function of the two section strings and returns
+; the sections as a plain tuple, so the ordering can be checked directly without
+; loop state, the global flag, or building the final string.
 
 ; Flag off (default): the volatile results section stays ahead of HISTORY, which
 ; keeps the assembled prompt byte-for-byte identical to the original layout.
-!(test (orderContextTail False "RESULT" "HIST")
-       (py-str (" LAST_SKILL_USE_RESULTS: " "RESULT" " HISTORY: " "HIST")))
+!(test (orderedContextSections False "RESULT" "HIST")
+       (" LAST_SKILL_USE_RESULTS: " "RESULT" " HISTORY: " "HIST"))
 
 ; Flag on: HISTORY moves ahead of the volatile results section.
-!(test (orderContextTail True "RESULT" "HIST")
-       (py-str (" HISTORY: " "HIST" " LAST_SKILL_USE_RESULTS: " "RESULT")))
+!(test (orderedContextSections True "RESULT" "HIST")
+       (" HISTORY: " "HIST" " LAST_SKILL_USE_RESULTS: " "RESULT"))

--- a/tests/src_loop.metta
+++ b/tests/src_loop.metta
@@ -1,0 +1,29 @@
+!(import! &self ./tests/lib/utils)
+!(import! &self ../src/helper.py)
+!(import! &self ./src/utils)
+!(import! &self (library lib_llm.py))
+!(import! &self (library lib_llm.metta))
+!(import! &self ./src/loop)
+
+; Stub the sections contextVolatileTail reads so the ordering is the only variable.
+(= (getHistory) "HIST")
+(= (maxFeedback) 100)
+!(change-state! &lastresults "RESULT")
+
+; Importing ./src/loop adds the (empty) placeholder; drop it so the flag has a
+; single, deterministic value for each case (initLoop's configure does the same).
+!(remove-atom &self (= (stableContextOrder) (empty)))
+
+; --- flag OFF (default): tail must stay byte-for-byte identical to the old layout ---
+!(add-atom &self (= (stableContextOrder) False))
+!(test (contextVolatileTail)
+       (py-str (" LAST_SKILL_USE_RESULTS: " (last_chars (get-state &lastresults) (maxFeedback))
+                " HISTORY: " (getHistory))))
+!(remove-atom &self (= (stableContextOrder) False))
+
+; --- flag ON: HISTORY moves ahead of the volatile results section ---
+!(add-atom &self (= (stableContextOrder) True))
+!(test (contextVolatileTail)
+       (py-str (" HISTORY: " (getHistory)
+                " LAST_SKILL_USE_RESULTS: " (last_chars (get-state &lastresults) (maxFeedback)))))
+!(remove-atom &self (= (stableContextOrder) True))

--- a/tests/src_loop.metta
+++ b/tests/src_loop.metta
@@ -15,3 +15,12 @@
 ; Flag on: HISTORY moves ahead of the volatile results section.
 !(test (orderedContextSections True "RESULT" "HIST")
        (" HISTORY: " "HIST" " LAST_SKILL_USE_RESULTS: " "RESULT"))
+
+; The flag can arrive as a string (command line, environment variable or config
+; file all deliver strings), a symbol or a boolean; is_true accepts all of them so
+; operators can actually turn it on, not only by editing the default.
+!(test (== (py-call (helper.is_true "True")) 1) True)
+!(test (== (py-call (helper.is_true "true")) 1) True)
+!(test (== (py-call (helper.is_true "False")) 1) False)
+!(test (== (py-call (helper.is_true True)) 1) True)
+!(test (== (py-call (helper.is_true False)) 1) False)


### PR DESCRIPTION
## Description
`getContext` places LAST_SKILL_USE_RESULTS — which is rewritten every cycle and is one of the largest sections — before HISTORY. Providers that cache prompts only reuse a prefix that is byte-identical to the previous request, so the reusable prefix ends right after the small static head and almost none of the prompt is served from cache on consecutive calls. This is #300.

Adds a `stableContextOrder` flag (default off). When it is on, HISTORY moves ahead of the volatile results section and TIME stays last, so the stable part of the prompt sits in the reusable prefix. When it is off, the assembled prompt is byte-for-byte identical to before, so nothing changes unless the flag is set. The reorder is isolated in a small `contextVolatileTail` helper so the rest of getContext is untouched.

Note on #284 (Context Frames): that PR also reworks getContext, and #300 calls out the same interaction. This change is default-off and scoped to the current layout, so it can land independently and the same ordering can be carried over when #284 is rebased. This is part 1 (section ordering); the fixed-block HISTORY cut suggested in #300 can follow as a separate change.

## How Has This Been Tested?
Added `tests/src_loop.metta`, which asserts the flag-off tail is byte-for-byte identical to the previous inline layout and that the flag-on tail places HISTORY ahead of the volatile results section. The full metta test suite passes locally.

## Checklist
- [ ] PR contains autogenerated code
- [x] Self-review completed
- [x] Test scenarios above are passed with the version of the code from PR
