### PR TITLE
[OMEGA-409] Revert README restore until v0.1.20 is released

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,28 +72,22 @@ Ensure that you have [Docker installed](https://docs.docker.com/engine/install/)
 
 Run Omega using the next command:
 ```
-curl -fsSL https://raw.githubusercontent.com/singnet/Omega/refs/heads/main/scripts/omega | bash -s -- singularitynet/omega:latest
+curl -fsSL https://github.com/singnet/Omega/raw/refs/tags/v0.1.19/scripts/omegaclaw | bash -s -- singularitynet/omega:v0.1.19
 ```
 
-To run a specific version of Omega (v0.1.20 or later) set version in `TAG` environment variable and run the following command:
+To run a specific version of Omega set version in `TAG` environment variable and run the following command:
 ```
-export TAG=<version>; curl -fsSL  https://github.com/singnet/Omega/raw/refs/tags/$TAG/scripts/omega | bash -s -- singularitynet/omega:$TAG
+export TAG=<version>; curl -fsSL  https://github.com/singnet/Omega/raw/refs/tags/$TAG/scripts/omegaclaw | bash -s -- singularitynet/omegaclaw:$TAG
 ```
 
 To stop the Omega Docker container:
 ```
-docker stop omega
+docker stop omegaclaw
 ```
 
 To restart the Omega Docker container:
 ```
-docker start omega
-```
-
-To reset Omega's memory, remove the container together with its memory volume and then run Omega again:
-```
-docker rm -f omega
-docker volume rm omega-memory
+docker start omegaclaw
 ```
 
 ### Memory portability
@@ -111,7 +105,7 @@ To restore an archive while upgrading to a tagged image, use the same transfer d
 ```sh
 scripts/omega start -d singularitynet/omega:<tag> -p OpenAI -t telegram \
   --memory-transfer-dir "$HOME/omega-transfers" \
-  --memory-import omega-memory-<timestamp>.tar.gz \
+  --memory-import omegaclaw-memory-<timestamp>.tar.gz \
   --memory-mode overwrite
 ```
 


### PR DESCRIPTION
Reverts #346, which was merged before v0.1.20 was published. `latest` on Docker Hub still points to v0.1.19, and the restored README instructions do not work with that image. This brings back the temporary README that runs v0.1.19.

Once v0.1.20 is published and `latest` points to it, revert this PR to bring #346 back.