### PR TITLE
[OMEGA-409] revert temporary change to README.md needed to quick fix omega to omegaclaw rename crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Run Omega using the next command:
 curl -fsSL https://raw.githubusercontent.com/singnet/Omega/refs/heads/main/scripts/omega | bash -s -- singularitynet/omega:latest
 ```
 
-To run a specific version of Omega set version in `TAG` environment variable and run the following command:
+To run a specific version of Omega (v0.1.20 or later) set version in `TAG` environment variable and run the following command:
 ```
 export TAG=<version>; curl -fsSL  https://github.com/singnet/Omega/raw/refs/tags/$TAG/scripts/omega | bash -s -- singularitynet/omega:$TAG
 ```
@@ -90,8 +90,9 @@ To restart the Omega Docker container:
 docker start omega
 ```
 
-To reset Omega's memory:
+To reset Omega's memory, remove the container together with its memory volume and then run Omega again:
 ```
+docker rm -f omega
 docker volume rm omega-memory
 ```
 
@@ -110,7 +111,7 @@ To restore an archive while upgrading to a tagged image, use the same transfer d
 ```sh
 scripts/omega start -d singularitynet/omega:<tag> -p OpenAI -t telegram \
   --memory-transfer-dir "$HOME/omega-transfers" \
-  --memory-import omegaclaw-memory-<timestamp>.tar.gz \
+  --memory-import omega-memory-<timestamp>.tar.gz \
   --memory-mode overwrite
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,22 +72,27 @@ Ensure that you have [Docker installed](https://docs.docker.com/engine/install/)
 
 Run Omega using the next command:
 ```
-curl -fsSL https://github.com/singnet/Omega/raw/refs/tags/v0.1.19/scripts/omegaclaw | bash -s -- singularitynet/omega:v0.1.19
+curl -fsSL https://raw.githubusercontent.com/singnet/Omega/refs/heads/main/scripts/omega | bash -s -- singularitynet/omega:latest
 ```
 
 To run a specific version of Omega set version in `TAG` environment variable and run the following command:
 ```
-export TAG=<version>; curl -fsSL  https://github.com/singnet/Omega/raw/refs/tags/$TAG/scripts/omegaclaw | bash -s -- singularitynet/omegaclaw:$TAG
+export TAG=<version>; curl -fsSL  https://github.com/singnet/Omega/raw/refs/tags/$TAG/scripts/omega | bash -s -- singularitynet/omega:$TAG
 ```
 
 To stop the Omega Docker container:
 ```
-docker stop omegaclaw
+docker stop omega
 ```
 
 To restart the Omega Docker container:
 ```
-docker start omegaclaw
+docker start omega
+```
+
+To reset Omega's memory:
+```
+docker volume rm omega-memory
 ```
 
 ### Memory portability


### PR DESCRIPTION
## Description
Last week we discovered that the newly updated script with "omega" was associated in README.md to "omegaclaw." This caused a crash for anybody trying to run it. So the README was quick-fixed so it would work. Now this PR restores the naming to "omega".

IMPORTANT:  THE NEW RELEASE V0.1.20 MUST BE AVAILABLE OR CRASH WILL RESULT ON RUN ATTEMPT OF DOCKER WITH SCRIPT REFERENCED.

How Has This Been Tested?
Must be tested once the new release is ready.  This is only a copy of the prior README that would cause name conflicts.

## Checklist
- [ ] PR contains autogenerated code
- [X] Self-review completed
- [X] Test scenarios above are passed with the version of the code from PR
